### PR TITLE
Move implicits to package objects, so that the compiler finds them automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /build/*
-**/generated/*
 .idea/
 /codepropertygraph/src/main/proto/io/shiftleft/codepropertygraph/protos.proto
 target/

--- a/README.md
+++ b/README.md
@@ -373,13 +373,10 @@ val cpg = io.shiftleft.cpgloading.CpgLoader.loadCodePropertyGraph("cpg.bin.zip")
 
 # Querying the cpg
 Once you've loaded a cpg you can run queries, which are provided by the `query-primitives` subproject. Note that if you're in the sbt shell you can play with it interactively: `TAB` completion is your friend. Otherwise your IDE will assist. 
-Don't forget to `import io.shiftleft.queryprimitives.steps.Implicits._`.
 
 Here are some simple traversals to get all the base nodes. Running all of these without errors is a good test to ensure that your cpg is valid: 
 
 ```scala
-import io.shiftleft.queryprimitives.steps.Implicits._
-
 cpg.literal.toList
 cpg.file.toList
 cpg.namespace.toList

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ There are some sample cpgs in this repository in the `resources/cpgs` directory.
 sbt semanticcpg/console
 ```
 ```scala
-val cpg = io.shiftleft.CpgLoader.loadCodePropertyGraph("cpg.bin.zip")
+val cpg = io.shiftleft.cpgloading.CpgLoader.loadCodePropertyGraph("cpg.bin.zip")
 ```
 
 # Querying the cpg

--- a/build.sbt
+++ b/build.sbt
@@ -48,5 +48,5 @@ lazy val cpgqueryingtests = Projects.cpgqueryingtests
 lazy val semanticcpg = Projects.semanticcpg
 
 ThisBuild/publishTo := sonatypePublishTo.value
-ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature")
+ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 ThisBuild/compile/javacOptions ++= Seq("-g") //debug symbols

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -3,7 +3,7 @@ package io.shiftleft.cpgqueryingtests.codepropertygraph
 import java.io.{File, PrintWriter}
 import java.nio.file.Files
 
-import io.shiftleft.CpgLoader
+import io.shiftleft.cpgloading.CpgLoader
 import io.shiftleft.queryprimitives.steps.starters.Cpg
 
 class CpgFactory(frontend: LanguageFrontend) {

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.cpgqueryingtests.codepropertygraph
 
 import gremlin.scala._
-import io.shiftleft.CpgLoader
+import io.shiftleft.cpgloading.CpgLoader
 
 case class CpgTestFixture(projectName: String) {
   lazy val cpg = CpgLoader.loadCodePropertyGraph(s"resources/cpgs/$projectName/cpg.bin.zip")

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CDataFlowTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CDataFlowTests.scala
@@ -5,7 +5,6 @@ import org.scalatest.{Matchers, WordSpec}
 import io.shiftleft.passes.dataflows._
 import io.shiftleft.passes.dataflows.steps.{FlowPrettyPrinter}
 import io.shiftleft.codepropertygraph.generated.{NodeKeys, nodes}
-import io.shiftleft.queryprimitives.steps.Implicits._
 import io.shiftleft.queryprimitives.steps._
 import io.shiftleft.passes.dataflows.Implicits._
 

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CDataFlowTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CDataFlowTests.scala
@@ -9,7 +9,6 @@ import io.shiftleft.queryprimitives.steps.Implicits._
 import io.shiftleft.queryprimitives.steps._
 import io.shiftleft.passes.dataflows.Implicits._
 
-import scala.language.implicitConversions
 
 class CDataFlowTests extends CpgDataFlowTests {
   val cpgFactory = new CpgFactory(LanguageFrontend.Fuzzyc)

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CpgDataFlowTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CpgDataFlowTests.scala
@@ -8,7 +8,6 @@ import io.shiftleft.queryprimitives.steps.types.expressions.Literal
 import io.shiftleft.queryprimitives.steps.types.structure.{Member, Method}
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.language.implicitConversions
 import shapeless.HNil
 
 class CpgDataFlowTests extends WordSpec with Matchers {

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CpgDataFlowTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CpgDataFlowTests.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.cpgqueryingtests.steps
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.Implicits._
 import io.shiftleft.queryprimitives.steps.starters.Cpg
 import io.shiftleft.queryprimitives.steps._
 import io.shiftleft.queryprimitives.steps.types.expressions.Literal

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/ExpressionTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/ExpressionTests.scala
@@ -2,7 +2,6 @@ package io.shiftleft.cpgqueryingtests.steps
 
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgTestFixture
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.Implicits._
 import org.scalatest.{Matchers, WordSpec}
 
 class ExpressionTests extends WordSpec with Matchers {

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/FileTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/FileTests.scala
@@ -2,7 +2,6 @@ package io.shiftleft.cpgqueryingtests.steps
 
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgTestFixture
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.Implicits._
 import org.scalatest.{Matchers, WordSpec}
 
 class FileTests extends WordSpec with Matchers {

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodParameterTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodParameterTests.scala
@@ -2,7 +2,6 @@ package io.shiftleft.cpgqueryingtests.steps
 
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgTestFixture
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.Implicits.NodeTypeDeco
 import org.scalatest.{Matchers, WordSpec}
 
 class MethodParameterTests extends WordSpec with Matchers {

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodParameterTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodParameterTests.scala
@@ -2,7 +2,7 @@ package io.shiftleft.cpgqueryingtests.steps
 
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgTestFixture
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.NodeTypeDeco
 import org.scalatest.{Matchers, WordSpec}
 
 class MethodParameterTests extends WordSpec with Matchers {

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodTests.scala
@@ -3,7 +3,6 @@ package io.shiftleft.cpgqueryingtests.steps
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgTestFixture
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.{Languages, NodeKeys, NodeTypes}
-import io.shiftleft.queryprimitives.steps.Implicits._
 import org.scalatest.{Matchers, WordSpec}
 import java.io._
 import org.json4s._

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/NamespaceTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/NamespaceTests.scala
@@ -2,7 +2,6 @@ package io.shiftleft.cpgqueryingtests.steps
 
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgTestFixture
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.Implicits._
 import org.scalatest.{Matchers, WordSpec}
 
 class NamespaceTests extends WordSpec with Matchers {

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/StepsTest.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/StepsTest.scala
@@ -1,12 +1,11 @@
 package io.shiftleft.cpgqueryingtests.steps
 
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgTestFixture
-import gremlin.scala._
+import gremlin.scala.{Edge,GremlinScala,StepLabel,Vertex}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.diffgraph.{DiffGraph, DiffGraphApplier}
-import io.shiftleft.queryprimitives.steps.Implicits._
 import org.json4s.JString
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.{Matchers, WordSpec}

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/TypeTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/TypeTests.scala
@@ -2,7 +2,6 @@ package io.shiftleft.cpgqueryingtests.steps
 
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgTestFixture
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.Implicits._
 import org.scalatest.{Matchers, WordSpec}
 
 class TypeTests extends WordSpec with Matchers {

--- a/query-primitives/src/main/scala/io/shiftleft/codepropertygraph/generated/nodes/package.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/codepropertygraph/generated/nodes/package.scala
@@ -1,0 +1,53 @@
+package io.shiftleft.codepropertygraph.generated
+
+import gremlin.scala._
+import io.shiftleft.queryprimitives.steps.{NewNodeSteps,NodeSteps}
+import shapeless.{HList, HNil}
+
+package object nodes {
+
+  private def newAnonymousTraversalWithAssociatedGraph[NodeType <: StoredNode](seq: NodeType*): GremlinScala.Aux[NodeType, HNil] = {
+    val anonymousTraversal = __[NodeType](seq: _*)
+    if (seq.nonEmpty) {
+      anonymousTraversal.traversal.asAdmin().setGraph(seq.head.graph)
+    }
+    anonymousTraversal
+  }
+
+  implicit class NodeTypeDeco[NodeType <: StoredNode](node: NodeType) {
+
+    /**
+      Start a new traversal from this node
+      */
+    def start: NodeSteps[NodeType, HNil] =
+      new NodeSteps[NodeType, HNil](newAnonymousTraversalWithAssociatedGraph(node))
+  }
+
+  implicit class NodeTypeDecoForSeq[NodeType <: nodes.StoredNode](seq: Seq[NodeType]) {
+
+    /**
+      Start a new traversal from these nodes
+      */
+    def start: NodeSteps[NodeType, HNil] =
+      new NodeSteps[NodeType, HNil](newAnonymousTraversalWithAssociatedGraph(seq: _*))
+  }
+
+  implicit class NewNodeTypeDeco[NodeType <: nodes.NewNode](node: NodeType) {
+
+    /**
+    Start a new traversal from this node
+      */
+    def start: NewNodeSteps[NodeType, HNil] =
+      new NewNodeSteps[NodeType, HNil](__[NodeType](node))
+  }
+
+  implicit class NewNodeTypeDecoForSeq[NodeType <: nodes.NewNode](seq: Seq[NodeType]) {
+
+    /**
+    Start a new traversal from these nodes
+      */
+    def start: NewNodeSteps[NodeType, HNil] =
+      new NewNodeSteps[NodeType, HNil](__[NodeType](seq: _*))
+  }
+
+}

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Implicits.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Implicits.scala
@@ -2,14 +2,10 @@ package io.shiftleft.queryprimitives.steps
 
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.types.structure._
-import io.shiftleft.queryprimitives.steps.types.expressions._
-import io.shiftleft.queryprimitives.steps.types.expressions.generalizations._
 import shapeless.{HList, HNil}
 
-object Implicits extends Implicits // to allow for a hierarchy of implicits
-
-trait Implicits {
+// TODO move to `nodes` package object?
+object Implicits {
 
   private def newAnonymousTraversalWithAssociatedGraph[NodeType <: nodes.StoredNode](seq: NodeType*) = {
     val anonymousTraversal = __[NodeType](seq: _*)
@@ -86,62 +82,5 @@ trait Implicits {
       }
     }
   }
-
-  /* TODO: generate this boilerplate */
-  implicit def toLiteral[Labels <: HList](steps: Steps[nodes.Literal, Labels]): Literal[Labels] =
-    new Literal[Labels](steps.raw)
-
-  implicit def toType[Labels <: HList](steps: Steps[nodes.Type, Labels]): Type[Labels] =
-    new Type[Labels](steps.raw)
-
-  implicit def toTypeDecl[Labels <: HList](steps: Steps[nodes.TypeDecl, Labels]): TypeDecl[Labels] =
-    new TypeDecl[Labels](steps.raw)
-
-  implicit def toCall[Labels <: HList](steps: Steps[nodes.Call, Labels]): Call[Labels] =
-    new Call[Labels](steps.raw)
-
-  implicit def toIdentifier[Labels <: HList](steps: Steps[nodes.Identifier, Labels]): Identifier[Labels] =
-    new Identifier[Labels](steps.raw)
-
-  implicit def toMember[Labels <: HList](steps: Steps[nodes.Member, Labels]): Member[Labels] =
-    new Member[Labels](steps.raw)
-
-  implicit def toLocal[Labels <: HList](steps: Steps[nodes.Local, Labels]): Local[Labels] =
-    new Local[Labels](steps.raw)
-
-  implicit def toMethodInst[Labels <: HList](steps: Steps[nodes.MethodInst, Labels]): MethodInst[Labels] =
-    new MethodInst[Labels](steps.raw)
-
-  implicit def toMethod[Labels <: HList](steps: Steps[nodes.Method, Labels]): Method[Labels] =
-    new Method[Labels](steps.raw)
-
-  implicit def toMethodParameter[Labels <: HList](
-      steps: Steps[nodes.MethodParameterIn, Labels]): MethodParameter[Labels] =
-    new MethodParameter[Labels](steps.raw)
-
-  implicit def toMethodParameterOut[Labels <: HList](
-      steps: Steps[nodes.MethodParameterOut, Labels]): MethodParameterOut[Labels] =
-    new MethodParameterOut[Labels](steps.raw)
-
-  implicit def toMethodReturn[Labels <: HList](steps: Steps[nodes.MethodReturn, Labels]): MethodReturn[Labels] =
-    new MethodReturn[Labels](steps.raw)
-
-  implicit def toNamespace[Labels <: HList](steps: Steps[nodes.Namespace, Labels]): Namespace[Labels] =
-    new Namespace[Labels](steps.raw)
-
-  implicit def toNamespaceBlock[Labels <: HList](steps: Steps[nodes.NamespaceBlock, Labels]): NamespaceBlock[Labels] =
-    new NamespaceBlock[Labels](steps.raw)
-
-  implicit def toModifier[Labels <: HList](steps: Steps[nodes.Modifier, Labels]): Modifier[Labels] =
-    new Modifier[Labels](steps.raw)
-
-  implicit def toExpression[Labels <: HList](steps: Steps[nodes.Expression, Labels]): Expression[Labels] =
-    new Expression[Labels](steps.raw)
-
-  implicit def toDeclaration[Labels <: HList](steps: Steps[nodes.Declaration, Labels]): Declaration[Labels] =
-    new Declaration[Labels](steps.raw)
-
-  implicit def toFile[Labels <: HList](steps: Steps[nodes.File, Labels]): File[Labels] =
-    new File[Labels](steps.raw)
 
 }

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Implicits.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Implicits.scala
@@ -4,52 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
 import shapeless.{HList, HNil}
 
-// TODO move to `nodes` package object?
 object Implicits {
-
-  private def newAnonymousTraversalWithAssociatedGraph[NodeType <: nodes.StoredNode](seq: NodeType*) = {
-    val anonymousTraversal = __[NodeType](seq: _*)
-    if (seq.nonEmpty) {
-      anonymousTraversal.traversal.asAdmin().setGraph(seq.head.graph())
-    }
-    anonymousTraversal
-  }
-
-  implicit class NodeTypeDeco[NodeType <: nodes.StoredNode](node: NodeType) {
-
-    /**
-      Start a new traversal from this node
-      */
-    def start: NodeSteps[NodeType, HNil] =
-      new NodeSteps[NodeType, HNil](newAnonymousTraversalWithAssociatedGraph(node))
-  }
-
-  implicit class NodeTypeDecoForSeq[NodeType <: nodes.StoredNode](seq: Seq[NodeType]) {
-
-    /**
-      Start a new traversal from these nodes
-      */
-    def start: NodeSteps[NodeType, HNil] =
-      new NodeSteps[NodeType, HNil](newAnonymousTraversalWithAssociatedGraph(seq: _*))
-  }
-
-  implicit class NewNodeTypeDeco[NodeType <: nodes.NewNode](node: NodeType) {
-
-    /**
-    Start a new traversal from this node
-      */
-    def start: NewNodeSteps[NodeType, HNil] =
-      new NewNodeSteps[NodeType, HNil](__[NodeType](node))
-  }
-
-  implicit class NewNodeTypeDecoForSeq[NodeType <: nodes.NewNode](seq: Seq[NodeType]) {
-
-    /**
-    Start a new traversal from these nodes
-      */
-    def start: NewNodeSteps[NodeType, HNil] =
-      new NewNodeSteps[NodeType, HNil](__[NodeType](seq: _*))
-  }
 
   implicit class GremlinScalaDeco[End <: Vertex, Labels <: HList](raw: GremlinScala.Aux[End, Labels]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Implicits.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Implicits.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.types.structure._
 import io.shiftleft.queryprimitives.steps.types.expressions._
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations._
-import scala.language.implicitConversions
 import shapeless.{HList, HNil}
 
 object Implicits extends Implicits // to allow for a hierarchy of implicits

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Implicits.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Implicits.scala
@@ -2,13 +2,11 @@ package io.shiftleft.queryprimitives.steps
 
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.starters.{Cpg, NodeTypeStarters}
 import io.shiftleft.queryprimitives.steps.types.structure._
 import io.shiftleft.queryprimitives.steps.types.expressions._
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations._
-import shapeless.{HList, HNil}
-
 import scala.language.implicitConversions
+import shapeless.{HList, HNil}
 
 object Implicits extends Implicits // to allow for a hierarchy of implicits
 
@@ -89,9 +87,6 @@ trait Implicits {
       }
     }
   }
-
-  implicit def toNodeTypeStarters(cpg: Cpg): NodeTypeStarters =
-    new NodeTypeStarters(cpg)
 
   /* TODO: generate this boilerplate */
   implicit def toLiteral[Labels <: HList](steps: Steps[nodes.Literal, Labels]): Literal[Labels] =

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/NodeSteps.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/NodeSteps.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.queryprimitives.steps
 
-import gremlin.scala._
+import gremlin.scala.{GremlinScala,P,Vertex}
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.types.structure.File
 import java.util.{List => JList}
 
@@ -30,7 +29,7 @@ class NodeSteps[NodeType <: nodes.StoredNode, Labels <: HList](raw: GremlinScala
       raw
         .cast[nodes.StoredNode]
         .until(_.hasLabel(NodeTypes.FILE))
-        .repeat(_.in(EdgeTypes.AST).cast[StoredNode])
+        .repeat(_.in(EdgeTypes.AST).cast[nodes.StoredNode])
         .cast[nodes.File])
 
   /* follow the incoming edges of the given type as long as possible */

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Steps.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Steps.scala
@@ -17,6 +17,7 @@ import shapeless.{::, HList, HNil}
 import shapeless.ops.hlist.{IsHCons, Mapper, Prepend, RightFolder, ToTraversable, Tupler}
 import shapeless.ops.product.ToHList
 
+// TODO maybe remove?
 trait StepsRoot {
   type NodeType0
   def raw: GremlinScala[NodeType0]
@@ -28,7 +29,7 @@ trait StepsRoot {
   Base class for our DSL
   These are the base steps available in all steps of the query language.
   */
-class Steps[NodeType, Labels <: HList](val raw: GremlinScala.Aux[NodeType, Labels]) extends StepsRoot {
+class Steps[NodeType, Labels <: HList](val raw: GremlinScala.Aux[NodeType, Labels]) extends StepsRoot with ext.Enrichable {
   type NodeType0 = NodeType
   implicit lazy val graph: Graph = raw.traversal.asAdmin.getGraph.get
 

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/WithinMethodMethods.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/WithinMethodMethods.scala
@@ -3,7 +3,7 @@ package io.shiftleft.queryprimitives.steps
 import io.shiftleft.codepropertygraph.generated.nodes.NodeVisitor
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.queryprimitives.steps.visitormixins.ExpressionGeneralization
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
 import org.apache.tinkerpop.gremlin.structure.Direction
 
 class WithinMethodMethods(val node: nodes.WithinMethod) extends AnyVal {

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/ext/Enrichable.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/ext/Enrichable.scala
@@ -1,0 +1,12 @@
+package io.shiftleft.queryprimitives.steps.ext
+
+
+/** Sole purpose of this trait is to allow to enrich ('pimp') this DSL without the need of additional
+  * imports a la `import x.y.z.Implicits._`. We're making use of the fact that package objects of
+  * inherited traits are automatically part of implicit scope. This way, these extensions also show 
+  * up in scaladoc. 
+  * 
+  * Important: this project should *not* define anything in the `ext` package object. If it does,
+  * it will be shadowed by enriching libraries. 
+ */
+trait Enrichable

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.queryprimitives
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import scala.language.implicitConversions
 
 /**
   Steps for traversing the code property graph

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
@@ -1,13 +1,24 @@
 package io.shiftleft.queryprimitives
 
+import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.queryprimitives.steps.types.structure._
+import io.shiftleft.queryprimitives.steps.types.expressions._
+import io.shiftleft.queryprimitives.steps.types.expressions.generalizations._
+import shapeless.{HList, HNil}
 
 /**
   Steps for traversing the code property graph
 
-  All traversal start at io.shiftleft.queryprimitives.starters.Cpg.
+  All traversals start at io.shiftleft.queryprimitives.starters.Cpg.
+  
+  Implicit conversions to specific steps, based on the node at hand. 
+  Automatically in scope when using anything in the `steps` package, e.g. `Steps`
   */
 package object steps {
+
+  // TODO MP: rather use `start` mechanism?
+  // alternative: move to `nodes` package object?
   implicit def trackingPointMethodsQp(node: nodes.TrackingPoint): TrackingPointMethods =
     new TrackingPointMethods(node)
 
@@ -19,4 +30,61 @@ package object steps {
 
   implicit def cfgNodeMethodsQp(node: nodes.CfgNode): CfgNodeMethods =
     new CfgNodeMethods(node)
+
+
+  implicit def toLiteral[Labels <: HList](steps: Steps[nodes.Literal, Labels]): Literal[Labels] =
+    new Literal[Labels](steps.raw)
+
+  implicit def toType[Labels <: HList](steps: Steps[nodes.Type, Labels]): Type[Labels] =
+    new Type[Labels](steps.raw)
+
+  implicit def toTypeDecl[Labels <: HList](steps: Steps[nodes.TypeDecl, Labels]): TypeDecl[Labels] =
+    new TypeDecl[Labels](steps.raw)
+
+  implicit def toCall[Labels <: HList](steps: Steps[nodes.Call, Labels]): Call[Labels] =
+    new Call[Labels](steps.raw)
+
+  implicit def toIdentifier[Labels <: HList](steps: Steps[nodes.Identifier, Labels]): Identifier[Labels] =
+    new Identifier[Labels](steps.raw)
+
+  implicit def toMember[Labels <: HList](steps: Steps[nodes.Member, Labels]): Member[Labels] =
+    new Member[Labels](steps.raw)
+
+  implicit def toLocal[Labels <: HList](steps: Steps[nodes.Local, Labels]): Local[Labels] =
+    new Local[Labels](steps.raw)
+
+  implicit def toMethodInst[Labels <: HList](steps: Steps[nodes.MethodInst, Labels]): MethodInst[Labels] =
+    new MethodInst[Labels](steps.raw)
+
+  implicit def toMethod[Labels <: HList](steps: Steps[nodes.Method, Labels]): Method[Labels] =
+    new Method[Labels](steps.raw)
+
+  implicit def toMethodParameter[Labels <: HList](
+      steps: Steps[nodes.MethodParameterIn, Labels]): MethodParameter[Labels] =
+    new MethodParameter[Labels](steps.raw)
+
+  implicit def toMethodParameterOut[Labels <: HList](
+      steps: Steps[nodes.MethodParameterOut, Labels]): MethodParameterOut[Labels] =
+    new MethodParameterOut[Labels](steps.raw)
+
+  implicit def toMethodReturn[Labels <: HList](steps: Steps[nodes.MethodReturn, Labels]): MethodReturn[Labels] =
+    new MethodReturn[Labels](steps.raw)
+
+  implicit def toNamespace[Labels <: HList](steps: Steps[nodes.Namespace, Labels]): Namespace[Labels] =
+    new Namespace[Labels](steps.raw)
+
+  implicit def toNamespaceBlock[Labels <: HList](steps: Steps[nodes.NamespaceBlock, Labels]): NamespaceBlock[Labels] =
+    new NamespaceBlock[Labels](steps.raw)
+
+  implicit def toModifier[Labels <: HList](steps: Steps[nodes.Modifier, Labels]): Modifier[Labels] =
+    new Modifier[Labels](steps.raw)
+
+  implicit def toExpression[Labels <: HList](steps: Steps[nodes.Expression, Labels]): Expression[Labels] =
+    new Expression[Labels](steps.raw)
+
+  implicit def toDeclaration[Labels <: HList](steps: Steps[nodes.Declaration, Labels]): Declaration[Labels] =
+    new Declaration[Labels](steps.raw)
+
+  implicit def toFile[Labels <: HList](steps: Steps[nodes.File, Labels]): File[Labels] =
+    new File[Labels](steps.raw)
 }

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
@@ -31,7 +31,6 @@ package object steps {
   implicit def cfgNodeMethodsQp(node: nodes.CfgNode): CfgNodeMethods =
     new CfgNodeMethods(node)
 
-
   implicit def toLiteral[Labels <: HList](steps: Steps[nodes.Literal, Labels]): Literal[Labels] =
     new Literal[Labels](steps.raw)
 

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/starters/Cpg.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/starters/Cpg.scala
@@ -3,7 +3,7 @@ package io.shiftleft.queryprimitives.steps.starters
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.{NodeSteps, Steps}
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import shapeless.HNil
 
 object Cpg {

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/starters/Cpg.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/starters/Cpg.scala
@@ -4,6 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.{NodeSteps, Steps}
 import io.shiftleft.queryprimitives.steps.Implicits._
+import scala.language.implicitConversions
 import shapeless.HNil
 
 object Cpg {
@@ -11,6 +12,9 @@ object Cpg {
   /* syntactic sugar for `Cpg(graph)`. Usage:
    * `Cpg(graph)` or simply `Cpg` if you have an `implicit Graph` in scope */
   def apply(implicit graph: Graph) = new Cpg(graph)
+
+  implicit def toNodeTypeStarters(cpg: Cpg): NodeTypeStarters =
+    new NodeTypeStarters(cpg)
 }
 
 /**

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/starters/Cpg.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/starters/Cpg.scala
@@ -4,7 +4,6 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.{NodeSteps, Steps}
 import io.shiftleft.queryprimitives.steps.Implicits._
-import scala.language.implicitConversions
 import shapeless.HNil
 
 object Cpg {

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/Call.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/Call.scala
@@ -4,7 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.{ICallResolver, NodeSteps, Steps}
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.types.propertyaccessors._
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations._
 import io.shiftleft.queryprimitives.steps.types.structure.{Member, Method, MethodInst, MethodReturn}

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Block.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Block.scala
@@ -2,10 +2,9 @@ package io.shiftleft.queryprimitives.steps.types.structure
 
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
-import io.shiftleft.queryprimitives.steps.Implicits._
 import io.shiftleft.queryprimitives.steps.NodeSteps
 import shapeless.HList
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations.ExpressionBase
 
 class Block[Labels <: HList](raw: GremlinScala.Aux[nodes.Block, Labels])

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Method.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Method.scala
@@ -4,7 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations.{DeclarationBase, Expression, Modifier}
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.{ICallResolver, NodeSteps}
 import io.shiftleft.queryprimitives.steps.types.expressions.{Call, Literal}
 import io.shiftleft.queryprimitives.steps.types.propertyaccessors._

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/MethodInst.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/MethodInst.scala
@@ -2,7 +2,7 @@ package io.shiftleft.queryprimitives.steps.types.structure
 
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.{ICallResolver, NodeSteps}
 import io.shiftleft.queryprimitives.steps.types.expressions.{Call, Literal}
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations.Modifier

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/MethodParameter.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/MethodParameter.scala
@@ -4,7 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.NodeSteps
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations.{DeclarationBase, Expression}
 import io.shiftleft.queryprimitives.steps.types.propertyaccessors._
 import shapeless.HList

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/MethodParameterOut.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/MethodParameterOut.scala
@@ -4,7 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.{NodeSteps, Steps}
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations.{DeclarationBase, Expression}
 import io.shiftleft.queryprimitives.steps.types.propertyaccessors._
 import shapeless.HList

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Type.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Type.scala
@@ -4,7 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.{NodeSteps, Steps}
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations.{Declaration, Expression}
 import io.shiftleft.queryprimitives.steps.types.propertyaccessors.{FullNameAccessors, NameAccessors}
 import shapeless.{HList, HNil}

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/TypeDecl.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/TypeDecl.scala
@@ -4,7 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps.NodeSteps
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations.Modifier
 import io.shiftleft.queryprimitives.steps.types.propertyaccessors.{FullNameAccessors, IsExternalAccessor, NameAccessors}
 import shapeless.HList

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/ExpandTo.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/ExpandTo.scala
@@ -3,7 +3,7 @@ package io.shiftleft.queryprimitives.utils
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated._
 import org.apache.tinkerpop.gremlin.structure.{Direction, Vertex}
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
 
 import scala.collection.JavaConverters._
 

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/Statements.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/Statements.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.queryprimitives.utils
 
 import io.shiftleft.queryprimitives.steps.starters.Cpg
-import io.shiftleft.queryprimitives.steps.Implicits._
 
 object Statements {
   def countAll(cpg: Cpg): Long = {

--- a/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
@@ -1,8 +1,8 @@
-package io.shiftleft
+package io.shiftleft.cpgloading
 
 import gremlin.scala.{Graph, ScalaGraph}
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.generated.{NodeKeys, NodeTypes, nodes}
-import io.shiftleft.cpgloading.{IgnoredProtoEntries, OnDiskOverflowConfig, ProtoCpgLoader}
 import io.shiftleft.layers.enhancedbase.EnhancedBaseCreator
 import io.shiftleft.queryprimitives.steps.starters.Cpg
 import io.shiftleft.queryprimitives.CpgOverlayLoader

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/Implicits.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/Implicits.scala
@@ -3,7 +3,7 @@ package io.shiftleft.passes.dataflows
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.passes.dataflows.steps.TrackingPoint
 import io.shiftleft.queryprimitives.steps.Steps
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import shapeless.HList
 
 object Implicits {

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/Implicits.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/Implicits.scala
@@ -11,4 +11,5 @@ object Implicits {
   implicit def toTrackingPoint[X <% Steps[NodeType, Labels], NodeType <: nodes.TrackingPoint, Labels <: HList](
       steps: X): TrackingPoint[Labels] =
     new TrackingPoint[Labels](steps.raw.cast[nodes.TrackingPoint])
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/package.scala
@@ -1,0 +1,13 @@
+package io.shiftleft.passes.dataflows
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.passes.dataflows.steps.TrackingPoint
+import io.shiftleft.queryprimitives.steps.Steps
+import shapeless.HList
+
+package object steps {
+
+  implicit def toTrackingPoint[Labels <: HList](steps: Steps[nodes.TrackingPoint, Labels]): TrackingPoint[Labels] =
+    new TrackingPoint[Labels](steps.raw)
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/steps/FlowPrettyPrinter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/steps/FlowPrettyPrinter.scala
@@ -6,7 +6,6 @@ import java.nio.charset.StandardCharsets
 import dnl.utils.text.table.TextTable
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.queryprimitives.steps._
-import io.shiftleft.passes.dataflows.Implicits._
 
 object FlowPrettyPrinter {
   def prettyPrint(path: List[nodes.TrackingPoint]): String = {

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/steps/FlowPrettyPrinter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/steps/FlowPrettyPrinter.scala
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets
 
 import dnl.utils.text.table.TextTable
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.queryprimitives.steps.Implicits._
 import io.shiftleft.queryprimitives.steps._
 import io.shiftleft.passes.dataflows.Implicits._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/steps/TrackingPoint.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/dataflows/steps/TrackingPoint.scala
@@ -14,7 +14,7 @@ import scala.collection.JavaConverters._
   * Base class for nodes that can occur in data flows
   * */
 class TrackingPoint[Labels <: HList](raw: GremlinScala.Aux[nodes.TrackingPoint, Labels])
-  extends NodeSteps(raw) {
+  extends NodeSteps[nodes.TrackingPoint, Labels](raw) {
 
   private class ReachableByContainer(val reachedSource: nodes.TrackingPoint, val path: List[nodes.TrackingPoint]) {
     override def clone(): ReachableByContainer = {

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -6,7 +6,6 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.queryprimitives.steps.starters.Cpg
-import io.shiftleft.queryprimitives.steps.Implicits._
 import org.apache.tinkerpop.gremlin.structure.Direction
 
 import scala.collection.JavaConverters._

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
@@ -4,7 +4,6 @@ import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.queryprimitives.steps.starters.Cpg
-import io.shiftleft.queryprimitives.steps.Implicits._
 
 class TypeDeclStubCreator(graph: ScalaGraph) extends CpgPass(graph) {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/linking/linker/Linker.scala
@@ -3,7 +3,7 @@ package io.shiftleft.passes.linking.linker
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.passes.CpgPass
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
 import java.lang.{Long => JLong}
 
 import io.shiftleft.diffgraph.DiffGraph

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/linking/memberaccesslinker/MemberAccessLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/linking/memberaccesslinker/MemberAccessLinker.scala
@@ -1,11 +1,11 @@
 package io.shiftleft.passes.linking.memberaccesslinker
-import gremlin.scala._
-import io.shiftleft.codepropertygraph.generated._
+
+import io.shiftleft.codepropertygraph.generated.{nodes, EdgeTypes, NodeKeys, Operators}
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
-import io.shiftleft.queryprimitives.steps.Implicits._
 import io.shiftleft.queryprimitives.steps.starters.Cpg
 import org.apache.tinkerpop.gremlin.structure.Direction
+import gremlin.scala.{ScalaGraph, Vertex}
 
 import scala.collection.JavaConverters._
 
@@ -31,7 +31,7 @@ class MemberAccessLinker(graph: ScalaGraph) extends CpgPass(graph) {
           val memberName = call
             .vertices(Direction.OUT, EdgeTypes.AST)
             .asScala
-            .filter(_.value2(NodeKeys.ORDER) == 2)
+            .filter(_.value(NodeKeys.ORDER.name) == 2)
             .next
             .asInstanceOf[nodes.Identifier]
             .name

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/methoddecorations/MethodDecoratorPass.scala
@@ -4,7 +4,7 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
-import io.shiftleft.queryprimitives.steps.Implicits._
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
 import org.apache.tinkerpop.gremlin.structure.Direction
 
 object MethodDecoratorPass {

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/reachingdef/ReachingDefPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/reachingdef/ReachingDefPass.scala
@@ -4,7 +4,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
-import io.shiftleft.queryprimitives.steps.Implicits._
 import io.shiftleft.queryprimitives.steps.types.structure.File
 import io.shiftleft.queryprimitives.utils.ExpandTo
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
@@ -4,7 +4,7 @@ import java.nio.file.Files
 
 import gremlin.scala._
 import io.shiftleft.passes.methoddecorations.MethodDecoratorPass
-import io.shiftleft.CpgLoader
+import io.shiftleft.cpgloading.CpgLoader
 import io.shiftleft.queryprimitives.steps.starters.Cpg
 import org.apache.tinkerpop.gremlin.structure.Graph
 


### PR DESCRIPTION
We don't need to `impoirt x.y.z.Implicits._` any more, which is nice for writing code, but even more so enables scaladoc to find those conversions, so we can drop our patched version of scaladoc. 
Fixes https://github.com/ShiftLeftSecurity/ocular/issues/267

More context:
Methods like `TypeDecl.annotation` and `Cpg.annotation` used to be in the apidocs as long as we maintained had a duplicate version of codepropertygraph, query-primitives etc. That's why they're gone now, since those projects are now unified (which is a good thing).

The reason they don't appear any more is because they are only accessible behind an implicit conversion that has to be imported manually, typically using `import x.y.z.Implicits._`, and scaladoc simply doesn't see that. 

In the past I fixed that exact problem by patching scaladoc and allow to specify additional implicits that are always in scope. That worked, but the chances of getting that merged into upstream scaladoc are rather slim: the use case is rather specialised and it's adding incidental complexity: what if that additional global implicit leads to problems in some files?

Therefor, while we *could* continue doing that, there's a better way: avoiding the `object Implicits` altogether. The trick is to move all implicits into a scope where they are automatically found, without an additional import. One such place is the package object, so we could just define our 'extension' implicits for steps in the `io.shiftleft.queryprimitives.steps` package object.
Sounds great, but there's one problem: if cpg-public already defines that package object, we cannot 'extend/enrich' it in a different compilation unit (e.g. codescience). Instead, it will be shadowed, i.e. we lose the implicits from the original package object.

Because we control both repositories, we can manually deduplicate them in such a 'shadowing' case, or even follow the *convention* to not use package objects in cpg-public altogether. I don't really like this idea, for once because the `io.shiftleft.queryprimitives.steps` package belongs to cpg-public, and therefor it's package object should, too. Also, it's another arbitrary rule for an already complex topic.

However, digging deeper in the implicit resolution rules, I found a variation that I believe ticks all our boxes: the compiler doesn't only look in the package object of the concrete class, but also in all package objects of all trait mixins. We can make use of that: `cpg-public` could define an `io.shiftleft.queryprimitives.ext.Enrichable` trait that's being mixed into `Steps`. 
The `io.shiftleft.queryprimitives.steps.ext` package object will then be defined in `codescience/query-primitives-ext`, providing implicit conversions like `Steps[nodes.TypeDecl] -> TypeDeclExt`, where `TypeDeclExt` has internal-only steps like `.annotation`. All of this works without *explicitly* importing other implicits (`import Implicits._`), which means that our code as well as scaladoc finds them automatically, and we can drop our fork of scaladoc. This would then be described as the default enrichment mechanism for anyone building on top of cpg-public.