### PR TITLE
allow up to 30 mins for a release before timing out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
   - stage: test
     script: sbt +test
   - stage: release
-    script: sbt ci-release-sonatype
+    script: travis_wait 30 sbt ci-release-sonatype
 
 before_cache:
 - du -h -d 1 $HOME/.ivy2/cache


### PR DESCRIPTION
we've had a few builds time out during release, e.g.
https://travis-ci.org/ShiftLeftSecurity/codepropertygraph/jobs/517687956

The unfortunate thing is that it leaves incomplete staged repositories
behind, which may affect other projects.

relevant docs: https://docs.travis-ci.com/user/common-build-problems/#My-builds-are-timing-out