### PR TITLE
Refactor and move CpgLoader class to enable reuse in CS repo.

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -8,6 +8,7 @@ libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",
   "commons-io" % "commons-io" % "2.5",
+  "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0",
   "org.apache.logging.log4j" % "log4j-api" % "2.11.0",
   "org.apache.logging.log4j" % "log4j-core" % "2.11.0",
   "org.scalatest" %% "scalatest" % "3.0.3" % Test

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -1,9 +1,7 @@
-package io.shiftleft.cpgloading
+package io.shiftleft.codepropertygraph.cpgloading
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.cpgloading.{IgnoredProtoEntries, OnDiskOverflowConfig, ProtoCpgLoader}
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.queryprimitives.CpgOverlayLoader
 import org.apache.logging.log4j.LogManager
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -37,6 +37,20 @@ object CpgLoader {
   def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.default): Cpg = {
     new CpgLoader().load(filename, config)
   }
+
+
+  /**
+    * Create any indexes necessary for quick access.
+    *
+    * @param cpg the CPG to create indexes in
+    */
+  def createIndexes(cpg: Cpg): Unit = {
+    new CpgLoader().createIndexes(cpg)
+  }
+
+  def addOverlays(overlayFilenames: Seq[String], cpg: Cpg): Unit = {
+    new CpgLoader().createIndexes(cpg)
+  }
 }
 
 private class CpgLoader {
@@ -65,9 +79,10 @@ private class CpgLoader {
   def createIndexes(cpg: Cpg): Unit =
     cpg.graph.asInstanceOf[TinkerGraph].createIndex(NodeKeys.FULL_NAME.name, classOf[Vertex])
 
-  def addOverlays(overlayFilenames: Seq[String], cpg: Cpg) =
+  def addOverlays(overlayFilenames: Seq[String], cpg: Cpg): Unit = {
     overlayFilenames.foreach { overlayFilename =>
       CpgOverlayLoader.load(overlayFilename, cpg)
     }
+  }
 
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -38,7 +38,6 @@ object CpgLoader {
     new CpgLoader().load(filename, config)
   }
 
-
   /**
     * Create any indexes necessary for quick access.
     *

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgOverlayApplier.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgOverlayApplier.scala
@@ -1,16 +1,14 @@
-package io.shiftleft.queryprimitives
+package io.shiftleft.codepropertygraph.cpgloading
 
-import gremlin.scala._
-import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
-import io.shiftleft.proto.cpg.Cpg.{CpgOverlay, PropertyValue}
 import java.lang.{Long => JLong}
 import java.util.{ArrayList => JArrayList}
 
-import io.shiftleft.codepropertygraph.cpgloading.ProtoToCpg
+import gremlin.scala._
+import io.shiftleft.proto.cpg.Cpg.{CpgOverlay, PropertyValue}
 import org.apache.tinkerpop.gremlin.structure.{T, Vertex, VertexProperty}
 
-import scala.collection.mutable
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /**
   * Component to merge CPG overlay into existing graph
@@ -90,7 +88,7 @@ class CpgOverlayApplier {
     } else {
       val iter = graph.graph.vertices(id.asInstanceOf[Object])
       assert(iter.hasNext, s"node with id=$id neither found in overlay nodes, nor in existing graph")
-      iter.nextChecked
+      nextChecked(iter)
     }
   }
 
@@ -100,7 +98,7 @@ class CpgOverlayApplier {
     } else {
       val iter = graph.graph.edges(id.asInstanceOf[Object])
       assert(iter.hasNext, s"edge with id=$id neither found in overlay edges, nor in existing graph")
-      iter.nextChecked
+      nextChecked(iter)
     }
   }
 
@@ -126,6 +124,15 @@ class CpgOverlayApplier {
       case VALUE_NOT_SET =>
       case valueCase =>
         throw new RuntimeException("Error: unsupported property case: " + valueCase)
+    }
+  }
+
+  private def nextChecked[T](iterator: java.util.Iterator[T]): T = {
+    try {
+      iterator.next
+    } catch {
+      case _: NoSuchElementException =>
+        throw new NoSuchElementException()
     }
   }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgOverlayLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgOverlayLoader.scala
@@ -1,7 +1,6 @@
-package io.shiftleft.queryprimitives
+package io.shiftleft.codepropertygraph.cpgloading
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.cpgloading.ProtoCpgLoader
 
 import scala.collection.JavaConverters._
 

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -5,7 +5,7 @@ import java.nio.file.Files
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.cpgloading.{CpgLoader, CpgLoaderConfig}
+import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.layers.ScpgLayers
 import io.shiftleft.semanticsloader.SemanticsLoader
 

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -3,8 +3,11 @@ package io.shiftleft.cpgqueryingtests.codepropertygraph
 import java.io.{File, PrintWriter}
 import java.nio.file.Files
 
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.cpgloading.{CpgLoader, CpgLoaderConfig}
+import io.shiftleft.layers.ScpgLayers
+import io.shiftleft.semanticsloader.SemanticsLoader
 
 class CpgFactory(frontend: LanguageFrontend, semanticsFilename: String) {
 
@@ -23,10 +26,12 @@ class CpgFactory(frontend: LanguageFrontend, semanticsFilename: String) {
     val cpgFile = frontend.execute(tmpDir)
 
     val config = CpgLoaderConfig.default
-    config.semanticsFilename = Some(semanticsFilename)
-    val graph = CpgLoader.load(cpgFile.getAbsolutePath, config)
+    val cpg = CpgLoader.load(cpgFile.getAbsolutePath, config)
 
-    graph
+    val semantics = new SemanticsLoader(semanticsFilename).load
+    new ScpgLayers(semantics).run(cpg, new SerializedCpg())
+
+    cpg
   }
 
 }

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
@@ -1,10 +1,14 @@
 package io.shiftleft.cpgqueryingtests.codepropertygraph
 
 import gremlin.scala.{Graph, ScalaGraph}
+import io.shiftleft.SerializedCpg
 import io.shiftleft.cpgloading.CpgLoader
+import io.shiftleft.layers.ScpgLayers
+import io.shiftleft.semanticsloader.SemanticsLoader
 
 case class CpgTestFixture(projectName: String) {
   lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip")
+  new ScpgLayers(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg())
   implicit val graph: Graph = cpg.graph
   lazy val scalaGraph: ScalaGraph = graph
 }

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
@@ -2,7 +2,7 @@ package io.shiftleft.cpgqueryingtests.codepropertygraph
 
 import gremlin.scala.{Graph, ScalaGraph}
 import io.shiftleft.SerializedCpg
-import io.shiftleft.cpgloading.{CpgLoader, CpgLoaderConfig}
+import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.layers.ScpgLayers
 import io.shiftleft.semanticsloader.SemanticsLoader
 

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
@@ -2,12 +2,13 @@ package io.shiftleft.cpgqueryingtests.codepropertygraph
 
 import gremlin.scala.{Graph, ScalaGraph}
 import io.shiftleft.SerializedCpg
-import io.shiftleft.cpgloading.CpgLoader
+import io.shiftleft.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.layers.ScpgLayers
 import io.shiftleft.semanticsloader.SemanticsLoader
 
 case class CpgTestFixture(projectName: String) {
-  lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip")
+  val loadConfig = CpgLoaderConfig.default.copy(ignoredProtoEntries = IgnoredCpgEntities.forJava2Cpg)
+  lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", loadConfig)
   new ScpgLayers(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg())
   implicit val graph: Graph = cpg.graph
   lazy val scalaGraph: ScalaGraph = graph

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/IgnoredProtoEntries.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/IgnoredProtoEntries.scala
@@ -1,0 +1,13 @@
+package io.shiftleft.cpgqueryingtests.codepropertygraph
+
+import io.shiftleft.codepropertygraph.cpgloading.IgnoredProtoEntries
+
+object IgnoredCpgEntities {
+  /* some non-public frontends (e.g. java2cpg) use cpg proto entries that are `UNRECOGNIZED` by cpg-public.
+   * we'll ignore those during the import */
+  val forJava2Cpg =
+    Some(IgnoredProtoEntries(
+      nodeTypes = Set(5, 6, 7, 49),
+      nodeKeys = Set(14, 16)
+    ))
+}

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/IgnoredProtoEntries.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/IgnoredProtoEntries.scala
@@ -6,8 +6,9 @@ object IgnoredCpgEntities {
   /* some non-public frontends (e.g. java2cpg) use cpg proto entries that are `UNRECOGNIZED` by cpg-public.
    * we'll ignore those during the import */
   val forJava2Cpg =
-    Some(IgnoredProtoEntries(
-      nodeTypes = Set(5, 6, 7, 49),
-      nodeKeys = Set(14, 16)
-    ))
+    Some(
+      IgnoredProtoEntries(
+        nodeTypes = Set(5, 6, 7, 49),
+        nodeKeys = Set(14, 16)
+      ))
 }

--- a/query-primitives/build.sbt
+++ b/query-primitives/build.sbt
@@ -4,7 +4,6 @@ dependsOn(Projects.codepropertygraph)
 
 libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-native" % "3.5.2",
-  "org.scala-lang.modules" %% "scala-java8-compat" % "0.8.0",
   "com.massisframework" % "j-text-utils" % "0.3.4",
   "org.scalatest" %% "scalatest" % "3.0.3" % Test
 )

--- a/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/cpgloading/CpgLoader.scala
@@ -4,7 +4,7 @@ import gremlin.scala.{Graph, ScalaGraph}
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.{IgnoredProtoEntries, OnDiskOverflowConfig, ProtoCpgLoader}
-import io.shiftleft.semanticsloader.{ArgumentDefs, SemanticsLoader}
+import io.shiftleft.semanticsloader.{Semantics, SemanticsLoader}
 import io.shiftleft.codepropertygraph.generated.{NodeKeys, NodeTypes, nodes}
 import io.shiftleft.layers.enhancedbase.EnhancedBaseCreator
 import io.shiftleft.queryprimitives.CpgOverlayLoader
@@ -17,17 +17,15 @@ import scala.compat.java8.OptionConverters._
 object CpgLoaderConfig {
 
   def default: CpgLoaderConfig =
-    CpgLoaderConfig(semanticsFilename = None, createIndices = true, onDiskOverflowConfig = None)
+    CpgLoaderConfig(createIndices = true, onDiskOverflowConfig = None)
 }
 
 /**
   * Configuration for the CPG loader
-  * @param semanticsFilename filename of the file containing taint semantics
   * @param createIndices indicate whether to create indices or not
   * @param onDiskOverflowConfig configuration for the on-disk-overflow feature
   *  */
-case class CpgLoaderConfig(var semanticsFilename: Option[String],
-                           var createIndices: Boolean,
+case class CpgLoaderConfig(var createIndices: Boolean,
                            var onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {}
 
 object CpgLoader {
@@ -41,23 +39,6 @@ object CpgLoader {
   def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.default): Cpg = {
     new CpgLoader().load(filename, config)
   }
-
-  /**
-    * Load a Code Property Graph
-    *
-    * @param filename      name of file that stores the code property graph
-    * @param semanticsFilename file containing argument definition entries
-    * @param createIndices whether or not to create indices
-    * @param onDiskOverflowConfig for the on-disk-overflow feature
-    */
-  @deprecated("this method will be removed", "codepropertygraph")
-  def loadCodePropertyGraph(filename: String,
-                            semanticsFilename: Option[String] = None,
-                            createIndices: Boolean = true,
-                            onDiskOverflowConfig: Option[OnDiskOverflowConfig] = None): Cpg = {
-    new CpgLoader().loadCodePropertyGraph(filename, semanticsFilename, createIndices, onDiskOverflowConfig)
-  }
-
 }
 
 private class CpgLoader {
@@ -80,50 +61,10 @@ private class CpgLoader {
     * */
   def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.default): Cpg = {
     logger.debug("Loading " + filename)
-    val argumentDefs =
-      if (config.semanticsFilename.isDefined) {
-        val argumentDefLoader = new SemanticsLoader(config.semanticsFilename.get)
-        argumentDefLoader.load()
-      } else {
-        ArgumentDefs(Nil)
-      }
     val cpg =
       ProtoCpgLoader.loadFromProtoZip(filename, config.onDiskOverflowConfig.asJava, Some(ignoredProtoEntries).asJava)
-    runEnhancements(cpg.graph, argumentDefs)
     if (config.createIndices) { createIndexes(cpg) }
     cpg
-  }
-
-  /**
-    * Load a Code Property Graph
-    *
-    * @param filename      name of file that stores the code property graph
-    * @param semanticsFilename file containing argument definition entries
-    * @param createIndices whether or not to create indices
-    * @param onDiskOverflowConfig for the on-disk-overflow feature
-    */
-  @deprecated("this method will be removed", "codepropertygraph")
-  def loadCodePropertyGraph(filename: String,
-                            semanticsFilename: Option[String],
-                            createIndices: Boolean,
-                            onDiskOverflowConfig: Option[OnDiskOverflowConfig]): Cpg = {
-
-    val config = new CpgLoaderConfig(semanticsFilename, createIndices, onDiskOverflowConfig)
-    load(filename, config)
-  }
-
-  protected def runEnhancements(graph: Graph, argumentDefs: ArgumentDefs): Unit = {
-    val language = metaNode(graph).language
-    val serializedCpg = new SerializedCpg
-    new EnhancedBaseCreator(graph, language, serializedCpg, argumentDefs).create
-  }
-
-  private def metaNode(graph: ScalaGraph): nodes.MetaData = {
-    graph.V
-      .hasLabel(NodeTypes.META_DATA)
-      .headOption()
-      .getOrElse(throw new Exception("Meta node missing."))
-      .asInstanceOf[nodes.MetaData]
   }
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/layers/ScpgLayers.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/layers/ScpgLayers.scala
@@ -1,0 +1,15 @@
+package io.shiftleft.layers
+
+import io.shiftleft.SerializedCpg
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.layers.enhancedbase.EnhancedBaseCreator
+import io.shiftleft.semanticsloader.Semantics
+
+
+class ScpgLayers(semantics: Semantics) {
+  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
+
+    val language = cpg.metaData.language.head
+    new EnhancedBaseCreator(cpg.graph, language, serializedCpg, semantics).create
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/layers/ScpgLayers.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/layers/ScpgLayers.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.layers.enhancedbase.EnhancedBaseCreator
 import io.shiftleft.semanticsloader.Semantics
 
-
 class ScpgLayers(semantics: Semantics) {
   def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/layers/enhancedbase/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/layers/enhancedbase/EnhancedBaseCreator.scala
@@ -16,10 +16,7 @@ import io.shiftleft.passes.propagateedges.PropagateEdgePass
 import io.shiftleft.passes.reachingdef.ReachingDefPass
 import io.shiftleft.passes.receiveredges.ReceiverEdgePass
 
-class EnhancedBaseCreator(graph: ScalaGraph,
-                          language: String,
-                          serializedCpg: SerializedCpg,
-                          semantics: Semantics) {
+class EnhancedBaseCreator(graph: ScalaGraph, language: String, serializedCpg: SerializedCpg, semantics: Semantics) {
 
   private val runner = new CpgPassRunner(serializedCpg)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/layers/enhancedbase/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/layers/enhancedbase/EnhancedBaseCreator.scala
@@ -7,7 +7,7 @@ import io.shiftleft.passes.linking.linker.Linker
 import io.shiftleft.passes.linking.memberaccesslinker.MemberAccessLinker
 import io.shiftleft.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.SerializedCpg
-import io.shiftleft.semanticsloader.ArgumentDefs
+import io.shiftleft.semanticsloader.Semantics
 import io.shiftleft.passes.containsedges.ContainsEdgePass
 import io.shiftleft.passes.languagespecific.fuzzyc.{MethodStubCreator, TypeDeclStubCreator}
 import io.shiftleft.passes.linking.capturinglinker.CapturingLinker
@@ -19,7 +19,7 @@ import io.shiftleft.passes.receiveredges.ReceiverEdgePass
 class EnhancedBaseCreator(graph: ScalaGraph,
                           language: String,
                           serializedCpg: SerializedCpg,
-                          argumentDefs: ArgumentDefs) {
+                          semantics: Semantics) {
 
   private val runner = new CpgPassRunner(serializedCpg)
 
@@ -31,7 +31,7 @@ class EnhancedBaseCreator(graph: ScalaGraph,
         List(
           new ReceiverEdgePass(graph),
           new MethodDecoratorPass(graph),
-          new PropagateEdgePass(graph, argumentDefs),
+          new PropagateEdgePass(graph, semantics),
           new CapturingLinker(graph),
           new Linker(graph),
           new MemberAccessLinker(graph),
@@ -45,7 +45,7 @@ class EnhancedBaseCreator(graph: ScalaGraph,
           new MethodStubCreator(graph),
           new ReceiverEdgePass(graph),
           new MethodDecoratorPass(graph),
-          new PropagateEdgePass(graph, argumentDefs),
+          new PropagateEdgePass(graph, semantics),
           new CapturingLinker(graph),
           new Linker(graph),
           new MemberAccessLinker(graph),
@@ -57,7 +57,7 @@ class EnhancedBaseCreator(graph: ScalaGraph,
         List(
           new ReceiverEdgePass(graph),
           new MethodDecoratorPass(graph),
-          new PropagateEdgePass(graph, argumentDefs),
+          new PropagateEdgePass(graph, semantics),
           new CapturingLinker(graph),
           new Linker(graph),
           new MemberAccessLinker(graph),

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/propagateedges/PropagateEdgePass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/propagateedges/PropagateEdgePass.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.passes.propagateedges
 
 import gremlin.scala._
-import io.shiftleft.semanticsloader.ArgumentDefs
+import io.shiftleft.semanticsloader.Semantics
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
@@ -12,19 +12,19 @@ import scala.collection.JavaConverters._
 /**
   * Create PROPAGATE edges which mark parameters defined by a method.
   */
-class PropagateEdgePass(graph: ScalaGraph, argumentDefs: ArgumentDefs) extends CpgPass(graph) {
+class PropagateEdgePass(graph: ScalaGraph, semantics: Semantics) extends CpgPass(graph) {
   var dstGraph: DiffGraph = _
 
   override def run(): Stream[DiffGraph] = {
     dstGraph = new DiffGraph()
 
-    argumentDefs.elements.foreach { argDef =>
+    semantics.elements.foreach { semantic =>
       val methodOption =
-        graph.V().hasLabel(NodeTypes.METHOD).has(NodeKeys.FULL_NAME -> argDef.methodFullName).headOption()
+        graph.V().hasLabel(NodeTypes.METHOD).has(NodeKeys.FULL_NAME -> semantic.methodFullName).headOption()
 
       methodOption match {
         case Some(method) =>
-          addSelfDefSemantic(method, argDef.parameterIndex)
+          addSelfDefSemantic(method, semantic.parameterIndex)
         case None =>
       }
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticsloader/SemanticsLoader.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticsloader/SemanticsLoader.scala
@@ -4,18 +4,24 @@ import org.apache.logging.log4j.LogManager
 
 import scala.io.Source
 
-case class ArgumentDef(methodFullName: String, parameterIndex: Int)
-case class ArgumentDefs(elements: List[ArgumentDef])
+case class Semantic(methodFullName: String, parameterIndex: Int)
+case class Semantics(elements: List[Semantic])
+
+object SemanticsLoader {
+  def emptySemantics: Semantics = {
+    Semantics(Nil)
+  }
+}
 
 class SemanticsLoader(filename: String) {
   private val logger = LogManager.getLogger(getClass)
 
-  def load(): ArgumentDefs = {
+  def load(): Semantics = {
     val bufferedReader = Source.fromFile(filename)
     var lineNumber = 0
 
     try {
-      val argumentDefElements =
+      val semanticElements =
         bufferedReader
           .getLines()
           .flatMap { line =>
@@ -26,7 +32,7 @@ class SemanticsLoader(filename: String) {
                 val methodFullName = parts(0).trim
                 val parameterIndex = parts(1).trim.toInt
                 lineNumber += 1
-                Some(ArgumentDef(methodFullName, parameterIndex))
+                Some(Semantic(methodFullName, parameterIndex))
               } catch {
                 case _: NumberFormatException =>
                   logFormatError("Argument index is not convertable to Int.", lineNumber)
@@ -41,7 +47,7 @@ class SemanticsLoader(filename: String) {
           }
           .toList
 
-      ArgumentDefs(argumentDefElements)
+      Semantics(semanticElements)
     } finally {
       bufferedReader.close()
     }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
@@ -3,13 +3,14 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.SerializedCpg
 import io.shiftleft.passes.methoddecorations.MethodDecoratorPass
-import io.shiftleft.cpgloading.CpgLoader
+import io.shiftleft.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.layers.ScpgLayers
 import io.shiftleft.semanticsloader.SemanticsLoader
 import org.apache.tinkerpop.gremlin.structure.Graph
 
 class Fixture(projectName: String) {
-  val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip")
+  val loadConfig = CpgLoaderConfig.default.copy(ignoredProtoEntries = IgnoredCpgEntities.forJava2Cpg)
+  val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", loadConfig)
   new ScpgLayers(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg())
   val scalaGraph: ScalaGraph = cpg.graph
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
@@ -2,8 +2,8 @@ package io.shiftleft.semanticcpg
 
 import gremlin.scala._
 import io.shiftleft.SerializedCpg
+import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.passes.methoddecorations.MethodDecoratorPass
-import io.shiftleft.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.layers.ScpgLayers
 import io.shiftleft.semanticsloader.SemanticsLoader
 import org.apache.tinkerpop.gremlin.structure.Graph

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
@@ -1,12 +1,16 @@
 package io.shiftleft.semanticcpg
 
 import gremlin.scala._
+import io.shiftleft.SerializedCpg
 import io.shiftleft.passes.methoddecorations.MethodDecoratorPass
 import io.shiftleft.cpgloading.CpgLoader
+import io.shiftleft.layers.ScpgLayers
+import io.shiftleft.semanticsloader.SemanticsLoader
 import org.apache.tinkerpop.gremlin.structure.Graph
 
 class Fixture(projectName: String) {
   val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip")
+  new ScpgLayers(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg())
   val scalaGraph: ScalaGraph = cpg.graph
 
   protected def applyMethodDecorator(graph: Graph): Unit = {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/IgnoredProtoEntries.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/IgnoredProtoEntries.scala
@@ -1,0 +1,13 @@
+package io.shiftleft.semanticcpg
+
+import io.shiftleft.codepropertygraph.cpgloading.IgnoredProtoEntries
+
+object IgnoredCpgEntities {
+  /* some non-public frontends (e.g. java2cpg) use cpg proto entries that are `UNRECOGNIZED` by cpg-public.
+   * we'll ignore those during the import */
+  val forJava2Cpg =
+    Some(IgnoredProtoEntries(
+      nodeTypes = Set(5, 6, 7, 49),
+      nodeKeys = Set(14, 16)
+    ))
+}


### PR DESCRIPTION
Refactoring consists of taking out enhancement run which now
needs to be done separatley.
The CpgLoader class has been moved to codepropertygraph.