### PR TITLE
Pass in cfgNode implementation via implicit var.

### DIFF
--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -200,6 +200,7 @@ object DomainClassCreator {
       val nodeVisitor = 
         s"""trait NodeVisitor[T] {
           ${generateNodeVisitorMethods}
+          ${generateNewNodeVisitorMethods}
           ${generateBaseTraitVisitorMethods}
         }\n"""
 
@@ -269,6 +270,16 @@ object DomainClassCreator {
         val nodeNameCamelCase = camelCase(nodeType.name).capitalize
 
         s"def visit(node: ${nodeNameCamelCase}): T = ???"
+      }.mkString("\n")
+    }
+
+    def generateNewNodeVisitorMethods() = {
+      val nodeTypes = (Resources.cpgJson \ "nodeTypes").as[List[NodeType]]
+
+      nodeTypes.map { nodeType =>
+        val nodeNameCamelCase = camelCase(nodeType.name).capitalize
+
+        s"def visit(node: New${nodeNameCamelCase}): T = ???"
       }.mkString("\n")
     }
 
@@ -770,7 +781,9 @@ object DomainClassCreator {
         override val properties: Map[String, Any] = $propertiesImpl
         override def containedNodesByLocalName: Map[String, List[Node]] = $containedNodesByLocalName
 
-        override def accept[T](visitor: NodeVisitor[T]): T = ???
+        override def accept[T](visitor: NodeVisitor[T]): T = {
+          visitor.visit(this)
+        }
       }
       """
     }

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/TrackingPointMethods.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/TrackingPointMethods.scala
@@ -10,12 +10,12 @@ import org.apache.tinkerpop.gremlin.structure.Direction
 import scala.collection.JavaConverters._
 
 class TrackingPointMethods(val node: nodes.TrackingPointBase) extends AnyVal {
-  def cfgNode: nodes.CfgNode = {
-    node.accept(TrackPointToCfgNode)
+  def cfgNode(implicit impl: TrackPointToCfgNode): nodes.CfgNode = {
+    node.accept(impl)
   }
 }
 
-private object TrackPointToCfgNode extends NodeVisitor[nodes.CfgNode] with ExpressionGeneralization[nodes.CfgNode] {
+class TrackPointToCfgNode extends NodeVisitor[nodes.CfgNode] with ExpressionGeneralization[nodes.CfgNode] {
   override def visit(node: nodes.MethodParameterIn): nodes.CfgNode = {
     ExpandTo.parameterToMethod(node).asInstanceOf[nodes.CfgNode]
   }

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/package.scala
@@ -22,7 +22,9 @@ package object steps {
   // TODO MP: rather use `start` mechanism?
   // alternative: move to `nodes` package object?
   implicit def trackingPointBaseMethodsQp(node: nodes.TrackingPointBase): TrackingPointMethods =
-    new TrackingPointMethods(node.asInstanceOf[nodes.TrackingPoint])
+    new TrackingPointMethods(node)
+
+  implicit var trackingPointToCfgNodeImpl = new TrackPointToCfgNode()
 
   implicit def withMethodMethodsQp(node: nodes.WithinMethod): WithinMethodMethods =
     new WithinMethodMethods(node)


### PR DESCRIPTION
This makes it possible to extend functionality in downstream projects.
Include NewXXX classes in NodeVisitor pattern.