### PR TITLE
Work on TrackingPointBase instead of TrackingPoint.

### DIFF
--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/TrackingPointMethods.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/TrackingPointMethods.scala
@@ -9,7 +9,7 @@ import org.apache.tinkerpop.gremlin.structure.Direction
 
 import scala.collection.JavaConverters._
 
-class TrackingPointMethods(val node: nodes.TrackingPoint) extends AnyVal {
+class TrackingPointMethods(val node: nodes.TrackingPointBase) extends AnyVal {
   def cfgNode: nodes.CfgNode = {
     node.accept(TrackPointToCfgNode)
   }

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
@@ -21,9 +21,6 @@ package object steps {
 
   // TODO MP: rather use `start` mechanism?
   // alternative: move to `nodes` package object?
-  implicit def trackingPointMethodsQp(node: nodes.TrackingPoint): TrackingPointMethods =
-    new TrackingPointMethods(node)
-
   implicit def trackingPointBaseMethodsQp(node: nodes.TrackingPointBase): TrackingPointMethods =
     new TrackingPointMethods(node.asInstanceOf[nodes.TrackingPoint])
 


### PR DESCRIPTION
This allows us to also handle TrackingPoint instances not in the graph
itself.