### PR TITLE
Second try to get in default values for strings

### DIFF
--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -694,7 +694,7 @@ object DomainClassCreator {
             /* a little hack to allow us to have different DomainClassCreator while using the same cpg traversals */
             if (getHigherType(key) == HigherValueType.Option) " = None"
             else if (key.valueType == "int") " = -1"
-            else if (key.valueType == "String") """ ="" """
+            else if (getHigherType(key) == HigherValueType.None && key.valueType == "string") """ ="" """
             else ""
           s"${camelCase(key.name)}: ${getCompleteType(key)} $optionalDefault"
         }


### PR DESCRIPTION
First PR matched for "String" while it should have been "string". When I fixed the typo, it became clear that we also need to check for cardinality of the property. Only string fields with cardinality one should be set to the empty string by default.