### PR TITLE
change default heap threshold back to 80%

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/OnDiskOverflowConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/OnDiskOverflowConfig.scala
@@ -10,5 +10,5 @@ case class OnDiskOverflowConfig(alternativeParentDirectory: Option[String] = Non
 
 object OnDiskOverflowConfig {
   val defaultForJava = OnDiskOverflowConfig()
-  val defaultHeapPercentageThreshold: Int = 90
+  val defaultHeapPercentageThreshold: Int = 80
 }


### PR DESCRIPTION
running OOM on certain machines in certain situations again, this
didn't happen with the old threshold
e.g. https://ci.shiftleftsecurity.com/job/TEST-SPTests/1586/consoleFull