### PR TITLE
Shorthands for queries on calls

### DIFF
--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/Call.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/Call.scala
@@ -63,6 +63,12 @@ class Call[Labels <: HList](raw: GremlinScala.Aux[nodes.Call, Labels])
     new Expression[Labels](raw.out(EdgeTypes.AST).cast[nodes.Expression])
 
   /**
+    `i'th` arguments of the call
+    */
+  def argument(i: Integer): Expression[Labels] =
+    argument.order(i)
+
+  /**
     To formal method return parameter
     */
   def toMethodReturn: MethodReturn[Labels] =

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/generalizations/Expression.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/generalizations/Expression.scala
@@ -47,7 +47,7 @@ trait ExpressionBase[NodeType <: nodes.Expression, Labels <: HList]
   /**
    Cast to call if applicable and filter for callee fullName `calleeRegex`
     */
-  def call(calleeRegex: String)(implicit callResolver : ICallResolver): Call[Labels] =
+  def call(calleeRegex: String)(implicit callResolver: ICallResolver): Call[Labels] =
     call.filter(_.calledMethod.fullName(calleeRegex))
 
   /**

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/generalizations/Expression.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/generalizations/Expression.scala
@@ -10,6 +10,8 @@ import io.shiftleft.queryprimitives.steps.types.propertyaccessors._
 import io.shiftleft.queryprimitives.steps.types.structure.{Method, MethodParameter, Type}
 import shapeless.HList
 
+import io.shiftleft.queryprimitives.steps.ICallResolver
+
 /**
   An expression (base type)
   */
@@ -41,6 +43,12 @@ trait ExpressionBase[NodeType <: nodes.Expression, Labels <: HList]
     */
   def call: Call[Labels] =
     new Call[Labels](raw.hasLabel(NodeTypes.CALL).cast[nodes.Call])
+
+  /**
+   Cast to call if applicable and filter for callee fullName `calleeRegex`
+    */
+  def call(calleeRegex: String)(implicit callResolver : ICallResolver): Call[Labels] =
+    call.filter(_.calledMethod.fullName(calleeRegex))
 
   /**
     Traverse to enclosing expression

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Method.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Method.scala
@@ -134,6 +134,12 @@ class Method[Labels <: HList](override val raw: GremlinScala.Aux[nodes.Method, L
     new Call[Labels](raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**
+    * Outgoing call sites to methods where fullName matches `regex`.
+    * */
+  def callOut(regex: String)(implicit callResolver: ICallResolver): Call[Labels] =
+    callOut.filter(_.calledMethod.fullName(regex))
+
+  /**
     * The type declaration associated with this method, e.g., the class it is defined in.
     * */
   def definingTypeDecl: TypeDecl[Labels] =


### PR DESCRIPTION
Introduced the following shorthands:
* `argument.order(n)` -> `argument(n)`
* `method.callOut.filter(_.calledMethod.fullName(regex))` -> `method.callOut(regex)`
* `expression.call.filter(_.calledMethod.fullName(regex))` -> `expression.call(regex)`
