### PR TITLE
Hot patch: allow reaching def edges starting at blocks

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -128,7 +128,8 @@
         {"name" : "BLOCK",
           "outEdges" : [
             {"edgeName": "CALL_ARG", "inNodes": ["METHOD_PARAMETER_IN"]},
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]},
+	    {"edgeName": "REACHING_DEF", "inNodes": ["CALL", "RETURN", "BLOCK"]}
           ]
         },
         {"name" : "UNKNOWN",


### PR DESCRIPTION
The ReachingDefPass is trying to create REACHING_DEF edges starting at blocks. I'm not sure if  that's correct, it makes little sense to me, however, since it crashes, it's better to at least allow it for now.

@b-64rry please create a branch where you revert this commit, and then use the code at https://github.com/ros/ros_comm to trigger the issue and investigate.