### PR TITLE
Added parallel computation for most demanding Cpg passes.

### DIFF
--- a/enhancements/src/main/scala/io/shiftleft/passes/ParallelIteratorExecutor.scala
+++ b/enhancements/src/main/scala/io/shiftleft/passes/ParallelIteratorExecutor.scala
@@ -1,0 +1,17 @@
+package io.shiftleft.passes
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+class ParallelIteratorExecutor[T](iterator: Iterator[T]) {
+  def map[D](func: T => D): Iterator[D] = {
+    val futures = Future.traverse(iterator){ element =>
+      Future {
+        func(element)
+      }
+    }
+
+    Await.result(futures, Duration.Inf)
+  }
+}

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/GremlinScalaIterator.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/GremlinScalaIterator.scala
@@ -1,0 +1,13 @@
+package io.shiftleft.queryprimitives.steps
+
+import gremlin.scala.GremlinScala
+
+case class GremlinScalaIterator[T](traversal: GremlinScala[T]) extends Iterator[T] {
+  override def hasNext: Boolean = {
+    traversal.traversal.hasNext
+  }
+
+  override def next(): T = {
+    traversal.traversal.next
+  }
+}

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Steps.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/Steps.scala
@@ -27,6 +27,10 @@ class Steps[NodeType, Labels <: HList](val raw: GremlinScala.Aux[NodeType, Label
     with ext.dataflowengine.Enrichable {
   implicit lazy val graph: Graph = raw.traversal.asAdmin.getGraph.get
 
+  def toIterator(): Iterator[NodeType] = {
+    GremlinScalaIterator(raw)
+  }
+
   /**
     Execute the traversal and convert the result to a list
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/containsedges/ContainsEdgePass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/containsedges/ContainsEdgePass.scala
@@ -6,6 +6,7 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.{CpgPass, ParallelIteratorExecutor}
 import io.shiftleft.passes.utils.Traversals
+import io.shiftleft.queryprimitives.steps.GremlinScalaIterator
 
 class ContainsEdgePass(graph: ScalaGraph) extends CpgPass(graph) {
 
@@ -30,8 +31,7 @@ class ContainsEdgePass(graph: ScalaGraph) extends CpgPass(graph) {
   override def run(): Iterator[DiffGraph] = {
     val dstGraph = new DiffGraph
 
-    val sourceVertices = graph.V.hasLabel(sourceTypes.head, sourceTypes.tail: _*).toList
-    val sourceVerticesIterator = sourceVertices.iterator
+    val sourceVerticesIterator = GremlinScalaIterator(graph.V.hasLabel(sourceTypes.head, sourceTypes.tail: _*))
 
     new ParallelIteratorExecutor(sourceVerticesIterator).map(perSource)
   }


### PR DESCRIPTION
The MemberAccessLinker and ContainsEdgePass are now internally using
multiple threads for computation.
Also did some optimization on the Linker pass but did not yet parallelize
because the expected performance gain should be minor.