### PR TITLE
Python testing

### DIFF
--- a/cpgclientlib/runtests.sh
+++ b/cpgclientlib/runtests.sh
@@ -1,0 +1,1 @@
+python3 -m unittest tests/test.py

--- a/cpgserver/build.sbt
+++ b/cpgserver/build.sbt
@@ -5,6 +5,7 @@ name := "CPG server"
 resolvers += Classpaths.typesafeReleases
 
 dependsOn(Projects.codepropertygraph)
+dependsOn(Projects.queryPrimitives)
 
 libraryDependencies ++= Seq(
   "org.scalatra" %% "scalatra" % ScalatraVersion,
@@ -22,5 +23,6 @@ libraryDependencies ++= Seq(
   "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
 )
 
+enablePlugins(JavaAppPackaging)
 enablePlugins(SbtTwirl)
 enablePlugins(ScalatraPlugin)

--- a/cpgserver/src/main/scala/ScalatraBootstrap.scala
+++ b/cpgserver/src/main/scala/ScalatraBootstrap.scala
@@ -1,0 +1,14 @@
+import io.shiftleft.cpgserver.{CpgServerController, CpgServerSwagger, TestServerImpl, ResourcesApp}
+import javax.servlet.ServletContext
+import org.scalatra._
+
+class ScalatraBootstrap extends LifeCycle {
+
+  implicit val swagger = new CpgServerSwagger
+
+  override def init(context: ServletContext) {
+    context.mount(new CpgServerController(new TestServerImpl), "/*")
+    context.mount(new ResourcesApp, "/api-docs")
+  }
+
+}

--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/TestServerImpl.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/TestServerImpl.scala
@@ -1,0 +1,20 @@
+package io.shiftleft.cpgserver
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.diffgraph.DiffGraph
+
+class TestServerImpl extends ServerImpl {
+
+  override def cpg: Option[Cpg] = _cpg
+  var _cpg : Option[Cpg] = None
+
+  override def createCpg(filenames: List[String]): Unit = {
+    _cpg = Some(new Cpg())
+
+    implicit val diffGraph = new DiffGraph
+    new nodes.NewMethod(name = "main").start.store
+    diffGraph.applyDiff(_cpg.get.scalaGraph)
+
+  }
+}

--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/TestServerMain.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/TestServerMain.scala
@@ -1,0 +1,6 @@
+package io.shiftleft.cpgserver
+
+object TestServerMain extends App {
+  val port = 8080
+  JettyLauncher.startServer(port)
+}

--- a/cpgserver/src/test/scala/io/shiftleft/cpgserver/CpgServerControllerTests.scala
+++ b/cpgserver/src/test/scala/io/shiftleft/cpgserver/CpgServerControllerTests.scala
@@ -10,7 +10,7 @@ class CpgServerControllerTests extends ScalatraFunSuite {
 
   implicit val swagger = new CpgServerSwagger
   val system = ActorSystem()
-  val impl = new NullServerImpl
+  val impl = new TestServerImpl
   val controller = new CpgServerController(impl)
   addServlet(controller, "/*")
 

--- a/cpgserver/src/test/scala/io/shiftleft/cpgserver/NullServerImpl.scala
+++ b/cpgserver/src/test/scala/io/shiftleft/cpgserver/NullServerImpl.scala
@@ -1,9 +1,0 @@
-package io.shiftleft.cpgserver
-
-import io.shiftleft.codepropertygraph.Cpg
-
-class NullServerImpl extends ServerImpl {
-  override def cpg: Option[Cpg] = None
-
-  override def createCpg(filenames: List[String]): Unit = {}
-}

--- a/testserver.sh
+++ b/testserver.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+SCRIPT_ABS_PATH=$(readlink -f "$0")
+SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
+
+$SCRIPT_ABS_DIR/cpgserver/target/universal/stage/bin/cpg-server $@
+


### PR DESCRIPTION
Make it possible to run python tests without starting a joern-server. Fixes #182 . With this in place, we can now set up travis to run both Scala and Python tests on merge to master.