### PR TITLE
Avoid linking types in the frontend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,20 +128,18 @@ Method body       | LITERAL, IDENTIFIER, CALL, RETURN, METHOD_INST, METHOD_REF
 Meta data         | META_DATA
 
 
-There are a total of 8 edge types:
+There are a total of 6 edge types:
 
 Name | Usage
 -----|----------------------------------------------------------------
 AST  | Syntax tree edge - structure
 CFG  | Control flow edge - execution order and conditions
 REF  | Reference edge - references to type/method/identifier declarations
-EVAL_TYPE | Type edge - attach known types to expressions
 CALL | Method invocation edge - caller/callee relationship
 VTABLE | Virtual method table edge - represents vtables
-INHERITS_FROM | Type inheritance edge - models OOP inheritance
 BINDS_TO | Binding edge - provides type parameters
 
-There are a total of 17 node keys across 3 categories:
+There are a total of 17 node keys across 4 categories:
 
 Category       | Names
 ---------------| ---------------------------------------------------------------------------------------------------------------------------------
@@ -197,16 +195,19 @@ designated type-declaration node (type TYPE_DECL), with at least a
 full-name attribute. Member variables (type MEMBER), method declarations
 (type METHOD), and type parameters (type TYPE_PARAMETER) are
 connected to the type declaration via AST edges, originating at the
-type declaration. Inheritance relations are expressed via
-INHERITS_FROM edges to zero or more other type declarations (type
-TYPE_DECL), which indicate that the source type declaration inherits
-from the destination declaration.
+type declaration. Inheritance relations are expressed by possibly multiple
+type full name properties (type INHERITS_FROM_TYPE_FULL_NAME) indicating
+derived from TYPE.
 
 Usage of a type, for example in the declaration of a variable, is indicated
-by a type node (type TYPE). The type node is connected to the
-corresponding type declaration via a reference edge (type REF), and to
-type arguments via AST edges (type AST). Finally, type-argument nodes
-are connected to type parameters via binding edges (type BINDS_TO).
+by a type node (type TYPE). A type (type TYPE) is associated to a type
+declaration (type TYPE_DECL) via the declarations fullname (type
+TYPE_DECL_FULL_NAME). Furthermore a type can specify type arguments nodes
+(type TYPE_ARGUMENT) which are connected to it via AST edges. Note that you
+can specify multiple identical TYPE nodes and the backend will deduplicate
+those. This allows frontend to not hold a global type table. Finally,
+type-argument nodes are connected to type parameters via binding edges
+(type BINDS_TO).
 
 ## Method declarations
 

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -34,7 +34,12 @@
 
         {"id": 25, "name": "DISPATCH_TYPE", "comment": "The dispatch type of a call, which is either static or dynamic. See dispatchTypes.", "valueType" : "string", "cardinality" : "one"},
         {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\".", "valueType" : "string", "cardinality" : "one"},
-        {"id": 50, "name" : "CLOSURE_BINDING_ID", "comment" : "Identifier which uniquely describes a CLOSURE_BINDING. This property is used to match captured LOCAL nodes with the corresponding CLOSURE_BINDING nodes.", "valueType" : "string", "cardinality" : "zeroOrOne"}
+
+        // Properties used to link nodes in the backend
+        {"id": 50, "name" : "CLOSURE_BINDING_ID", "comment" : "Identifier which uniquely describes a CLOSURE_BINDING. This property is used to match captured LOCAL nodes with the corresponding CLOSURE_BINDING nodes.", "valueType" : "string", "cardinality" : "zeroOrOne"},
+        {"id": 51, "name" : "TYPE_FULL_NAME", "comment" : "The static type of an entity. E.g. expressions, local, parameters etc. This property is matched against the FULL_NAME of TYPE nodes and thus it is required to have at least one TYPE node for each TYPE_FULL_NAME.", "valueType" : "string", "cardinality" : "one"},
+        {"id": 52, "name" : "TYPE_DECL_FULL_NAME", "comment" : "The static type decl of a TYPE. This property is matched against the FULL_NAME of TYPE_DECL nodes. It is required to have exactly one TYPE_DECL for each different TYPE_DECL_FULL_NAME.", "valueType" : "string", "cardinality" : "one"},
+        {"id": 53, "name" : "INHERITS_FROM_TYPE_FULL_NAME", "comment" : "The static types a TYPE_DECL inherits from. This property is matched against the FULL_NAME of TYPE nodes and thus it is required to have at least one TYPE node for each TYPE_FULL_NAME.", "valueType" : "string", "cardinality" : "list"}
     ],
 
     // Keys for edge properties
@@ -81,13 +86,13 @@
         },
 
         {"id" : 34, "name" : "METHOD_PARAMETER_IN",
-         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "This node represents a formal parameter going towards the callee side.",
          "is": ["DECLARATION", "DATA_FLOW_OBJECT", "LOCAL_LIKE"]
         },
 
         {"id" : 3, "name" : "METHOD_RETURN",
-         "keys": ["CODE", "EVALUATION_STRATEGY", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "A formal method return",
          "is": ["DATA_FLOW_OBJECT"]
         },
@@ -103,19 +108,17 @@
         // Types
 
         {"id" : 45, "name" : "TYPE",
-         "keys" : ["NAME", "FULL_NAME"],
+         "keys" : ["NAME", "FULL_NAME", "TYPE_DECL_FULL_NAME"],
          "comment" : "A type which always has to reference a type declaration and may have type argument children if the refered type declaration is a template.",
          "outEdges" : [
-             {"edgeName": "REF", "inNodes": ["TYPE_DECL"]},
              {"edgeName": "AST", "inNodes": ["TYPE_ARGUMENT"]}
          ]
         },
         {"id" : 46, "name" : "TYPE_DECL",
-         "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL"],
+         "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME"],
          "comment" : "A type declaration.",
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["TYPE_DECL", "TYPE_PARAMETER", "METHOD", "MEMBER", "MODIFIER"]},
-             {"edgeName": "INHERITS_FROM", "inNodes": ["TYPE"]},
              {"edgeName": "VTABLE", "inNodes": ["METHOD"]}
          ]
         },
@@ -134,7 +137,7 @@
         },
 
         {"id" : 9, "name" : "MEMBER",
-         "keys" : [ "CODE", "NAME"],
+         "keys" : [ "CODE", "NAME", "TYPE_FULL_NAME"],
          "comment" : "Member of a class struct or union",
          "is": ["DECLARATION"]
         },
@@ -152,7 +155,7 @@
         // Nodes that describe method content
 
         {"id" : 8, "name" : "LITERAL",
-         "keys" : ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys" : ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "Literal/Constant",
          "is": ["DECLARATION", "DATA_FLOW_OBJECT", "EXPRESSION"],
          "outEdges" : [
@@ -160,7 +163,7 @@
          ]
         },
         {"id": 15, "name" : "CALL",
-         "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "DISPATCH_TYPE", "SIGNATURE", "LINE_NUMBER",
+         "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "DISPATCH_TYPE", "SIGNATURE", "TYPE_FULL_NAME", "LINE_NUMBER",
                   "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "A (method)-call",
          "is": ["EXPRESSION"],
@@ -172,12 +175,12 @@
          ]
         },
         {"id":23, "name" : "LOCAL",
-         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment": "A local variable",
          "is": ["DECLARATION", "LOCAL_LIKE"]
         },
         {"id":27, "name": "IDENTIFIER",
-         "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "An arbitrary identifier/reference.",
          "is": ["DATA_FLOW_OBJECT", "EXPRESSION", "LOCAL_LIKE"],
          "outEdges" : [
@@ -263,7 +266,6 @@
         // Edges to represent type relations
 
         {"id" : 22, "name" : "BINDS_TO", "keys": [], "comment" : "Type argument binding to a type parameter.", "keys" : [] },
-        {"id" : 23, "name" : "INHERITS_FROM", "keys": [], "comment" : "Inheritance relation between types.", "keys" : [] },
         {"id" : 10, "name" : "REF", "keys" : [], "comment" : "Referencing to e.g. a LOCAL" },
         {"id" : 30, "name": "VTABLE", "comment" : "Indicates that a method is part of the vtable of a certain type declaration.", "keys": []}
 

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -233,7 +233,7 @@
         // This is the "catch-all-others" node type.
 
         {"id" : 44, "name": "UNKNOWN",
-         "keys" : ["CODE", "PARSER_TYPE_NAME", "ORDER", "ARGUMENT_INDEX", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys" : ["CODE", "PARSER_TYPE_NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "A language-specific node",
          "is": ["EXPRESSION"],
          "outEdges" : [

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -83,19 +83,13 @@
         {"id" : 34, "name" : "METHOD_PARAMETER_IN",
          "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "This node represents a formal parameter going towards the callee side.",
-         "is": ["DECLARATION", "DATA_FLOW_OBJECT", "LOCAL_LIKE"],
-         "outEdges" : [
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
-         ]
+         "is": ["DECLARATION", "DATA_FLOW_OBJECT", "LOCAL_LIKE"]
         },
 
         {"id" : 3, "name" : "METHOD_RETURN",
          "keys": ["CODE", "EVALUATION_STRATEGY", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "A formal method return",
-         "is": ["DATA_FLOW_OBJECT"],
-         "outEdges" : [
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
-         ]
+         "is": ["DATA_FLOW_OBJECT"]
         },
 
         // Modifier
@@ -142,10 +136,7 @@
         {"id" : 9, "name" : "MEMBER",
          "keys" : [ "CODE", "NAME"],
          "comment" : "Member of a class struct or union",
-         "is": ["DECLARATION"],
-         "outEdges": [
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
-         ]
+         "is": ["DECLARATION"]
         },
 
         {
@@ -165,8 +156,7 @@
          "comment" : "Literal/Constant",
          "is": ["DECLARATION", "DATA_FLOW_OBJECT", "EXPRESSION"],
          "outEdges" : [
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]},
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]}
          ]
         },
         {"id": 15, "name" : "CALL",
@@ -178,17 +168,13 @@
              {"edgeName": "REF", "inNodes": ["MEMBER"]},
              {"edgeName": "CALL", "inNodes": ["METHOD_INST"]},
              {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]},
-             {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF"]},
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+             {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF"]}
          ]
         },
         {"id":23, "name" : "LOCAL",
          "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment": "A local variable",
-         "is": ["DECLARATION", "LOCAL_LIKE"],
-         "outEdges" : [
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
-         ]
+         "is": ["DECLARATION", "LOCAL_LIKE"]
         },
         {"id":27, "name": "IDENTIFIER",
          "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
@@ -196,8 +182,7 @@
          "is": ["DATA_FLOW_OBJECT", "EXPRESSION", "LOCAL_LIKE"],
          "outEdges" : [
              {"edgeName": "REF", "inNodes": ["LOCAL"]},
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]},
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]}
          ]
         },
         {"id":30, "name": "RETURN",
@@ -252,9 +237,7 @@
              {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "RETURN", "METHOD_REF"]},
              {"edgeName": "AST", "inNodes": ["LITERAL", "MEMBER",
                                              "MODIFIER", "ARRAY_INITIALIZER", "CALL", "LOCAL",
-                                             "IDENTIFIER", "RETURN", "BLOCK", "METHOD_INST", "UNKNOWN"]},
-
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+                                             "IDENTIFIER", "RETURN", "BLOCK", "METHOD_INST", "UNKNOWN"]}
          ]
         }
     ],
@@ -279,7 +262,6 @@
 
         // Edges to represent type relations
 
-        {"id" : 21, "name" : "EVAL_TYPE", "keys": [], "comment" : "Link to evaluation type.", "keys" : [] },
         {"id" : 22, "name" : "BINDS_TO", "keys": [], "comment" : "Type argument binding to a type parameter.", "keys" : [] },
         {"id" : 23, "name" : "INHERITS_FROM", "keys": [], "comment" : "Inheritance relation between types.", "keys" : [] },
         {"id" : 10, "name" : "REF", "keys" : [], "comment" : "Referencing to e.g. a LOCAL" },

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -21,6 +21,11 @@
             "comment": "This node represents a namespace as a hole whereas the NAMESPACE_BLOCK is used for each grouping occurrence of a namespace in code. Single representing NAMESPACE node is required for easier navigation in the query language.",
             "outEdges": []
         },
+        { "name": "METHOD_PARAMETER_IN",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
         {"id" : 33, "name" : "METHOD_PARAMETER_OUT",
          "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "This node represents a formal parameter going towards the caller side.",
@@ -30,6 +35,46 @@
            {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
          ]
+        },
+        { "name": "METHOD_RETURN",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
+        { "name": "MEMBER",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
+        { "name": "LITERAL",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
+        { "name": "CALL",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
+        { "name": "LOCAL",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
+        { "name": "IDENTIFIER",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
+        { "name": "LOCAL",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
+        { "name": "UNKNOWN",
+          "outEdges" : [
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
         }
     ],
 
@@ -38,7 +83,9 @@
         {"id" : 4, "name" : "CALL_ARG", "comment" : "Function call argument", "keys" : [] },
         {"id" : 5, "name" : "CALL_RET", "comment" : "Function call return value", "keys" : [] },
         {"id" : 11, "name": "TAGGED_BY", "keys" : [], "comment" : "Edges from nodes to tags"},
-        {"id" : 14, "name": "CALL_ARG_OUT", "comment" : "Function call output argument. Goes from METHOD_PARAMETER_OUT to call argument node.", "keys" : []}
+        {"id" : 14, "name": "CALL_ARG_OUT", "comment" : "Function call output argument. Goes from METHOD_PARAMETER_OUT to call argument node.", "keys" : []},
+
+        {"id" : 21, "name" : "EVAL_TYPE", "keys": [], "comment" : "Link to evaluation type.", "keys" : [] }
     ]
 
 }

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -41,6 +41,16 @@
             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
           ]
         },
+        { "name": "TYPE",
+          "outEdges" : [
+             {"edgeName": "REF", "inNodes": ["TYPE_DECL"]}
+          ]
+        },
+        { "name": "TYPE_DECL",
+          "outEdges" : [
+             {"edgeName": "INHERITS_FROM", "inNodes": ["TYPE"]}
+          ]
+        },
         { "name": "MEMBER",
           "outEdges" : [
             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
@@ -85,7 +95,8 @@
         {"id" : 11, "name": "TAGGED_BY", "keys" : [], "comment" : "Edges from nodes to tags"},
         {"id" : 14, "name": "CALL_ARG_OUT", "comment" : "Function call output argument. Goes from METHOD_PARAMETER_OUT to call argument node.", "keys" : []},
 
-        {"id" : 21, "name" : "EVAL_TYPE", "keys": [], "comment" : "Link to evaluation type.", "keys" : [] }
+        {"id" : 21, "name" : "EVAL_TYPE", "keys": [], "comment" : "Link to evaluation type.", "keys" : [] },
+        {"id" : 23, "name" : "INHERITS_FROM", "keys": [], "comment" : "Inheritance relation between types.", "keys" : [] }
     ]
 
 }

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -27,7 +27,7 @@
           ]
         },
         {"id" : 33, "name" : "METHOD_PARAMETER_OUT",
-         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "This node represents a formal parameter going towards the caller side.",
          "is": ["DECLARATION", "DATA_FLOW_OBJECT"],
          "outEdges" : [


### PR DESCRIPTION
Introduce TYPE_FULL_NAME, TYPE_DECL_FULL_NAME and INHERITS_FROM_TYPE_FULL_NAME.
Those properties are used to link to TYPE and TYPE_DECL in the backend.