### PR TITLE
Separate data flow layer from enhancement layer

### DIFF
--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -6,7 +6,7 @@ import java.nio.file.Files
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
-import io.shiftleft.layers.EnhancementRunner
+import io.shiftleft.layers.{DataFlowRunner, EnhancementRunner}
 import io.shiftleft.semanticsloader.SemanticsLoader
 
 class CpgFactory(frontend: LanguageFrontend, semanticsFilename: String) {
@@ -29,7 +29,8 @@ class CpgFactory(frontend: LanguageFrontend, semanticsFilename: String) {
     val cpg = CpgLoader.load(cpgFile.getAbsolutePath, config)
 
     val semantics = new SemanticsLoader(semanticsFilename).load
-    new EnhancementRunner(semantics).run(cpg, new SerializedCpg())
+    new EnhancementRunner().run(cpg, new SerializedCpg())
+    new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
 
     cpg
   }

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
@@ -3,13 +3,14 @@ package io.shiftleft.cpgqueryingtests.codepropertygraph
 import gremlin.scala.{Graph, ScalaGraph}
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
-import io.shiftleft.layers.EnhancementRunner
+import io.shiftleft.layers.{DataFlowRunner, EnhancementRunner}
 import io.shiftleft.semanticsloader.SemanticsLoader
 
 case class CpgTestFixture(projectName: String) {
   val loadConfig = CpgLoaderConfig.default.copy(ignoredProtoEntries = IgnoredCpgEntities.forJava2Cpg)
   lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", loadConfig)
-  new EnhancementRunner(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg())
+  new EnhancementRunner().run(cpg, new SerializedCpg())
+  new DataFlowRunner(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg());
   implicit val graph: Graph = cpg.graph
   lazy val scalaGraph: ScalaGraph = graph
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/layers/DataFlowRunner.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/layers/DataFlowRunner.scala
@@ -1,0 +1,20 @@
+package io.shiftleft.layers
+
+import io.shiftleft.SerializedCpg
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.passes.CpgPassRunner
+import io.shiftleft.passes.propagateedges.PropagateEdgePass
+import io.shiftleft.passes.reachingdef.ReachingDefPass
+import io.shiftleft.semanticsloader.Semantics
+
+class DataFlowRunner(semantics: Semantics) {
+
+  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
+    val graph = cpg.graph
+    val runner = new CpgPassRunner(serializedCpg)
+    val enhancementExecList = List(new PropagateEdgePass(graph, semantics), new ReachingDefPass(graph))
+
+    enhancementExecList.foreach(runner.createStoreAndApplyOverlay(_))
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/layers/EnhancedBaseCreator.scala
@@ -1,25 +1,20 @@
-package io.shiftleft.layers.enhancedbase
+package io.shiftleft.layers
 
 import gremlin.scala.ScalaGraph
-import io.shiftleft.codepropertygraph.generated.Languages
-import io.shiftleft.passes.{CpgPass, CpgPassRunner}
-import io.shiftleft.passes.linking.linker.Linker
-import io.shiftleft.passes.linking.memberaccesslinker.MemberAccessLinker
-import io.shiftleft.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.SerializedCpg
-import io.shiftleft.semanticsloader.Semantics
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.containsedges.ContainsEdgePass
 import io.shiftleft.passes.languagespecific.fuzzyc.{MethodStubCreator, TypeDeclStubCreator}
 import io.shiftleft.passes.linking.capturinglinker.CapturingLinker
+import io.shiftleft.passes.linking.linker.Linker
+import io.shiftleft.passes.linking.memberaccesslinker.MemberAccessLinker
 import io.shiftleft.passes.methoddecorations.MethodDecoratorPass
-import io.shiftleft.passes.propagateedges.PropagateEdgePass
-import io.shiftleft.passes.reachingdef.ReachingDefPass
+import io.shiftleft.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.passes.receiveredges.ReceiverEdgePass
+import io.shiftleft.passes.{CpgPass, CpgPassRunner}
 
-class EnhancedBaseCreator(graph: ScalaGraph, language: String, serializedCpg: SerializedCpg, semantics: Semantics) {
-
+class EnhancedBaseCreator(graph: ScalaGraph, language: String, serializedCpg: SerializedCpg) {
   private val runner = new CpgPassRunner(serializedCpg)
-
   private val enhancementExecList = createEnhancementExecList(language)
 
   private def createEnhancementExecList(language: String): List[CpgPass] = {
@@ -28,13 +23,11 @@ class EnhancedBaseCreator(graph: ScalaGraph, language: String, serializedCpg: Se
         List(
           new ReceiverEdgePass(graph),
           new MethodDecoratorPass(graph),
-          new PropagateEdgePass(graph, semantics),
           new CapturingLinker(graph),
           new Linker(graph),
           new MemberAccessLinker(graph),
           new ContainsEdgePass(graph),
-          new NamespaceCreator(graph),
-          new ReachingDefPass(graph),
+          new NamespaceCreator(graph)
         )
       case Languages.C =>
         List(
@@ -42,25 +35,21 @@ class EnhancedBaseCreator(graph: ScalaGraph, language: String, serializedCpg: Se
           new MethodStubCreator(graph),
           new ReceiverEdgePass(graph),
           new MethodDecoratorPass(graph),
-          new PropagateEdgePass(graph, semantics),
           new CapturingLinker(graph),
           new Linker(graph),
           new MemberAccessLinker(graph),
           new ContainsEdgePass(graph),
-          new NamespaceCreator(graph),
-          new ReachingDefPass(graph),
+          new NamespaceCreator(graph)
         )
       case _ =>
         List(
           new ReceiverEdgePass(graph),
           new MethodDecoratorPass(graph),
-          new PropagateEdgePass(graph, semantics),
           new CapturingLinker(graph),
           new Linker(graph),
           new MemberAccessLinker(graph),
           new ContainsEdgePass(graph),
-          new NamespaceCreator(graph),
-          new ReachingDefPass(graph),
+          new NamespaceCreator(graph)
         )
     }
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/layers/EnhancementRunner.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/layers/EnhancementRunner.scala
@@ -2,13 +2,10 @@ package io.shiftleft.layers
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.layers.enhancedbase.EnhancedBaseCreator
-import io.shiftleft.semanticsloader.Semantics
 
-class EnhancementRunner(semantics: Semantics) {
+class EnhancementRunner {
   def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
-
     val language = cpg.metaData.language.head
-    new EnhancedBaseCreator(cpg.graph, language, serializedCpg, semantics).create
+    new EnhancedBaseCreator(cpg.graph, language, serializedCpg).create
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/propagateedges/PropagateEdgePass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/propagateedges/PropagateEdgePass.scala
@@ -11,6 +11,8 @@ import scala.collection.JavaConverters._
 
 /**
   * Create PROPAGATE edges which mark parameters defined by a method.
+  * PROPAGATE edges can be picked up by the reachingdef pass to calculate
+  * reaching definition edges.
   */
 class PropagateEdgePass(graph: ScalaGraph, semantics: Semantics) extends CpgPass(graph) {
   var dstGraph: DiffGraph = _

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
@@ -4,14 +4,15 @@ import gremlin.scala._
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.passes.methoddecorations.MethodDecoratorPass
-import io.shiftleft.layers.EnhancementRunner
+import io.shiftleft.layers.{DataFlowRunner, EnhancementRunner}
 import io.shiftleft.semanticsloader.SemanticsLoader
 import org.apache.tinkerpop.gremlin.structure.Graph
 
 class Fixture(projectName: String) {
   val loadConfig = CpgLoaderConfig.default.copy(ignoredProtoEntries = IgnoredCpgEntities.forJava2Cpg)
   val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", loadConfig)
-  new EnhancementRunner(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg())
+  new EnhancementRunner().run(cpg, new SerializedCpg())
+  new DataFlowRunner(SemanticsLoader.emptySemantics)
   val scalaGraph: ScalaGraph = cpg.graph
 
   protected def applyMethodDecorator(graph: Graph): Unit = {


### PR DESCRIPTION
Enhancement fall into two categories: enhancements that depend on semantics, and those which do not. A user may wish to change data flow semantics for a CPG, and therefore, it makes more sense to apply semantics and semantic-dependent enhancements when loading the graph. In contrast, enhancements that do not depend on semantics can be applied once on graph generation.
In this PR, we separate semantic-dependent from semantic-independent passes to make this possible.