### PR TITLE
implement cardinality.LIST

### DIFF
--- a/codepropertygraph/codegen/src/main/python/generateJava.py
+++ b/codepropertygraph/codegen/src/main/python/generateJava.py
@@ -47,17 +47,21 @@ def writeJavaFile(className, entryList, template, constantType, identifierField=
 
 def entryListToJavaStrings(entryList, lineTemplate, constantType, identifierField, valueField):
     if constantType == 'Key':
-        lines = [lineTemplate % (x['comment'] if 'comment' in x else '', toJavaType(x['valueType']), x[identifierField], x[valueField]) for x in entryList]
+        lines = [lineTemplate % (x['comment'] if 'comment' in x else '', toJavaType(x['valueType'], x['cardinality']), x[identifierField], x[valueField]) for x in entryList]
     elif constantType == 'String':
         lines = [lineTemplate % (x['comment'] if 'comment' in x else '', x[identifierField], x[valueField]) for x in entryList]
     return "\n".join(lines)
 
-def toJavaType(cpgType):
-    return {
+def toJavaType(cpgType, cardinality):
+    baseType = {
         'string': 'String',
         'int': 'Integer',
         'boolean' : 'Boolean'
     }.get(cpgType, 'UNKNOWN')
+    if cardinality.lower() == 'list':
+        return 'java.util.List<%s>' % baseType
+    else:
+        return baseType
 
 def writeNodeKeyTypesFile(className, nodeKeys, template):
     strings = ''
@@ -72,7 +76,7 @@ def writeNodeKeys(className, types, nodeKeys, template):
     nodeKeysByName = {}
     for key in cpgDescr['nodeKeys']:
         nodeKeysByName[key['name']] = "/** %s */\npublic static final Key<%s> %s = new Key<>(\"%s\");\n\n" \
-                                      % (key['comment'], toJavaType(key['valueType']), key['name'], key['name'])
+                                      % (key['comment'], toJavaType(key['valueType'], key['cardinality']), key['name'], key['name'])
 
     contents = ''.join(sorted(nodeKeysByName.values()))
     for tpe in types:

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -24,7 +24,7 @@
 
         // String properties for various types of nodes
 
-        {"id" : 5, "name": "NAME", "comment": "Name of represented object, e.g., method name", "valueType" : "string", "cardinality" : "one"},
+        {"id" : 5, "name": "NAME", "comment": "Name of represented object, e.g., method name", "valueType" : "string", "cardinality" : "list"},
         {"id" : 6, "name": "FULL_NAME", "comment" : "Full name of an element, e.g., the class name along, including its package.", "valueType" : "string", "cardinality" : "one"},
         {"id": 21, "name": "CODE", "comment": "The code snippet the node represents", "valueType" : "string", "cardinality" : "one"},
         {"id": 22, "name": "SIGNATURE", "comment": "Method signature", "valueType" : "string", "cardinality" : "one"},

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -256,7 +256,7 @@ object DomainClassCreator {
       val keyConstants = keys.map(key => s"""val ${camelCase(key.name).capitalize} = "${key.name}" """).mkString("\n")
       val keyToValueMap = keys.map { key: Property =>
         getHigherType(key) match {
-          case HigherValueType.NONE =>
+          case HigherValueType.NONE | HigherValueType.LIST =>
             s""" "${key.name}" -> { instance: $nodeNameCamelCase => instance.${camelCase(key.name)}}"""
           case HigherValueType.OPTION =>
             s""" "${key.name}" -> { instance: $nodeNameCamelCase => instance.${camelCase(key.name)}.orNull}"""
@@ -269,6 +269,8 @@ object DomainClassCreator {
             s"""${camelCase(key.name)} = properties.get("${key.name}").asInstanceOf[${getBaseType(key)}]"""
           case HigherValueType.OPTION =>
             s"""${camelCase(key.name)} = Option(properties.get("${key.name}").asInstanceOf[${getBaseType(key)}])"""
+          case HigherValueType.LIST =>
+            s"""${camelCase(key.name)} = properties.get("${key.name}").asInstanceOf[${getCompleteType(key)}]"""
         }
       } match {
         case Nil => ""
@@ -334,6 +336,8 @@ object DomainClassCreator {
                   s""" if (key == "${property.name}") this.${camelCase(property.name)} = value.asInstanceOf[${getBaseType(property)}] """
                 case HigherValueType.OPTION =>
                   s""" if (key == "${property.name}") this.${camelCase(property.name)} = Option(value).asInstanceOf[${getCompleteType(property)}] """
+                case HigherValueType.LIST =>
+                  s""" if (key == "${property.name}") this.${camelCase(property.name)} = value.asInstanceOf[${getCompleteType(property)}] """
               }
             }
             (casesForKeys :+ caseNotFound).mkString("\n else ")
@@ -388,7 +392,7 @@ object DomainClassCreator {
           val completeType = cardinality match {
             case Cardinality.ZeroOrOne => s"Option[$containedNodeType]"
             case Cardinality.One => containedNodeType
-            case Cardinality.List => s"List[$containedNodeType]"
+            case Cardinality.List => s"JList[$containedNodeType]"
           }
           val traversalEnding = cardinality match {
             case Cardinality.ZeroOrOne => s".headOption"
@@ -432,13 +436,13 @@ object DomainClassCreator {
 
         s"""
         Map("_label" -> "${nodeType.name}",
-          "_id" -> _id,
+          "_id" -> (_id: Long),
           $forKeys
         ).filterNot { case (k,v) =>
             v == null || v == None
           }
          .map {
-            case (k, v: Option[_]) => (k,v.get)
+            case (k, Some(v)) => (k,v)
             case other => other
           }
         """
@@ -460,7 +464,7 @@ object DomainClassCreator {
           val completeType = Cardinality.fromName(containedNode.cardinality) match {
             case Cardinality.ZeroOrOne => s"Option[$containedNodeType]"
             case Cardinality.One => containedNodeType
-            case Cardinality.List => s"List[$containedNodeType]"
+            case Cardinality.List => s"JList[$containedNodeType]"
           }
           s"""def ${containedNode.localName}: $completeType"""
           }.mkString("\n")
@@ -739,7 +743,7 @@ object Cardinality {
 case class EdgeType(name: String, keys: List[String])
 
 /* representation of nodeKey/edgeKey in cpg.json */
-case class Property(name: String, comment: String, valueType: String, cardinality: String, multipleValues: Option[String])
+case class Property(name: String, comment: String, valueType: String, cardinality: String)
 
 /* representation of nodeBaseTrait in cpg.json */
 case class NodeBaseTrait(name: String, hasKeys: List[String], `extends`: Option[String])
@@ -783,6 +787,6 @@ object Utils {
     getHigherType(property) match {
       case HigherValueType.NONE => getBaseType(property)
       case HigherValueType.OPTION => s"Option[${getBaseType(property)}]"
-      case HigherValueType.LIST => s"List[${getBaseType(property)}]"
+      case HigherValueType.LIST => s"java.util.List[${getBaseType(property)}]"
     }
 }


### PR DESCRIPTION
note: only works as is because it's a local db. to support remote DBs
we'd need to add cardinality support to gremlin.scala.Marshallable

manual testing results:
changed `NAME` property to cardinality=list
sbt codepropertygraph/console

```
import gremlin.scala._
import io.shiftleft.codepropertygraph.generated.nodes.Identifier
import io.shiftleft.codepropertygraph.generated.NodeKeys
import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
import java.util.Arrays

val graph = TinkerGraph.open

val identifier = new Identifier(
 _id = 9,
 _graph = graph,
 code = "code1",
 name = Arrays.asList("n1", "n2"),
 order = 1,
 argumentIndex = 2,
 lineNumber = Some(3),
 lineNumberEnd = None,
 columnNumber = Some(4),
 columnNumberEnd = None)

identifier.toMap
// Map(NAME -> [n1, n2], _id -> 9, CODE -> code1, LINE_NUMBER -> 3, COLUMN_NUMBER -> 4, ARGUMENT_INDEX -> 2, ORDER -> 1, _label -> IDENTIFIER)

identifier.property[java.util.List[String]]("NAME").value
// java.util.List[String] = [n1, n2]

identifier.setProperty(NodeKeys.NAME, Arrays.asList("n3", "n4"))

identifier.property[java.util.List[String]]("NAME").value
// java.util.List[String] = [n3, n4]
```