### PR TITLE
use latest release plugin, which only pushes the tag after release

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.4")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.12")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.15")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")


### PR DESCRIPTION
this should avoid that timeout issues (which happen during sonatype release occasionally) lead to incorrectly tagged repositories