### PR TITLE
Fix CPGServer

### DIFF
--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerController.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerController.scala
@@ -92,7 +92,7 @@ class CpgServerController(impl: ServerImpl, system: ActorSystem = ActorSystem())
   def runQuery(query: String): Unit = {
     Try {
       logger.info("Running query")
-      val e = new ScriptEngineManager(null).getEngineByName("scala")
+      val e = new ScriptEngineManager().getEngineByName("scala")
       if (e == null) {
         throw new RuntimeException("Error: cannot initialize script engine")
       }


### PR DESCRIPTION
While trying to get unit tests for CPGServer working, I accidentally broke it: the classloader was set to null, and therefore, the server did not find the scala interpreter at runtime. This PR fixes this. 