### PR TITLE
Only write out non-empty overlays

### DIFF
--- a/enhancements/src/main/scala/io/shiftleft/passes/CpgPassRunner.scala
+++ b/enhancements/src/main/scala/io/shiftleft/passes/CpgPassRunner.scala
@@ -10,8 +10,11 @@ class CpgPassRunner(serializedCpg: SerializedCpg) {
   def createStoreAndApplyOverlay(pass: CpgPass, counter: Int = 0) = {
     val overlays = pass.executeAndCreateOverlay()
     overlays.zipWithIndex.foreach {
-      case (x, index) =>
-        serializedCpg.addOverlay(x, pass.getClass.getSimpleName + counter.toString + "_" + index)
+      case (overlay, index) => {
+        if (overlay.getSerializedSize > 0) {
+          serializedCpg.addOverlay(overlay, pass.getClass.getSimpleName + counter.toString + "_" + index)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Now that we generate overlays in parallel, we often end up with overlays of size 0. These do not carry any information, and it is safe to not write them into the serialized CPG.