### PR TITLE
Revert "default to identityHashCode"

### DIFF
--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -677,7 +677,6 @@ object DomainClassCreator {
         override val label = "${nodeType.name}"
         override val properties: Map[String, Any] = $propertiesImpl
         override def containedNodesByLocalName: Map[String, List[Node]] = $containedNodesByLocalName
-        override def hashCode = System.identityHashCode(this)
       }
       """
     }


### PR DESCRIPTION
This reverts commit 14be1e5bf7df031ff2a50200967e2395f66f03f7 temporarily until we found out why we suddenly get so many descriptor flows.