### PR TITLE
Move LOCAL node in AST below BLOCK.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -83,7 +83,7 @@
          "comment" : "A method/function/procedure",
          "is": ["DECLARATION"],
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["METHOD_RETURN", "METHOD_PARAMETER_IN", "LOCAL",
+             {"edgeName": "AST", "inNodes": ["METHOD_RETURN", "METHOD_PARAMETER_IN",
                                              "MODIFIER", "BLOCK", "TYPE_PARAMETER"]},
              {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]}
          ]
@@ -197,10 +197,10 @@
          ]
         },
         {"id":31, "name": "BLOCK",
-         "keys": [ "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": [ "ORDER", "ARGUMENT_INDEX", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "A structuring block in the AST.",
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]}
+             {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "LOCAL", "UNKNOWN"]}
          ]
         },
         {"id":32, "name":"METHOD_INST",

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -283,7 +283,8 @@
         {"id" : 1, "name" : "JAVA", "comment" : ""},
         {"id" : 2, "name" : "JAVA_SCRIPT", "comment" : ""},
         {"id" : 3, "name" : "GOLANG", "comment" : ""},
-        {"id" : 4, "name" : "CSHARP", "comment" : ""}
+        {"id" : 4, "name" : "CSHARP", "comment" : ""},
+        {"id" : 5, "name" : "FUZZYC", "comment" : ""}
     ],
 
     "modifierTypes" : [


### PR DESCRIPTION
This allows use to represent nested local variables with the need for name
mangling.

Add 'FUZZYC' as langauge.