### PR TITLE
External/Internal steps for `Namespace`

### DIFF
--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Namespace.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Namespace.scala
@@ -37,4 +37,19 @@ class Namespace[Labels <: HList](raw: GremlinScala.Aux[nodes.Namespace, Labels])
     * */
   def method: Method[Labels] =
     typeDecl.method
+
+  /**
+    * External namespaces - any namespaces
+    * which contain one or more external type.
+    * */
+  def external: Namespace[Labels] =
+    new Namespace(filter(_.typeDecl.external).raw)
+
+  /**
+    * Internal namespaces - any namespaces
+    * which contain one or more internal type
+    * */
+  def internal: Namespace[Labels] =
+    new Namespace(filter(_.typeDecl.internal).raw)
+
 }


### PR DESCRIPTION
Previously, `external` and `internal` were only defined on `typeDecl`. This PR introduces the same steps for `namespace`. A namespace is external if at least one of the types it hosts is external, and it is internal, if at least one of its types is internal.