### PR TITLE
Give TinkerVertexProperty an index of -1.

### DIFF
--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -507,7 +507,7 @@ object DomainClassCreator {
             case Some(fieldAccess) => 
               val value = fieldAccess(this)
               if (value == null) VertexProperty.empty[A]
-              else new TinkerVertexProperty(this, key, value.asInstanceOf[A])
+              else new TinkerVertexProperty(-1, this, key, value.asInstanceOf[A])
           }
 
         override protected def updateSpecificProperty[A](key: String, value: A): VertexProperty[A] = {


### PR DESCRIPTION
In order to be able to give back the specizialized node properties via
the tinkerpop API we need to create a TinkerVertexProperty which is than
returned. We now assign those temporary properties an index of -1 to
avoid Tinkergraph to internally count up its global ID counter in order
to obtain an ID for the new property.
This allows us to have node and edge IDs for newly created entities
which are not dependent of the number of property reads we do in
advance. And we also save a lot of time..