### PR TITLE
s/fuzzyc/c

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -287,7 +287,7 @@
         {"id" : 2, "name" : "JAVA_SCRIPT", "comment" : ""},
         {"id" : 3, "name" : "GOLANG", "comment" : ""},
         {"id" : 4, "name" : "CSHARP", "comment" : ""},
-        {"id" : 5, "name" : "FUZZYC", "comment" : ""}
+        {"id" : 5, "name" : "C", "comment" : ""}
     ],
 
     "modifierTypes" : [

--- a/enhancements/src/main/scala/io/shiftleft/layers/enhancedbase/EnhancedBaseCreator.scala
+++ b/enhancements/src/main/scala/io/shiftleft/layers/enhancedbase/EnhancedBaseCreator.scala
@@ -31,7 +31,7 @@ class EnhancedBaseCreator(graph: ScalaGraph, language: String) {
           new ContainsEdgePass(graph),
           new NamespaceCreator(graph),
         )
-      case Languages.FUZZYC =>
+      case Languages.C =>
         List(
           new MethodStubCreator(graph),
           new ReceiverEdgePass(graph),


### PR DESCRIPTION
This change renames the `fuzzyc` to a proper language `c`.
Frontends will be handled separately, if necessary, in a separate
category.