### PR TITLE
Fix namespace.method

### DIFF
--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Namespace.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Namespace.scala
@@ -30,7 +30,12 @@ class Namespace[Labels <: HList](raw: GremlinScala.Aux[nodes.Namespace, Labels])
     * Methods defined in this namespace
     * */
   def method: Method[Labels] =
-    typeDecl.method
+    new Method[Labels](
+      raw
+        .in(EdgeTypes.REF)
+        .out(EdgeTypes.AST)
+        .hasLabel(NodeTypes.METHOD)
+        .cast[nodes.Method])
 
   /**
     * External namespaces - any namespaces


### PR DESCRIPTION
`namespace.method` used to be defined as `namespace.typeDecl.method`, which works fine in languages where all methods are defined inside types, e.g., Java, however, it is not correct for C. This fixes this. Note, however, that for
```
namespace foo{
   class Bar {
     int method() {}
  };
}
```
we now require `namespace.typeDecl.method` to reach the method `method`.