### PR TITLE
Clean up CpgLoader API

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ There are some sample cpgs in this repository in the `resources/cpgs` directory.
 sbt semanticcpg/console
 ```
 ```scala
-val cpg = io.shiftleft.cpgloading.CpgLoader.loadCodePropertyGraph("cpg.bin.zip")
+val cpg = io.shiftleft.cpgloading.CpgLoader.load("cpg.bin.zip")
 ```
 
 # Querying the cpg

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -4,6 +4,7 @@ import java.io.{File, PrintWriter}
 import java.nio.file.Files
 
 import io.shiftleft.cpgloading.CpgLoader
+import io.shiftleft.cpgloading.CpgLoaderConfig
 import io.shiftleft.queryprimitives.steps.starters.Cpg
 
 class CpgFactory(frontend: LanguageFrontend) {
@@ -20,9 +21,9 @@ class CpgFactory(frontend: LanguageFrontend) {
 
     val cpgFile = frontend.execute(tmpDir)
 
-    val graph = CpgLoader.loadCodePropertyGraph(
-      cpgFile.getAbsolutePath,
-      argDefFilename = Some("cpgqueryingtests/src/test/resources/default.argdef"))
+    val config = CpgLoaderConfig.default
+    config.argDefFilename = Some("cpgqueryingtests/src/test/resources/default.argdef")
+    val graph = CpgLoader.load(cpgFile.getAbsolutePath, config)
 
     graph
   }

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
@@ -4,7 +4,7 @@ import gremlin.scala._
 import io.shiftleft.cpgloading.CpgLoader
 
 case class CpgTestFixture(projectName: String) {
-  lazy val cpg = CpgLoader.loadCodePropertyGraph(s"resources/cpgs/$projectName/cpg.bin.zip", argDefFilename = None)
+  lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip")
   implicit val graph: Graph = cpg.graph
   lazy val scalaGraph: ScalaGraph = graph.asScala
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
@@ -19,9 +19,9 @@ object CpgLoaderConfig {
     CpgLoaderConfig(argDefFilename = None, createIndices = true, onDiskOverflowConfig = None)
 }
 
-case class CpgLoaderConfig(argDefFilename: Option[String],
-                           createIndices: Boolean,
-                           onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {}
+case class CpgLoaderConfig(var argDefFilename: Option[String],
+                           var createIndices: Boolean,
+                           var onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {}
 
 object CpgLoader {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
@@ -13,7 +13,37 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 
 import scala.compat.java8.OptionConverters._
 
+object Config {
+
+  def default: Config = Config(argDefFilename = None, createIndices = true, onDiskOverflowConfig = None)
+}
+
+case class Config(argDefFilename: Option[String],
+                  createIndices: Boolean,
+                  onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {}
+
 object CpgLoader {
+
+  /**
+    * Load a Code Property Graph
+    *
+    * @param filename      name of file that stores the code property graph
+    * @param argDefFilename file containing argument definition entries
+    * @param createIndices whether or not to create indices
+    * @param onDiskOverflowConfig for the on-disk-overflow feature
+    */
+  @deprecated
+  def loadCodePropertyGraph(filename: String,
+                            argDefFilename: Option[String] = None,
+                            createIndices: Boolean = true,
+                            onDiskOverflowConfig: Option[OnDiskOverflowConfig] = None): Cpg = {
+    new CpgLoader().loadCodePropertyGraph(filename, argDefFilename, createIndices, onDiskOverflowConfig)
+  }
+
+}
+
+class CpgLoader {
+
   private val logger = LogManager.getLogger(getClass)
 
   /* some non-public frontends (e.g. java2cpg) use cpg proto entries that are `UNRECOGNIZED` by cpg-public.
@@ -27,26 +57,41 @@ object CpgLoader {
   /**
     * Load a Code Property Graph
     *
-    * @param filename      name of file that stores the code property graph
-    * @param argDefFilename name of file with the argument def statements
-    * @param createIndices create indexes after loading the file
-    */
-  def loadCodePropertyGraph(filename: String,
-                            argDefFilename: Option[String] = None,
-                            createIndices: Boolean = true,
-                            onDiskOverflowConfig: Option[OnDiskOverflowConfig] = None): Cpg = {
+    * @param filename name of file that stores the code property graph
+    * @param config loader configuration
+    * */
+  def loadCodePropertyGraph(filename: String, config: Config = Config.default): Cpg = {
     logger.debug("Loading " + filename)
     val argumentDefs =
-      if (argDefFilename.isDefined) {
-        val argumentDefLoader = new ArgumentDefLoader(argDefFilename.get)
+      if (config.argDefFilename.isDefined) {
+        val argumentDefLoader = new ArgumentDefLoader(config.argDefFilename.get)
         argumentDefLoader.load()
       } else {
         ArgumentDefs(Nil)
       }
-    val cpg = ProtoCpgLoader.loadFromProtoZip(filename, onDiskOverflowConfig.asJava, Some(ignoredProtoEntries).asJava)
+    val cpg =
+      ProtoCpgLoader.loadFromProtoZip(filename, config.onDiskOverflowConfig.asJava, Some(ignoredProtoEntries).asJava)
     runEnhancements(cpg.graph, argumentDefs)
-    if (createIndices) { createIndexes(cpg) }
+    if (config.createIndices) { createIndexes(cpg) }
     cpg
+  }
+
+  /**
+    * Load a Code Property Graph
+    *
+    * @param filename      name of file that stores the code property graph
+    * @param argDefFilename file containing argument definition entries
+    * @param createIndices whether or not to create indices
+    * @param onDiskOverflowConfig for the on-disk-overflow feature
+    */
+  @deprecated
+  def loadCodePropertyGraph(filename: String,
+                            argDefFilename: Option[String],
+                            createIndices: Boolean,
+                            onDiskOverflowConfig: Option[OnDiskOverflowConfig]): Cpg = {
+
+    val config = new Config(argDefFilename, createIndices, onDiskOverflowConfig)
+    loadCodePropertyGraph(filename, config)
   }
 
   protected def runEnhancements(graph: Graph, argumentDefs: ArgumentDefs): Unit = {
@@ -77,5 +122,3 @@ object CpgLoader {
     }
 
 }
-
-class CpgLoader {}

--- a/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
@@ -13,16 +13,27 @@ import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph
 
 import scala.compat.java8.OptionConverters._
 
-object Config {
+object CpgLoaderConfig {
 
-  def default: Config = Config(argDefFilename = None, createIndices = true, onDiskOverflowConfig = None)
+  def default: CpgLoaderConfig =
+    CpgLoaderConfig(argDefFilename = None, createIndices = true, onDiskOverflowConfig = None)
 }
 
-case class Config(argDefFilename: Option[String],
-                  createIndices: Boolean,
-                  onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {}
+case class CpgLoaderConfig(argDefFilename: Option[String],
+                           createIndices: Boolean,
+                           onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {}
 
 object CpgLoader {
+
+  /**
+    * Load a Code Property Graph
+    *
+    * @param filename name of file that stores the code property graph
+    * @param config loader configuration
+    * */
+  def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.default): Cpg = {
+    new CpgLoader().load(filename, config)
+  }
 
   /**
     * Load a Code Property Graph
@@ -32,7 +43,7 @@ object CpgLoader {
     * @param createIndices whether or not to create indices
     * @param onDiskOverflowConfig for the on-disk-overflow feature
     */
-  @deprecated
+  @deprecated("this method will be removed", "codepropertygraph")
   def loadCodePropertyGraph(filename: String,
                             argDefFilename: Option[String] = None,
                             createIndices: Boolean = true,
@@ -42,7 +53,7 @@ object CpgLoader {
 
 }
 
-class CpgLoader {
+private class CpgLoader {
 
   private val logger = LogManager.getLogger(getClass)
 
@@ -60,7 +71,7 @@ class CpgLoader {
     * @param filename name of file that stores the code property graph
     * @param config loader configuration
     * */
-  def loadCodePropertyGraph(filename: String, config: Config = Config.default): Cpg = {
+  def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.default): Cpg = {
     logger.debug("Loading " + filename)
     val argumentDefs =
       if (config.argDefFilename.isDefined) {
@@ -84,14 +95,14 @@ class CpgLoader {
     * @param createIndices whether or not to create indices
     * @param onDiskOverflowConfig for the on-disk-overflow feature
     */
-  @deprecated
+  @deprecated("this method will be removed", "codepropertygraph")
   def loadCodePropertyGraph(filename: String,
                             argDefFilename: Option[String],
                             createIndices: Boolean,
                             onDiskOverflowConfig: Option[OnDiskOverflowConfig]): Cpg = {
 
-    val config = new Config(argDefFilename, createIndices, onDiskOverflowConfig)
-    loadCodePropertyGraph(filename, config)
+    val config = new CpgLoaderConfig(argDefFilename, createIndices, onDiskOverflowConfig)
+    load(filename, config)
   }
 
   protected def runEnhancements(graph: Graph, argumentDefs: ArgumentDefs): Unit = {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
@@ -1,15 +1,12 @@
 package io.shiftleft.semanticcpg
 
-import java.nio.file.Files
-
 import gremlin.scala._
 import io.shiftleft.passes.methoddecorations.MethodDecoratorPass
 import io.shiftleft.cpgloading.CpgLoader
-import io.shiftleft.queryprimitives.steps.starters.Cpg
 import org.apache.tinkerpop.gremlin.structure.Graph
 
 class Fixture(projectName: String) {
-  val cpg = CpgLoader.loadCodePropertyGraph(s"resources/cpgs/$projectName/cpg.bin.zip", argDefFilename = None)
+  val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip")
   val scalaGraph: ScalaGraph = cpg.graph
 
   protected def applyMethodDecorator(graph: Graph): Unit = {


### PR DESCRIPTION
I noticed that our CpgLoader now receives 4 parameters for loading of CPGs, and that to specify them correctly, one needs to know quite a bit about internals. To allow more options to be specified in the future but also keep things simple for the end-user, I've moved configuration into a configuration object, which is set to a default object when not specified.

I marked the old loading methods as deprecated. I have also taken this as an opportunity to allow multiple loaders to be created at once.