### PR TITLE
specify edge ids in protos - avoid id clashes with nodes

### DIFF
--- a/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
+++ b/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
@@ -100,11 +100,11 @@ message CpgStruct {
 
   message Edge {
     reserved 5;
-    reserved "key";
     // Source node.
     int64 src = 1;
     // Destination node.
     int64 dst = 2;
+    int64 key = 6;
 
     // Edge type.
     enum EdgeType {
@@ -135,6 +135,7 @@ message AdditionalEdgeProperty {
 }
 
 message CpgOverlay {
+  string name = 5;
   repeated CpgStruct.Node node = 1;
   repeated CpgStruct.Edge edge = 2;
   repeated AdditionalNodeProperty node_property = 3;


### PR DESCRIPTION
nodes and edges have the same id namespace - to ensure we don't
accidentally assign an id to an edge that was supposed to be used by a
node later on, we're now storing the edge ids as well

this change is backwards compatible, but all frontends need to be
updated for this to have any effect