### PR TITLE
Add NoResolve as implicit for call lookups in CPG server

### DIFF
--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerController.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerController.scala
@@ -99,6 +99,8 @@ class CpgServerController(impl: ServerImpl, system: ActorSystem = ActorSystem())
       e.put("aCpg", cpg.get)
       e.eval(s"""
                 import io.shiftleft.codepropertygraph.Cpg
+                | import io.shiftleft.queryprimitives.steps.NoResolve
+                | implicit val resolver = NoResolve
                 | val cpg = aCpg.asInstanceOf[io.shiftleft.codepropertygraph.Cpg]
                 | $query
             """.stripMargin).toString


### PR DESCRIPTION
Since in `Joern`, we only have one resolver for calls at the moment (none), we might as well set the implicit so the user does not have to.