### PR TITLE
Run python tests as part of `sbt test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,12 @@ env:
   - PATH="${PROTOC_TARGET}/bin:${PATH}"
 
 install:
+- pip install requests
 - rm -rf $HOME/protoc
 - wget $PROTOC_RELEASE
 - unzip $PROTOC_PKG -d $PROTOC_TARGET
 - protoc --version
+
 
 stages:
 - name: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ stages:
 jobs:
   include:
   - stage: test
-    script: sbt +test
+    script: sbt stage +test
   - stage: release
     script: travis_wait 60 sbt ci-release-sonatype
 

--- a/cpgclientlib/cpgclient/CpgClient.py
+++ b/cpgclientlib/cpgclient/CpgClient.py
@@ -1,6 +1,7 @@
 import requests
 import time
 import pprint
+import json
 
 DEFAULT_PORT = 8080
 
@@ -32,7 +33,8 @@ class CpgClient:
 
     def _request(self, operation, body, isGet = False):
         url = "{}/{}".format(self.handlerAndUrl, operation)
-        response = requests.post(url, json = body)
+        body = json.dumps(body)
+        response = requests.post(url, data = body)
         if not response.status_code in [200, 202]:
             raise Exception("Invalid request: " + response)
         return response

--- a/cpgclientlib/runtests.sh
+++ b/cpgclientlib/runtests.sh
@@ -1,1 +1,2 @@
-python3 -m unittest tests/test.py
+python tests/test.py
+

--- a/cpgclientlib/tests/test.py
+++ b/cpgclientlib/tests/test.py
@@ -32,6 +32,8 @@ def doStartServer():
 def testServerPath():
     scriptDir = os.path.dirname(os.path.realpath(__file__))
     relpath = os.path.join(scriptDir, "..", "..","testserver.sh")
+    if not os.path.isfile(relpath):
+        raise Exception("testserver not found")
     return os.path.abspath(relpath)
 
 class TestStringMethods(unittest.TestCase):

--- a/cpgclientlib/tests/test.py
+++ b/cpgclientlib/tests/test.py
@@ -1,7 +1,11 @@
-import unittest
+import sys
 import os.path
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(SCRIPT_DIR + "/../")
+
+import unittest
 from cpgclient import CpgClient
-import pprint
 import json
 import subprocess
 import time
@@ -12,13 +16,13 @@ import threading
 SERVER = "127.0.0.1"
 PORT = 8080
 
-SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-
 stopEvent = threading.Event()
 
 def doStartServer():
     cmd = str(testServerPath())
-    subprocess.Popen(cmd, stdout = subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    FNULL = open(os.devnull, 'w')
+    subprocess.Popen(cmd, stdout = FNULL, stderr=FNULL)
     while True:
         try:
             response = requests.get("http://{}:{}/".format(SERVER, PORT))
@@ -77,3 +81,4 @@ class TestStringMethods(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    

--- a/cpgserver/src/test/scala/io/shiftleft/cpgserver/ClientTests.scala
+++ b/cpgserver/src/test/scala/io/shiftleft/cpgserver/ClientTests.scala
@@ -1,0 +1,13 @@
+package io.shiftleft.cpgserver
+
+import org.scalatest.{Matchers, WordSpec}
+
+class ClientTests extends WordSpec with Matchers {
+
+  "should execute cpgclientlibtests successfully" in {
+    import scala.sys.process._
+    println(new java.io.File(".").getCanonicalPath())
+    sys.process.Process(Seq("/home/tmp/shiftleft/codepropertygraph/cpgclientlib/runtests.sh"), new java.io.File("/home/tmp/shiftleft/codepropertygraph/cpgclientlib/")).!!
+  }
+
+}

--- a/cpgserver/src/test/scala/io/shiftleft/cpgserver/ClientTests.scala
+++ b/cpgserver/src/test/scala/io/shiftleft/cpgserver/ClientTests.scala
@@ -1,13 +1,17 @@
 package io.shiftleft.cpgserver
 
+import java.nio.file.Paths
+
 import org.scalatest.{Matchers, WordSpec}
 
 class ClientTests extends WordSpec with Matchers {
 
   "should execute cpgclientlibtests successfully" in {
     import scala.sys.process._
-    println(new java.io.File(".").getCanonicalPath())
-    sys.process.Process(Seq("/home/tmp/shiftleft/codepropertygraph/cpgclientlib/runtests.sh"), new java.io.File("/home/tmp/shiftleft/codepropertygraph/cpgclientlib/")).!!
+    val currentWorkingDirectory = new java.io.File(".").getAbsolutePath
+    val testDir = Paths.get(currentWorkingDirectory, "cpgclientlib").toAbsolutePath.toString
+    val testScript = Paths.get(testDir.toString, "runtests.sh").toAbsolutePath.toString
+    sys.process.Process(Seq(testScript), new java.io.File(testDir)).!!
   }
 
 }


### PR DESCRIPTION
We are now just running the python tests as a shell script as part of `sbt test`. Since this requires the server to be available, we need to run `sbt stage` first.