### PR TITLE
remove reference to `wrapped` within the generated class

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" % "tinkergraph-gremlin" % "3.3.4.11",
+  "io.shiftleft" % "tinkergraph-gremlin" % "3.3.4.12",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.3.4.13",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.2", //redirect tinkerpop's slf4j logging to log4j
   "com.google.guava" % "guava" % "21.0",

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -468,7 +468,7 @@ object DomainClassCreator {
           |  }
           |  override def toMap: Map[String, Any] = get.toMap
           |  override val productArity = get.productArity
-          |  override def productElement(n: Int): Any = wrapped.productElement(n)
+          |  override def productElement(n: Int): Any = get.productElement(n)
           |  override def canEqual(that: Any): Boolean = get.canEqual(that)
           |}""".stripMargin
       }


### PR DESCRIPTION
using `wrapped` within the generated class will result in holding a
local reference, preventing it to be GC'd...

big thanks @ml86 for finding this one!