### PR TITLE
Changes for LITERAL node.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -156,9 +156,9 @@
         // Nodes that describe method content
 
         {"id" : 8, "name" : "LITERAL",
-         "keys" : ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys" : ["CODE", /* DEPRECATED "NAME",*/ "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
          "comment" : "Literal/Constant",
-         "is": ["DECLARATION", "DATA_FLOW_OBJECT", "EXPRESSION"],
+         "is": ["DATA_FLOW_OBJECT", "EXPRESSION"],
          "outEdges" : [
              {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
          ]

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodTests.scala
@@ -26,7 +26,7 @@ class MethodTests extends WordSpec with Matchers {
         fixture.cpg.method.name("methodWithLiteral").literal.toList
 
       queryResult.size shouldBe 1
-      queryResult.head.name shouldBe "\"myLiteral\""
+      queryResult.head.code shouldBe "\"myLiteral\""
     }
 
     "filter by name" in {

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/Literal.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/Literal.scala
@@ -14,7 +14,6 @@ import shapeless.HList
   */
 class Literal[Labels <: HList](raw: GremlinScala[Vertex])
     extends CpgSteps[nodes.Literal, Labels](raw)
-    with DeclarationBase[nodes.Literal, Labels]
     with ExpressionBase[nodes.Literal, Labels]
     with CodeAccessors[nodes.Literal, Labels]
     with NameAccessors[nodes.Literal, Labels]


### PR DESCRIPTION
Deprecated NAME property. Since a literal has no name this property was
there by accident.
LITERAL nodes are no declarations anymore.