### PR TITLE
Allow semantics filename to be passed in from outside

### DIFF
--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -6,10 +6,14 @@ import java.nio.file.Files
 import io.shiftleft.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.queryprimitives.steps.starters.Cpg
 
-class CpgFactory(frontend: LanguageFrontend) {
+class CpgFactory(frontend: LanguageFrontend,
+                 semanticsFilename : String = "cpgqueryingtests/src/test/resources/default.semantics") {
+
+  /**
+    * Build a CPG for the provided C/C++ code snippet.
+    * */
 
   def buildCpg(sourceCode: String): Cpg = {
-
     val tmpDir = Files.createTempDirectory("dflowtest").toFile
     tmpDir.deleteOnExit()
 
@@ -21,7 +25,7 @@ class CpgFactory(frontend: LanguageFrontend) {
     val cpgFile = frontend.execute(tmpDir)
 
     val config = CpgLoaderConfig.default
-    config.semanticsFilename = Some("cpgqueryingtests/src/test/resources/default.semantics")
+    config.semanticsFilename = Some(semanticsFilename)
     val graph = CpgLoader.load(cpgFile.getAbsolutePath, config)
 
     graph

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -7,7 +7,7 @@ import io.shiftleft.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.queryprimitives.steps.starters.Cpg
 
 class CpgFactory(frontend: LanguageFrontend,
-                 semanticsFilename : String = "cpgqueryingtests/src/test/resources/default.semantics") {
+                 semanticsFilename : String) {
 
   /**
     * Build a CPG for the provided C/C++ code snippet.

--- a/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CDataFlowTests.scala
+++ b/cpgqueryingtests/src/test/scala/io/shiftleft/cpgqueryingtests/steps/CDataFlowTests.scala
@@ -4,7 +4,7 @@ import io.shiftleft.cpgqueryingtests.codepropertygraph.LanguageFrontend
 import io.shiftleft.cpgqueryingtests.codepropertygraph.CpgFactory
 
 class CDataFlowTests extends CpgDataFlowTests {
-  val cpgFactory = new CpgFactory(LanguageFrontend.Fuzzyc)
+  val cpgFactory = new CpgFactory(LanguageFrontend.Fuzzyc, "cpgqueryingtests/src/test/resources/default.semantics")
 
   "Test 1: flow from function call read to multiple versions of the same variable" in {
     val cpg = cpgFactory.buildCpg(


### PR DESCRIPTION
Outside of `cpgqueryingtests`, semantics may be located in a different place, so, with this PR, we can specify its location from the outside.