### PR TITLE
version with sbt-dynver to not default to 0.1.0-SNAPSHOT in local dev

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,5 @@
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.1")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.6")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")


### PR DESCRIPTION
let's hope this doesn't break the ci-release plugin. merging to
master will show.