### PR TITLE
Property storing the original captured name

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -45,7 +45,8 @@
         {"id": 55, "name" : "METHOD_INST_FULL_NAME", "comment" : "The FULL_NAME of a method instance. Used to link CALL and METHOD_REF nodes to METHOD_INST nodes. There needs to be at least one METHOD_INST node for each METHOD_INST_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
         {"id": 56, "name" : "AST_PARENT_TYPE", "comment" : "The type of the AST parent. Since this is only used in some parts of the graph the list does not include all possible parents by intention. Possible parents: METHOD, TYPE_DECL, NAMESPACE_BLOCK", "valueType" : "string", "cardinality" : "one"},
         {"id": 57, "name" : "AST_PARENT_FULL_NAME", "comment" : "The FULL_NAME of a the AST parent of an entity", "valueType" : "string", "cardinality" : "one"},
-        {"id": 158, "name" : "ALIAS_TYPE_FULL_NAME", "comment" : "Type full name of which a TYPE_DECL is an alias of", "valueType" : "string", "cardinality" : "zeroOrOne"}
+        {"id": 158, "name" : "ALIAS_TYPE_FULL_NAME", "comment" : "Type full name of which a TYPE_DECL is an alias of", "valueType" : "string", "cardinality" : "zeroOrOne"},
+        {"id": 159, "name" : "CLOSURE_ORIGINAL_NAME", "comment" : "The original name of the (potentially mangled) captured variable", "valueType" : "string", "cardinality" : "zeroOrOne"}
     ],
 
     // Keys for edge properties

--- a/codepropertygraph/src/main/resources/schemas/closure.json
+++ b/codepropertygraph/src/main/resources/schemas/closure.json
@@ -6,7 +6,7 @@
       ]
     },
     {"id":334, "name":"CLOSURE_BINDING",
-      "keys": [ "CLOSURE_BINDING_ID", "EVALUATION_STRATEGY" ],
+      "keys": [ "CLOSURE_BINDING_ID", "EVALUATION_STRATEGY", "CLOSURE_ORIGINAL_NAME" ],
       "comment":"Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method",
       "outEdges": [
         {"edgeName": "REF", "inNodes": ["LOCAL", "METHOD_PARAMETER_IN"]}


### PR DESCRIPTION
Various languages can perform name mangling for variables that are
captured in closures. In such case we want to have the possibility of
retrieving the original name from the mangled name of the captured
variable.