### PR TITLE
Fix crash on invalid input and improve logging.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/linking/linker/Linker.scala
@@ -221,7 +221,9 @@ class Linker(graph: ScalaGraph) extends CpgPass(graph) {
                       .flatMap(lookupNode(_))
                   case _ =>
                     logger.error(
-                      s"Invalid AST_PARENT_TYPE=${astChild.value2(NodeKeys.AST_PARENT_FULL_NAME)}; astChild=$astChild")
+                      s"Invalid AST_PARENT_TYPE=${astChild.valueOption(NodeKeys.AST_PARENT_FULL_NAME)};" +
+                        s" astChild LABEL=${astChild.label};" +
+                        s" astChild FULL_NAME=${astChild.valueOption(NodeKeys.FULL_NAME)}")
                     None
                 }
 


### PR DESCRIPTION
In case the AST parent relation was missing we crashed instead of just logging an error. This is now fixed.