### PR TITLE
gitignore for travis_wait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 /codepropertygraph/src/main/resources/cpg.json
 protoc-3.6.0-linux-x86_64.zip
 private-key.pem
+travis_wait_*


### PR DESCRIPTION
hopefully fixes travis.ci release after https://github.com/ShiftLeftSecurity/codepropertygraph/pull/119
errored build: https://travis-ci.org/ShiftLeftSecurity/codepropertygraph/jobs/519161426