### PR TITLE
Add dependency group ID for JVM-based tools.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -8,6 +8,7 @@
 
         { "id": 19, "name" : "LANGUAGE", "comment" : "The programming language this graph originates from", "valueType" : "string", "cardinality" : "one"},
         { "id" : 13, "name": "VERSION", "comment" : "A version, given as a string", "valueType" : "string", "cardinality" : "one"},
+        { "id" : 58, "name" : "DEPENDENCY_GROUP_ID", "comment" : "The group ID for a dependency.", "valueType" : "string", "cardinality" : "zeroOrOne" },
 
         // Properties that indicate where the code can be found
 


### PR DESCRIPTION
For https://github.com/ShiftLeftSecurity/ocular/pull/350.