### PR TITLE
Add CLOSURE_BINDING_ID property and remove CAPTURED_BY edge.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -33,7 +33,8 @@
         // Properties to characterize call-sites
 
         {"id": 25, "name": "DISPATCH_TYPE", "comment": "The dispatch type of a call, which is either static or dynamic. See dispatchTypes.", "valueType" : "string"},
-        {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\".", "valueType" : "string"}
+        {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\".", "valueType" : "string"},
+        {"id": 50, "name" : "CLOSURE_BINDING_ID", "comment" : "Identifier which uniquely describes a CLOSURE_BINDING. This property is used to match captured LOCAL nodes with the corresponding CLOSURE_BINDING nodes.", "valueType" : "string", "optional": true}
     ],
 
     // Keys for edge properties
@@ -182,7 +183,7 @@
          ]
         },
         {"id":23, "name" : "LOCAL",
-         "keys": ["CODE", "NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment": "A local variable",
          "is": ["HAS_EVAL_TYPE", "DECLARATION", "LOCAL_LIKE"],
          "outEdges" : [

--- a/codepropertygraph/src/main/resources/schemas/closure.json
+++ b/codepropertygraph/src/main/resources/schemas/closure.json
@@ -1,17 +1,12 @@
 {
   "nodeTypes" : [
-    { "name" : "LOCAL",
-      "outEdges" : [
-        {"edgeName": "CAPTURED_BY", "inNodes": ["CLOSURE_BINDING"]}
-      ]
-    },
     { "name" : "METHOD_REF",
       "outEdges" : [
         {"edgeName": "CAPTURE", "inNodes": ["CLOSURE_BINDING"]}
       ]
     },
     {"id":334, "name":"CLOSURE_BINDING",
-      "keys": [ "EVALUATION_STRATEGY" ],
+      "keys": [ "CLOSURE_BINDING_ID", "EVALUATION_STRATEGY" ],
       "comment":"Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method.",
       "outEdges": [
         {"edgeName": "REF", "inNodes": ["LOCAL", "METHOD_PARAMETER_IN"]}
@@ -20,7 +15,6 @@
   ],
 
   "edgeTypes" : [
-    {"id" : 40, "name": "CAPTURE", "comment" : "Represents the capturing of a variable into a closure.", "keys": []},
-    {"id" : 41, "name": "CAPTURED_BY", "comment" : "Connection between a capture LOCAL and the corresponding CLOSURE_BINDING", "keys": []}
+    {"id" : 40, "name": "CAPTURE", "comment" : "Represents the capturing of a variable into a closure.", "keys": []}
   ]
 }


### PR DESCRIPTION
The CLOSURE_BINDING_ID is used to be able to associate a captured LOCAL and a
CLOSURE_BINDING node.
The actual linking between those two nodes is now done in the backend to
relieve the frontends from this burden.