### PR TITLE
upgrade to sbt-ci-release-early v1.0.11

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.6")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.11")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")


### PR DESCRIPTION
previous versions of the plugin used `sonatypeReleaseAll` which fails if other projects in the same groupId have staging issues