### PR TITLE
Added METHOD_REF node and closure related entities.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -228,6 +228,14 @@
          "comment" : "Initialization contruct for arrays."
         },
 
+        {"id":333, "name":"METHOD_REF",
+          "keys": [ "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END", "CODE", "ORDER", "ARGUMENT_INDEX"],
+          "comment":"Reference to a method.",
+          "outEdges": [
+            {"edgeName": "REF", "inNodes": ["METHOD_INST"]}
+          ]
+        },
+
 
         // This is the "catch-all-others" node type.
 

--- a/codepropertygraph/src/main/resources/schemas/closure.json
+++ b/codepropertygraph/src/main/resources/schemas/closure.json
@@ -1,0 +1,25 @@
+{
+  "nodeTypes" : [
+    { "name" : "IDENTIFIER",
+      "outEdges" : [
+        {"edgeName": "REF", "inNodes": ["CLOSURE_BINDING"]}
+      ]
+    },
+    { "name" : "METHOD_REF",
+      "outEdges" : [
+        {"edgeName": "CAPTURE", "inNodes": ["CLOSURE_BINDING"]}
+      ]
+    },
+    {"id":334, "name":"CLOSURE_BINDING",
+      "keys": [ "EVALUATION_STRATEGY" ],
+      "comment":"Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method.",
+      "outEdges": [
+        {"edgeName": "REF", "inNodes": ["LOCAL", "METHOD_PARAMETER_IN"]}
+      ]
+    }
+  ],
+
+  "edgeTypes" : [
+    {"id" : 40, "name": "CAPTURE", "comment" : "Represents the capturing of a variable into a closure.", "keys": []}
+  ]
+}


### PR DESCRIPTION
See original PR on internal repo:
https://github.com/ShiftLeftSecurity/codepropertygraph-internal/pull/156