### PR TITLE
Example for node enrichment

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/nodes/Enrichable.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/nodes/Enrichable.scala
@@ -1,0 +1,11 @@
+package io.shiftleft.codepropertygraph.nodes
+
+/** Sole purpose of this trait is to allow to enrich ('pimp') this DSL without the need of additional
+  * imports a la `import x.y.z.Implicits._`. We're making use of the fact that package objects of
+  * inherited traits are automatically part of implicit scope. This way, these extensions also show
+  * up in scaladoc.
+  *
+  * Important: this project should *not* define anything in the `ext` package object. If it does,
+  * it will be shadowed by enriching libraries.
+  */
+trait Enrichable

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/MethodTests.scala
@@ -11,6 +11,13 @@ import org.json4s.native.JsonMethods._
 class MethodTests extends WordSpec with Matchers {
   val fixture = CpgTestFixture("method")
 
+  "Method node" should {
+    "expand to parameters" in {
+      val m = fixture.cpg.method.head
+      m.parameter.name.toSet shouldBe Set("param0", "param1")
+    }
+  }
+
   "Method traversals" should {
     "expand to type declaration" in {
       val queryResult: List[nodes.TypeDecl] =

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -175,7 +175,7 @@ object DomainClassCreator {
       import scala.collection.JavaConverters._
       import shapeless.HNil
 
-      trait Node extends gremlin.scala.dsl.DomainRoot {
+      trait Node extends gremlin.scala.dsl.DomainRoot with io.shiftleft.codepropertygraph.nodes.Enrichable {
         def accept[T](visitor: NodeVisitor[T]): T
       }
 

--- a/query-primitives/src/main/scala/io/shiftleft/codepropertygraph/nodes/package.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/codepropertygraph/nodes/package.scala
@@ -1,0 +1,11 @@
+package io.shiftleft.codepropertygraph
+
+import io.shiftleft.codepropertygraph.generated.{nodes => cpgnodes}
+import io.shiftleft.queryprimitives.steps.types.structure.MethodNode
+
+package object nodes {
+
+  implicit def toMethodNode(node : cpgnodes.Method) : MethodNode =
+    new MethodNode(node)
+
+}

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Method.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Method.scala
@@ -8,7 +8,14 @@ import io.shiftleft.queryprimitives.steps.Implicits.GremlinScalaDeco
 import io.shiftleft.queryprimitives.steps.{ICallResolver, NodeSteps}
 import io.shiftleft.queryprimitives.steps.types.expressions.{Call, Literal}
 import io.shiftleft.queryprimitives.steps.types.propertyaccessors._
-import shapeless.HList
+import shapeless.{HList, HNil}
+
+class MethodNode(node : nodes.Method) {
+
+  def parameter : MethodParameter[HNil] =
+    List(node).start.parameter
+
+}
 
 /**
   * A method, function, or procedure


### PR DESCRIPTION
This PR demonstrates how we can enrich nodes such that enrichments show up in scaladoc - following the same pattern that @mpollmeier used for step enrichment. The mechanism is demonstrated by adding a `parameter` method to `method` nodes.

I realize @ml86 is working on new concepts for our DSL implementation, however, I don't want to wait for that to conclude to make further language improvements. Instead, let's shape the DSL further with the current implementation, and thereby uncover what a new implementation would need to provide.