### PR TITLE
disable publishing of scaladoc jar to sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,3 +52,4 @@ lazy val cpgserver = Projects.cpgserver
 ThisBuild/publishTo := sonatypePublishTo.value
 ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 ThisBuild/compile/javacOptions ++= Seq("-g") //debug symbols
+ThisBuild/Compile/packageDoc/publishArtifact := false //don't publish javadoc/scaladoc


### PR DESCRIPTION
travis.ci build times are up to 15mins, sometimes timing out, due to
uploading of jars, and the biggest ones are the javadocs