### PR TITLE
Publish cpgqueryingtests

### DIFF
--- a/cpgqueryingtests/build.sbt
+++ b/cpgqueryingtests/build.sbt
@@ -1,5 +1,4 @@
 name := "cpgqueryingtests"
-publish / skip := true
 
 dependsOn(
   Projects.semanticcpg % Test,


### PR DESCRIPTION
The project `cpgqueryingtests` contains tests, but also test fixtures, which I would like to use in `joern`. For now, we skipped publishing of this artifact. This PR ensures that `cpgqueryingtests` is published.