### PR TITLE
Introduce TYPE_DECL aliases.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -44,7 +44,8 @@
         {"id": 54, "name" : "METHOD_FULL_NAME", "comment" : "The FULL_NAME of a method. Used to link METHOD_INST and METHOD nodes. It is required to have exactly one METHOD node for each METHOD_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
         {"id": 55, "name" : "METHOD_INST_FULL_NAME", "comment" : "The FULL_NAME of a method instance. Used to link CALL and METHOD_REF nodes to METHOD_INST nodes. There needs to be at least one METHOD_INST node for each METHOD_INST_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
         {"id": 56, "name" : "AST_PARENT_TYPE", "comment" : "The type of the AST parent. Since this is only used in some parts of the graph the list does not include all possible parents by intention. Possible parents: METHOD, TYPE_DECL, NAMESPACE_BLOCK", "valueType" : "string", "cardinality" : "one"},
-        {"id": 57, "name" : "AST_PARENT_FULL_NAME", "comment" : "The FULL_NAME of a the AST parent of an entity", "valueType" : "string", "cardinality" : "one"}
+        {"id": 57, "name" : "AST_PARENT_FULL_NAME", "comment" : "The FULL_NAME of a the AST parent of an entity", "valueType" : "string", "cardinality" : "one"},
+        {"id": 158, "name" : "ALIAS_TYPE_FULL_NAME", "comment" : "Type full name of which a TYPE_DECL is an alias of", "valueType" : "string", "cardinality" : "zeroOrOne"}
     ],
 
     // Keys for edge properties
@@ -120,7 +121,7 @@
          ]
         },
         {"id" : 46, "name" : "TYPE_DECL",
-         "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME"],
+         "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME", "ALIAS_TYPE_FULL_NAME"],
          "comment" : "A type declaration",
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["TYPE_PARAMETER", "MEMBER", "MODIFIER"]},

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -91,6 +91,7 @@
           "outEdges" : [
              {"edgeName": "AST", "inNodes": ["TYPE_DECL", "METHOD"]},
              {"edgeName": "INHERITS_FROM", "inNodes": ["TYPE"]},
+             {"edgeName": "ALIAS_OF", "inNodes": ["TYPE"]},
              {"edgeName": "CONTAINS", "inNodes": ["METHOD"]}
           ]
         },
@@ -154,7 +155,8 @@
         {"id" : 23, "name" : "INHERITS_FROM", "keys": [], "comment" : "Inheritance relation between types", "keys" : [] },
         {"id" : 28, "name" : "CONTAINS", "keys" : [], "comment" : "Shortcut over multiple AST edges"},
         {"id" : 1, "name" : "PROPAGATE", "keys" : ["ALIAS"], "comment" : "Encodes propagation of data from on node to another"},
-        {"id" : 137, "name": "REACHING_DEF", "keys" : [], "comment" : "Reaching definition edge", "keys" : []}
+        {"id" : 137, "name": "REACHING_DEF", "keys" : [], "comment" : "Reaching definition edge", "keys" : []},
+        {"id" : 138, "name" : "ALIAS_OF", "keys": [], "comment" : "Alias relation between types", "keys" : [] }
     ]
 
 }

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Type.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/Type.scala
@@ -81,6 +81,27 @@ class Type[Labels <: HList](raw: GremlinScala.Aux[nodes.Type, Labels])
   def derivedTypeDecl: TypeDecl[Labels] =
     new TypeDecl[Labels](raw.in(EdgeTypes.INHERITS_FROM).cast[nodes.TypeDecl])
 
+  /**
+    * Direct alias type declarations.
+    */
+  def aliasTypeDecl: TypeDecl[Labels] = {
+    new TypeDecl[Labels](raw.in(EdgeTypes.ALIAS_OF).cast[nodes.TypeDecl])
+  }
+
+  /**
+    * Direct alias types.
+    */
+  def aliasType: Type[Labels] = {
+    aliasTypeDecl.referencingType
+  }
+
+  /**
+    * Direct and transitive alias types.
+    */
+  def aliasTypeTransitive: Type[Labels] = {
+    repeat(_.aliasType).emit()
+  }
+
   def localsOfType: Local[Labels] =
     new Local[Labels](raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/TypeDecl.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/structure/TypeDecl.scala
@@ -128,10 +128,15 @@ class TypeDecl[Labels <: HList](raw: GremlinScala.Aux[nodes.TypeDecl, Labels])
     * else unchanged.
     */
   def unravelAlias: TypeDecl[Labels] = {
-    new TypeDecl[Labels](raw.map{ typeDecl =>
+    new TypeDecl[Labels](raw.map { typeDecl =>
       if (typeDecl.aliasTypeFullName.isDefined) {
-        typeDecl.vertices(Direction.OUT, EdgeTypes.ALIAS_OF).next.asInstanceOf[nodes.Type]
-          .vertices(Direction.OUT, EdgeTypes.REF).next.asInstanceOf[nodes.TypeDecl]
+        typeDecl
+          .vertices(Direction.OUT, EdgeTypes.ALIAS_OF)
+          .next
+          .asInstanceOf[nodes.Type]
+          .vertices(Direction.OUT, EdgeTypes.REF)
+          .next
+          .asInstanceOf[nodes.TypeDecl]
       } else {
         typeDecl
       }
@@ -151,9 +156,13 @@ class TypeDecl[Labels <: HList](raw: GremlinScala.Aux[nodes.TypeDecl, Labels])
     new TypeDecl[Labels](raw.map { typeDecl =>
       var currentTypeDecl = typeDecl
       while (currentTypeDecl.aliasTypeFullName.isDefined) {
-        currentTypeDecl =
-          currentTypeDecl.vertices(Direction.OUT, EdgeTypes.ALIAS_OF).next.asInstanceOf[nodes.Type]
-            .vertices(Direction.OUT, EdgeTypes.REF).next.asInstanceOf[nodes.TypeDecl]
+        currentTypeDecl = currentTypeDecl
+          .vertices(Direction.OUT, EdgeTypes.ALIAS_OF)
+          .next
+          .asInstanceOf[nodes.Type]
+          .vertices(Direction.OUT, EdgeTypes.REF)
+          .next
+          .asInstanceOf[nodes.TypeDecl]
       }
       currentTypeDecl
     })

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
@@ -49,6 +49,6 @@ class TypeDeclStubCreator(graph: ScalaGraph) extends CpgPass(graph) {
     val cpg = Cpg(graph.graph)
     cpg.typeDecl.sideEffect { typeDecl =>
       typeDeclFullNameToNode += typeDecl.fullName -> typeDecl
-    }
+    }.exec
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/linking/linker/Linker.scala
@@ -106,6 +106,18 @@ class Linker(graph: ScalaGraph) extends CpgPass(graph) {
       dstGraph
     )
 
+    linkToMultiple(
+      srcLabels = List(NodeTypes.TYPE_DECL),
+      dstNodeLabel = NodeTypes.TYPE,
+      edgeType = EdgeTypes.ALIAS_OF,
+      dstNodeIdMap = typeFullNameToNodeId,
+      getDstFullNames = (srcNode: nodes.TypeDecl) => {
+        srcNode.aliasTypeFullName
+      },
+      dstFullNameKey = NodeKeyNames.ALIAS_TYPE_FULL_NAME,
+      dstGraph
+    )
+
     Iterator(dstGraph)
   }
 


### PR DESCRIPTION
Reason: We want to be able to represent C typedef.

Details:
  TYPE_DECL now has a new optional property ALIAS_TYPE_FULL_NAME.
  If this is set the TYPE_DECL is an alias of the provide type.
  Note that is this case the TYPE_DECL cannot provide
  INHERITS_FROM_TYPE_FULL_NAME because deriving and being an
  alias is not possible at the same time. This makes TYPE_DECL
  effectively a sum type with two different characteristics.

Steps:
  Introduced a few new DSL steps to navigate between aliases
  and the referenced types/type declarations.