### PR TITLE
Revert "disable publishing of scaladoc jar to sonatype"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,4 +52,3 @@ lazy val cpgserver = Projects.cpgserver
 ThisBuild/publishTo := sonatypePublishTo.value
 ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 ThisBuild/compile/javacOptions ++= Seq("-g") //debug symbols
-ThisBuild/Compile/packageDoc/publishArtifact := false //don't publish javadoc/scaladoc


### PR DESCRIPTION
Reverts ShiftLeftSecurity/codepropertygraph#172

sonatype didn't like this:
```
error]     Failed: javadoc-staging, failureMessage:Missing: no javadoc jar found in folder '/io/shiftleft/codepropertygraph/0.9.188'
[error] java.lang.Exception: Failed to close the repository
```
We should be able to just publish an empty javadoc, but I didn't quickly find a way to do that, so will add this to my list. 