### PR TITLE
Add JettyServer

### DIFF
--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/JettyLauncher.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/JettyLauncher.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.cpgserver
+
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.servlet.DefaultServlet
+import org.eclipse.jetty.webapp.WebAppContext
+import org.scalatra.servlet.ScalatraListener
+import org.slf4j.LoggerFactory
+
+object JettyLauncher {
+
+  def startServer(port : Int) : Unit  = {
+    val logger = LoggerFactory.getLogger(getClass)
+    val server = new Server(port)
+    val context = new WebAppContext()
+    context setContextPath "/"
+    context.setResourceBase("src/main/webapp")
+    context.addEventListener(new ScalatraListener)
+    context.addServlet(classOf[DefaultServlet], "/")
+
+    server.setHandler(context)
+
+    try {
+      server.start
+    } catch {
+      case _: java.net.BindException => {
+        logger.warn(s"Not starting server - port $port is occupied")
+        System.exit(1)
+      }
+    }
+    server.join
+  }
+
+}


### PR DESCRIPTION
To address #182, I am moving the reusable parts of joern's jetty server into `codepropertygraph`. The null-server is then rather thin, as it should be.