### PR TITLE
Add COMMENT node

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/source-specific.json
+++ b/codepropertygraph/src/main/resources/schemas/source-specific.json
@@ -1,0 +1,15 @@
+{
+    "nodeTypes" : [
+	{"id" : 511, "name" : "COMMENT",
+	 "keys" : ["LINE_NUMBER", "CODE"],
+	 "comment" : "A comment",
+	 "outEdges" : []
+	},
+
+	{"name" : "FILE",
+	 "outEdges" : [
+	  {"edgeName": "AST", "inNodes": ["COMMENT"]}
+	 ]
+	}
+    ]
+}

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/File.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/File.scala
@@ -26,5 +26,5 @@ class File[Labels <: HList](raw: GremlinScala.Aux[nodes.File, Labels])
     new Namespace[Labels](raw.out(EdgeTypes.AST).out(EdgeTypes.REF).cast[nodes.Namespace])
 
   def namespaceBlock: NamespaceBlock[Labels] =
-    new NamespaceBlock[Labels](raw.out(EdgeTypes.AST).cast[nodes.NamespaceBlock])
+    new NamespaceBlock[Labels](raw.out(EdgeTypes.AST).hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
 }


### PR DESCRIPTION
Add the node type "COMMENT" in the new specification file "source-specific". Comments have a line number and code field, and files have outgoing AST edges to comments.

Once this is merged, we can bring in the corresponding change in fuzzyc2cpg, which generates source nodes. We need to watch out though: out("AST") on file nodes now also returns non-namespaceblock nodes, so, we need to ensure we filter correctly for existing steps.