### PR TITLE
adapt DomainClassCreator to latest TinkerGraph (which allows to save/load mvstores)

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" % "tinkergraph-gremlin" % "3.3.4.15-MP-SNAPSHOT",
+  "io.shiftleft" % "tinkergraph-gremlin" % "3.3.4.15",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.3.4.13",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.2", //redirect tinkerpop's slf4j logging to log4j
   "com.google.guava" % "guava" % "21.0",

--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" % "tinkergraph-gremlin" % "3.3.4.14",
+  "io.shiftleft" % "tinkergraph-gremlin" % "3.3.4.15-MP-SNAPSHOT",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.3.4.13",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.2", //redirect tinkerpop's slf4j logging to log4j
   "com.google.guava" % "guava" % "21.0",

--- a/codepropertygraph/src/main/java/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.java
+++ b/codepropertygraph/src/main/java/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.java
@@ -37,8 +37,8 @@ public class ProtoToCpg {
       configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_ONDISK_OVERFLOW_ENABLED, true);
       configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_OVERFLOW_HEAP_PERCENTAGE_THRESHOLD,
         config.heapPercentageThreshold());
-      config.alternativeParentDirectoryAsJava().ifPresent(dir ->
-        configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_ONDISK_ROOT_DIR, dir));
+      config.graphLocationAsJava().ifPresent(path ->
+        configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, path));
     } else {
       configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_ONDISK_OVERFLOW_ENABLED, false);
     }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/Cpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/Cpg.scala
@@ -16,7 +16,21 @@ object Cpg {
   /**
     * Create an empty code property graph
     */
-  def emptyCpg: Cpg = new Cpg(emptyGraph)
+  def emptyCpg: Cpg =
+    new Cpg(emptyGraph)
+
+  /**
+    * Instantiate cpg with storage.
+    * If the storage file already exists, it will load (a subset of) the data into memory. Otherwise it will create an empty cpg.
+    * In either case, configuring storage means that OverflowDb will be stored to disk on shutdown (`close`).
+    * I.e. if you want to preserve state between sessions, just use this method to instantiate the cpg and ensure to properly `close` the cpg at the end.
+    * @param path to the storage file, e.g. /home/user1/overflowdb.bin
+    */
+  def withStorage(path: String): Cpg = {
+    val configuration = TinkerGraph.EMPTY_CONFIGURATION
+    configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, path)
+    new Cpg(TinkerGraph.open(configuration, nodes.Factories.AllAsJava, edges.Factories.AllAsJava))
+  }
 
   /**
     * Returns a fresh, empty graph

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
@@ -2,13 +2,21 @@ package io.shiftleft.codepropertygraph.cpgloading
 
 object CpgLoaderConfig {
 
-  def default: CpgLoaderConfig = CpgLoaderConfig(
-    createIndices = true,
-    onDiskOverflowConfig = Some(OnDiskOverflowConfig()),
-    ignoredProtoEntries = None
-  )
+  def default =
+    CpgLoaderConfig(
+      createIndices = true,
+      onDiskOverflowConfig = Some(OnDiskOverflowConfig()),
+      ignoredProtoEntries = None
+    )
 
-  def withoutOverflow: CpgLoaderConfig =
+  def withStorage(path: String) =
+    CpgLoaderConfig(
+      createIndices = true,
+      onDiskOverflowConfig = Some(OnDiskOverflowConfig(graphLocation = Some(path))),
+      ignoredProtoEntries = None
+    )
+
+  def withoutOverflow =
     CpgLoaderConfig(
       createIndices = true,
       onDiskOverflowConfig = None,
@@ -22,6 +30,6 @@ object CpgLoaderConfig {
   * @param createIndices indicate whether to create indices or not
   * @param onDiskOverflowConfig configuration for the on-disk-overflow feature
   */
-case class CpgLoaderConfig(var createIndices: Boolean,
-                           var onDiskOverflowConfig: Option[OnDiskOverflowConfig],
-                           var ignoredProtoEntries: Option[IgnoredProtoEntries])
+case class CpgLoaderConfig(createIndices: Boolean,
+                           onDiskOverflowConfig: Option[OnDiskOverflowConfig],
+                           ignoredProtoEntries: Option[IgnoredProtoEntries])

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/OnDiskOverflowConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/OnDiskOverflowConfig.scala
@@ -2,10 +2,12 @@ package io.shiftleft.codepropertygraph.cpgloading
 
 import scala.compat.java8.OptionConverters._
 
-/** configure graphdb to use ondisk overflow. by default, system tmp directory is used (e.g. `/tmp`)  */
-case class OnDiskOverflowConfig(alternativeParentDirectory: Option[String] = None,
+/** configure graphdb to use ondisk overflow.
+  * if `graphLocation` is specified, graph will be saved there on close, and can be reloaded by just instantiating one with the same setting
+  * otherwise, system tmp directory is used (e.g. `/tmp`) and graph won't be saved on close */
+case class OnDiskOverflowConfig(graphLocation: Option[String] = None,
                                 heapPercentageThreshold: Int = OnDiskOverflowConfig.defaultHeapPercentageThreshold) {
-  lazy val alternativeParentDirectoryAsJava = alternativeParentDirectory.asJava
+  lazy val graphLocationAsJava = graphLocation.asJava
 }
 
 object OnDiskOverflowConfig {


### PR DESCRIPTION
use traits for Ref types, which solves two issues at once: 1) allow to call a different super constructor and 2) ensure the `wrapped` instance cannot be held onto internally
pass storage location through to tinkergraph: go through all places that instantiate TinkerGraph
new cpg factory to start from existing graph location

Depends on https://github.com/ShiftLeftSecurity/tinkergraph-gremlin/pull/29