### PR TITLE
Make BLOCK an expression.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -85,7 +85,7 @@
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["METHOD_RETURN", "METHOD_PARAMETER_IN",
                                              "MODIFIER", "BLOCK", "TYPE_PARAMETER"]},
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]}
+             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
          ]
         },
 
@@ -160,7 +160,7 @@
          "comment" : "Literal/Constant",
          "is": ["DECLARATION", "DATA_FLOW_OBJECT", "EXPRESSION"],
          "outEdges" : [
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]}
+             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
          ]
         },
         {"id": 15, "name" : "CALL",
@@ -169,7 +169,7 @@
          "comment" : "A (method)-call",
          "is": ["EXPRESSION"],
          "outEdges" : [
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]},
+             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]},
              {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF"]}
          ]
         },
@@ -184,7 +184,7 @@
          "is": ["DATA_FLOW_OBJECT", "EXPRESSION", "LOCAL_LIKE"],
          "outEdges" : [
              {"edgeName": "REF", "inNodes": ["LOCAL"]},
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]}
+             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
          ]
         },
         {"id":30, "name": "RETURN",
@@ -197,8 +197,9 @@
          ]
         },
         {"id":31, "name": "BLOCK",
-         "keys": [ "ORDER", "ARGUMENT_INDEX", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": [ "CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "A structuring block in the AST.",
+         "is": [ "EXPRESSION" ],
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "LOCAL", "UNKNOWN"]}
          ]
@@ -222,7 +223,7 @@
           "comment":"Reference to a method instance.",
          "is": ["EXPRESSION"],
           "outEdges": [
-            {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "UNKNOWN"]}
+            {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
           ]
         },
 
@@ -234,7 +235,7 @@
          "comment" : "A language-specific node",
          "is": ["EXPRESSION"],
          "outEdges" : [
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "RETURN", "METHOD_REF"]},
+             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "RETURN", "METHOD_REF", "BLOCK", "UNKNOWN"]},
              {"edgeName": "AST", "inNodes": ["LITERAL", "MEMBER",
                                              "MODIFIER", "ARRAY_INITIALIZER", "CALL", "LOCAL",
                                              "IDENTIFIER", "RETURN", "BLOCK", "METHOD_INST", "UNKNOWN"]}

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -47,18 +47,20 @@
          "comment" : "This node represents a formal parameter going towards the caller side.",
          "is": ["DECLARATION", "DATA_FLOW_OBJECT"],
          "outEdges" : [
-           {"edgeName": "CALL_ARG_OUT", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "UNKNOWN"]},
+           {"edgeName": "CALL_ARG_OUT", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "BLOCK", "UNKNOWN"]},
            {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
          ]
         },
         { "name": "METHOD_RETURN",
           "outEdges" : [
+            {"edgeName": "CALL_RET", "inNodes": ["CALL"]},
             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
           ]
         },
         { "name": "METHOD_REF",
           "outEdges" : [
+            {"edgeName": "CALL_ARG", "inNodes": ["METHOD_PARAMETER_IN"]},
             {"edgeName": "REF", "inNodes": ["METHOD_INST"]}
           ]
         },
@@ -80,11 +82,13 @@
         },
         { "name": "LITERAL",
           "outEdges" : [
+            {"edgeName": "CALL_ARG", "inNodes": ["METHOD_PARAMETER_IN"]},
             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
           ]
         },
         { "name": "CALL",
           "outEdges" : [
+            {"edgeName": "CALL_ARG", "inNodes": ["METHOD_PARAMETER_IN"]},
             {"edgeName": "REF", "inNodes": ["MEMBER"]},
             {"edgeName": "CALL", "inNodes": ["METHOD_INST"]},
             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
@@ -97,6 +101,13 @@
         },
         { "name": "IDENTIFIER",
           "outEdges" : [
+            {"edgeName": "CALL_ARG", "inNodes": ["METHOD_PARAMETER_IN"]},
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+          ]
+        },
+        { "name": "BLOCK",
+          "outEdges" : [
+            {"edgeName": "CALL_ARG", "inNodes": ["METHOD_PARAMETER_IN"]},
             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
           ]
         },
@@ -107,6 +118,7 @@
         },
         { "name": "UNKNOWN",
           "outEdges" : [
+            {"edgeName": "CALL_ARG", "inNodes": ["METHOD_PARAMETER_IN"]},
             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
           ]
         }


### PR DESCRIPTION
Also moved the definition of CALL_ARG edges from cpg-internal to cpg
repo, since those are to be created by a linker located in the public
code.