### PR TITLE
Make RETURN an expression.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -200,6 +200,7 @@
         {"id":30, "name": "RETURN",
          "keys": [ "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END", "ORDER", "ARGUMENT_INDEX", "CODE"],
          "comment" : "A return instruction.",
+         "is": [ "EXPRESSION" ],
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL"]},
              {"edgeName": "CFG", "inNodes": ["METHOD_RETURN"]}


### PR DESCRIPTION
After this change all nodes which can appear in a method body are
expressions which makes some step handling in our DSL easier.

This might seem counter intuitive but it acutally makes sense to
represent RETURN as an expression which has the eval type "Nothing"
which is at the moment represented through the lack of an
EVAL_TYPE edge. Compare to languages like Scala which do the same.