### PR TITLE
use `nextChecked` instead of `next`, so we get stack traces

### DIFF
--- a/query-primitives/src/main/java/io/shiftleft/cpgloading/ProtoToCpg.java
+++ b/query-primitives/src/main/java/io/shiftleft/cpgloading/ProtoToCpg.java
@@ -7,6 +7,7 @@ import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node.Property;
 import io.shiftleft.proto.cpg.Cpg.PropertyValue;
 import io.shiftleft.proto.cpg.Cpg.PropertyValue.ValueCase;
 import io.shiftleft.queryprimitives.steps.starters.Cpg;
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco;
 
 import org.apache.commons.configuration.Configuration;
 import org.apache.logging.log4j.Logger;
@@ -80,8 +81,8 @@ public class ProtoToCpg {
     for (Edge edge : protoEdges) {
       long srcNodeId = edge.getSrc();
       long dstNodeId = edge.getDst();
-      Vertex srcVertex = tinkerGraph.vertices(srcNodeId).next();
-      Vertex dstVertex = tinkerGraph.vertices(dstNodeId).next();
+      Vertex srcVertex = new JavaIteratorDeco<>(tinkerGraph.vertices(srcNodeId)).nextChecked();
+      Vertex dstVertex = new JavaIteratorDeco<>(tinkerGraph.vertices(dstNodeId)).nextChecked();
 
       List<Edge.Property> properties = edge.getPropertyList();
       final ArrayList<Object> keyValues = new ArrayList<>(2 * properties.size());

--- a/query-primitives/src/main/java/io/shiftleft/cpgloading/ProtoToCpg.java
+++ b/query-primitives/src/main/java/io/shiftleft/cpgloading/ProtoToCpg.java
@@ -81,6 +81,9 @@ public class ProtoToCpg {
     for (Edge edge : protoEdges) {
       long srcNodeId = edge.getSrc();
       long dstNodeId = edge.getDst();
+      if (srcNodeId == -1 || dstNodeId == -1) {
+        throw new IllegalArgumentException("edge " + edge + "has illegal src|dst node. something seems wrong with the cpg");
+      }
       Vertex srcVertex = new JavaIteratorDeco<>(tinkerGraph.vertices(srcNodeId)).nextChecked();
       Vertex dstVertex = new JavaIteratorDeco<>(tinkerGraph.vertices(dstNodeId)).nextChecked();
 

--- a/query-primitives/src/main/java/io/shiftleft/cpgloading/ProtoToCpg.java
+++ b/query-primitives/src/main/java/io/shiftleft/cpgloading/ProtoToCpg.java
@@ -82,7 +82,7 @@ public class ProtoToCpg {
       long srcNodeId = edge.getSrc();
       long dstNodeId = edge.getDst();
       if (srcNodeId == -1 || dstNodeId == -1) {
-        throw new IllegalArgumentException("edge " + edge + "has illegal src|dst node. something seems wrong with the cpg");
+        throw new IllegalArgumentException("edge " + edge + " has illegal src|dst node. something seems wrong with the cpg");
       }
       Vertex srcVertex = new JavaIteratorDeco<>(tinkerGraph.vertices(srcNodeId)).nextChecked();
       Vertex dstVertex = new JavaIteratorDeco<>(tinkerGraph.vertices(dstNodeId)).nextChecked();

--- a/query-primitives/src/main/scala/io/shiftleft/diffgraph/DiffGraphApplier.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/diffgraph/DiffGraphApplier.scala
@@ -3,6 +3,7 @@ package io.shiftleft.diffgraph
 import gremlin.scala._
 import io.shiftleft.IdentityHashWrapper
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
 import java.lang.{Long => JLong}
 import java.util
 
@@ -58,7 +59,7 @@ class DiffGraphApplier {
 
   private def addEdges(diffGraph: DiffGraph, graph: ScalaGraph) = {
     def lookupNode(id: JLong): Vertex =
-      graph.graph.vertices(id).next
+      graph.graph.vertices(id).nextChecked
 
     diffGraph.edges.foreach { edge =>
       val srcTinkerNode = overlayNodeToTinkerNode.get(IdentityHashWrapper(edge.src))

--- a/query-primitives/src/main/scala/io/shiftleft/passes/dataflows/steps/TrackingPoint.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/passes/dataflows/steps/TrackingPoint.scala
@@ -5,6 +5,7 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.queryprimitives.steps.{NodeSteps, Steps}
 import shapeless.HList
 import io.shiftleft.queryprimitives.steps.types.structure.Method
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
 import io.shiftleft.queryprimitives.utils.ExpandTo
 import org.apache.tinkerpop.gremlin.structure.Direction
 
@@ -92,11 +93,11 @@ class TrackingPoint[Labels <: HList](raw: GremlinScala.Aux[nodes.TrackingPoint, 
 
   private def getTrackingPoint(vertex: Vertex): Option[nodes.TrackingPoint] = {
     vertex match {
-      case identifier: nodes.Identifier          => getTrackingPoint(identifier.vertices(Direction.IN, EdgeTypes.AST).next)
+      case identifier: nodes.Identifier          => getTrackingPoint(identifier.vertices(Direction.IN, EdgeTypes.AST).nextChecked)
       case call: nodes.Call                      => Some(call)
       case ret: nodes.Return                     => Some(ret)
       case methodReturn: nodes.MethodReturn      => Some(methodReturn)
-      case literal: nodes.Literal                => getTrackingPoint(literal.vertices(Direction.IN, EdgeTypes.AST).next)
+      case literal: nodes.Literal                => getTrackingPoint(literal.vertices(Direction.IN, EdgeTypes.AST).nextChecked)
       case _                                     => None
     }
   }

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/ExpandTo.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/ExpandTo.scala
@@ -56,12 +56,7 @@ object ExpandTo {
   }
 
   def returnToReturnedExpression(returnExpression: Vertex): Option[nodes.Expression] = {
-    val it = returnExpression.vertices(Direction.OUT, EdgeTypes.AST)
-    if (it.hasNext) {
-      Some(it.next.asInstanceOf[nodes.Expression])
-    } else {
-      None
-    }
+    returnExpression.vertices(Direction.OUT, EdgeTypes.AST).nextOption.map(_.asInstanceOf[nodes.Expression])
   }
 
   def methodToFormalReturn(method: Vertex): Vertex = {
@@ -69,7 +64,8 @@ object ExpandTo {
       .vertices(Direction.OUT, EdgeTypes.AST)
       .asScala
       .filter(_.isInstanceOf[nodes.MethodReturn])
-      .next()
+      .asJava
+      .nextChecked
   }
 
   def formalReturnToReturn(methodReturn: Vertex): Seq[Vertex] = {
@@ -138,12 +134,7 @@ object ExpandTo {
   }
 
   def reference(node: Vertex): Option[Vertex] = {
-    val iterator = node.vertices(Direction.OUT, EdgeTypes.REF).asScala
-    if (iterator.hasNext) {
-      Some(iterator.next)
-    } else {
-      None
-    }
+    node.vertices(Direction.OUT, EdgeTypes.REF).nextOption
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/linking/linker/Linker.scala
@@ -102,19 +102,15 @@ class Linker(graph: ScalaGraph) extends CpgPass(graph) {
   }
 
   private def initMaps(): Unit = {
-    val iter = graph.graph.vertices()
-    while (iter.hasNext) {
-      iter.next() match {
-        case node: nodes.TypeDecl   => typeDeclFullNameToNodeId += node.fullName -> node.getId
-        case node: nodes.Type       => typeFullNameToNodeId += node.fullName -> node.getId
-        case node: nodes.Method     => methodFullNameToNodeId += node.fullName -> node.getId
-        case node: nodes.MethodInst => methodInstFullNameToNodeId += node.fullName -> node.getId
-        case node: nodes.NamespaceBlock =>
-          namespaceBlockFullNameToNodeId += node.fullName -> node.getId
-        case _ => // ignore
-      }
+    graph.graph.vertices().asScala.foreach {
+      case node: nodes.TypeDecl   => typeDeclFullNameToNodeId += node.fullName -> node.getId
+      case node: nodes.Type       => typeFullNameToNodeId += node.fullName -> node.getId
+      case node: nodes.Method     => methodFullNameToNodeId += node.fullName -> node.getId
+      case node: nodes.MethodInst => methodInstFullNameToNodeId += node.fullName -> node.getId
+      case node: nodes.NamespaceBlock =>
+        namespaceBlockFullNameToNodeId += node.fullName -> node.getId
+      case _ => // ignore
     }
-
   }
 
   private def linkToSingle[SRC_NODE_TYPE <: nodes.StoredNode](srcLabels: Set[String],
@@ -144,7 +140,7 @@ class Linker(graph: ScalaGraph) extends CpgPass(graph) {
           }
         } else {
           val dstFullName =
-            srcNode.vertices(Direction.OUT, edgeType).next.value2(NodeKeys.FULL_NAME)
+            srcNode.vertices(Direction.OUT, edgeType).nextChecked.value2(NodeKeys.FULL_NAME)
           srcNode.property(dstFullNameKey, dstFullName)
           if (!loggedDeprecationWarning) {
             logger.warn(
@@ -273,6 +269,6 @@ class Linker(graph: ScalaGraph) extends CpgPass(graph) {
   }
 
   private def lookupNode(nodeId: JLong): Option[nodes.StoredNode] =
-    Option(graph.graph.vertices(nodeId).next).asInstanceOf[Option[nodes.StoredNode]]
+    graph.graph.vertices(nodeId).nextOption.map(_.asInstanceOf[nodes.StoredNode])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/linking/memberaccesslinker/MemberAccessLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/linking/memberaccesslinker/MemberAccessLinker.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.passes.linking.memberaccesslinker
 
+import gremlin.scala.ScalaGraph
 import io.shiftleft.codepropertygraph.generated.{nodes, EdgeTypes, NodeKeys, Operators}
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.queryprimitives.steps.starters.Cpg
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
 import org.apache.tinkerpop.gremlin.structure.Direction
-import gremlin.scala.{ScalaGraph, Vertex}
+
 
 import scala.collection.JavaConverters._
 
@@ -32,7 +34,8 @@ class MemberAccessLinker(graph: ScalaGraph) extends CpgPass(graph) {
             .vertices(Direction.OUT, EdgeTypes.AST)
             .asScala
             .filter(_.value(NodeKeys.ORDER.name) == 2)
-            .next
+            .asJava
+            .nextChecked
             .asInstanceOf[nodes.Identifier]
             .name
 

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/methoddecorations/MethodDecoratorPass.scala
@@ -39,7 +39,7 @@ class MethodDecoratorPass(graph: ScalaGraph) extends CpgPass(graph) {
           )
 
           val method =
-            parameterIn.vertices(Direction.IN, EdgeTypes.AST).next.asInstanceOf[nodes.Method]
+            parameterIn.vertices(Direction.IN, EdgeTypes.AST).nextChecked.asInstanceOf[nodes.Method]
           if (parameterIn.typeFullName == null) {
             val evalType = parameterIn
               .vertices(Direction.OUT, EdgeTypes.EVAL_TYPE)

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/reachingdef/ReachingDefPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/reachingdef/ReachingDefPass.scala
@@ -1,16 +1,14 @@
 package io.shiftleft.passes.reachingdef
+
 import gremlin.scala._
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
-import io.shiftleft.queryprimitives.steps.types.structure.File
+import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
 import io.shiftleft.queryprimitives.utils.ExpandTo
-
-import scala.collection.mutable.ListBuffer
-import org.apache.tinkerpop.gremlin.structure.Direction
 import java.nio.file.Paths
 
+import org.apache.tinkerpop.gremlin.structure.Direction
 import scala.collection.JavaConverters._
 
 class ReachingDefPass(graph: ScalaGraph) extends CpgPass(graph) {
@@ -308,7 +306,7 @@ class DataFlowFrameworkHelper(graph: ScalaGraph) {
 
   def getOperation(vertex: Vertex): Option[Vertex] = {
     vertex match {
-      case _: nodes.Identifier => getOperation(vertex.vertices(Direction.IN, EdgeTypes.AST).next)
+      case _: nodes.Identifier => getOperation(vertex.vertices(Direction.IN, EdgeTypes.AST).nextChecked)
       case _: nodes.Call => Some(vertex)
       case _: nodes.Return => Some(vertex)
       case _                    => None


### PR DESCRIPTION
includes some other iterator-related refactorings

re https://github.com/ShiftLeftSecurity/product/issues/2405