### PR TITLE
use latest (more resilient) release plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
   - stage: test
     script: sbt +test
   - stage: release
-    script: travis_wait 30 sbt ci-release-sonatype
+    script: travis_wait 60 sbt ci-release-sonatype
 
 before_cache:
 - du -h -d 1 $HOME/.ivy2/cache

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.4")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.17")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.18")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.4")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.15")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.17")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")


### PR DESCRIPTION
* it shouldn't fail any more if old (possibly inconsistend) staging repositories are hanging around
* longer timeout on publish