### PR TITLE
Remove LINE_NUMBER_END and COLUMN_NUMBER_END and...

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -13,9 +13,7 @@
         // Properties that indicate where the code can be found
 
         {"id" : 2, "name": "LINE_NUMBER", "comment": "Line where the code starts", "valueType" : "int", "cardinality" : "zeroOrOne"},
-        {"id" : 10, "name": "LINE_NUMBER_END", "comment" : "Line where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne" },
         {"id" : 11, "name": "COLUMN_NUMBER", "comment" : "Column where the code starts", "valueType" : "int", "cardinality" : "zeroOrOne" },
-        {"id" : 12, "name": "COLUMN_NUMBER_END", "comment" : "Column where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne" },
 
         {"id" : 3, "name": "PARSER_TYPE_NAME", "comment": "Type name emitted by parser, only present for logical type UNKNOWN", "valueType" : "string", "cardinality" : "one"},
         {"id" : 4, "name": "ORDER", "comment": "General ordering property. E.g. used to express the ordering of children in the AST", "valueType" : "int", "cardinality" : "one"},
@@ -82,7 +80,7 @@
 
         {"id" : 1, "name" : "METHOD",
          "keys": ["NAME", "FULL_NAME", "SIGNATURE", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME",
-           "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+           "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A method/function/procedure",
          "is": ["DECLARATION", "CFG_NODE"],
          "outEdges" : [
@@ -93,13 +91,13 @@
         },
 
         {"id" : 34, "name" : "METHOD_PARAMETER_IN",
-         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "This node represents a formal parameter going towards the callee side",
          "is": ["DECLARATION", "LOCAL_LIKE", "TRACKING_POINT"]
         },
 
         {"id" : 3, "name" : "METHOD_RETURN",
-         "keys": ["CODE", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A formal method return",
          "is": ["CFG_NODE", "TRACKING_POINT"]
         },
@@ -159,7 +157,7 @@
         // Nodes that describe method content
 
         {"id" : 8, "name" : "LITERAL",
-         "keys" : ["CODE", /* DEPRECATED */"NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys" : ["CODE", /* DEPRECATED */"NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "Literal/Constant",
          "is": ["EXPRESSION"],
          "outEdges" : [
@@ -168,7 +166,7 @@
         },
         {"id": 15, "name" : "CALL",
          "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "DISPATCH_TYPE", "SIGNATURE", "TYPE_FULL_NAME", "METHOD_INST_FULL_NAME", "LINE_NUMBER",
-                  "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+                  "COLUMN_NUMBER"],
          "comment" : "A (method)-call",
          "is": ["EXPRESSION"],
          "outEdges" : [
@@ -178,12 +176,12 @@
          ]
         },
         {"id":23, "name" : "LOCAL",
-         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment": "A local variable",
          "is": ["DECLARATION", "LOCAL_LIKE"]
         },
         {"id":27, "name": "IDENTIFIER",
-         "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "An arbitrary identifier/reference",
          "is": ["EXPRESSION", "LOCAL_LIKE"],
          "outEdges" : [
@@ -192,7 +190,7 @@
          ]
         },
         {"id":30, "name": "RETURN",
-         "keys": [ "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END", "ORDER", "ARGUMENT_INDEX", "CODE"],
+         "keys": [ "LINE_NUMBER", "COLUMN_NUMBER", "ORDER", "ARGUMENT_INDEX", "CODE"],
          "comment" : "A return instruction",
          "is": [ "EXPRESSION"],
          "outEdges" : [
@@ -201,7 +199,7 @@
          ]
         },
         {"id":31, "name": "BLOCK",
-         "keys": [ "CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": [ "CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A structuring block in the AST",
          "is": [ "EXPRESSION"],
          "outEdges" : [
@@ -224,7 +222,7 @@
         },
 
         {"id":333, "name":"METHOD_REF",
-          "keys": ["CODE", "ORDER", "ARGUMENT_INDEX", "METHOD_INST_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+          "keys": ["CODE", "ORDER", "ARGUMENT_INDEX", "METHOD_INST_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
           "comment":"Reference to a method instance",
          "is": ["EXPRESSION"],
           "outEdges": [
@@ -236,7 +234,7 @@
         // This is the "catch-all-others" node type.
 
         {"id" : 44, "name": "UNKNOWN",
-         "keys" : ["CODE", "PARSER_TYPE_NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys" : ["CODE", "PARSER_TYPE_NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A language-specific node",
          "is": ["EXPRESSION"],
          "outEdges" : [
@@ -253,7 +251,7 @@
       { "name" : "DECLARATION", "comment" : "", "hasKeys" : ["NAME"]},
       { "name" : "EXPRESSION", "comment" : "Expression as a specialisation of data flow objects", "hasKeys" : ["CODE", "ORDER"], "extends" : ["TRACKING_POINT", "CFG_NODE"]},
       { "name" : "LOCAL_LIKE", "comment" : "", "hasKeys" : ["NAME"]},
-      { "name" : "CFG_NODE", "comment" : "", "hasKeys" : ["LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"], "extends": ["WITHIN_METHOD"]},
+      { "name" : "CFG_NODE", "comment" : "", "hasKeys" : ["LINE_NUMBER", "COLUMN_NUMBER"], "extends": ["WITHIN_METHOD"]},
       { "name" : "TRACKING_POINT", "comment" : "", "hasKeys" : [], "extends": ["WITHIN_METHOD"]},
       { "name" : "WITHIN_METHOD", "comment" : "", "hasKeys" : []}
     ],

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -54,7 +54,7 @@
           ]
         },
         {"id" : 33, "name" : "METHOD_PARAMETER_OUT",
-         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER", "COLUMN_NUMBER_END"],
+         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "This node represents a formal parameter going towards the caller side",
          "is": ["DECLARATION", "TRACKING_POINT"],
          "outEdges" : [

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -56,6 +56,19 @@ object DomainClassCreator {
       import org.apache.tinkerpop.gremlin.structure.{Vertex, VertexProperty}
       import org.apache.tinkerpop.gremlin.tinkergraph.structure.{EdgeRef, SpecializedElementFactory, SpecializedTinkerEdge, TinkerGraph, TinkerProperty, TinkerVertex, VertexRef}
       import scala.collection.JavaConverters._
+      import org.slf4j.LoggerFactory
+
+      object PropertyErrorRegister {
+        private var errorMap = Set[(Class[_], String)]()
+        private val logger = LoggerFactory.getLogger(getClass)
+
+        def logPropertyErrorIfFirst(clazz: Class[_], propertyName: String) {
+          if (!errorMap.contains((clazz, propertyName))) {
+            logger.warn("Property " + propertyName + " is deprecated for " + clazz.getName + ".")
+            errorMap += ((clazz, propertyName))
+          }
+        }
+      }
       """
 
       val factories = {
@@ -179,6 +192,19 @@ object DomainClassCreator {
       import org.apache.tinkerpop.gremlin.tinkergraph.structure.{SpecializedElementFactory, SpecializedTinkerVertex, TinkerGraph, TinkerVertexProperty, VertexRef}
       import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils
       import scala.collection.JavaConverters._
+      import org.slf4j.LoggerFactory
+
+      object PropertyErrorRegister {
+        private var errorMap = Set[(Class[_], String)]()
+        private val logger = LoggerFactory.getLogger(getClass)
+
+        def logPropertyErrorIfFirst(clazz: Class[_], propertyName: String) {
+          if (!errorMap.contains((clazz, propertyName))) {
+            logger.warn("Property " + propertyName + " is deprecated for " + clazz.getName + ".")
+            errorMap += ((clazz, propertyName))
+          }
+        }
+      }
 
       trait Node extends Product {
         def accept[T](visitor: NodeVisitor[T]): T = ???
@@ -846,7 +872,7 @@ object Utils {
 
   def updateSpecificPropertyBody(properties: List[Property]): String = {
     val caseNotFound =
-      s"""throw new RuntimeException("property with key=" + key + " not (yet) supported by " + this.getClass.getName + ". You may want to add it to cpg.json")"""
+      s"""PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)"""
     properties match {
       case Nil => caseNotFound
       case keys =>

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -64,7 +64,6 @@ class MethodStubCreator(graph: ScalaGraph) extends CpgPass(graph) {
       None,
       None,
       None,
-      None
     )
     dstGraph.addNode(methodNode)
 
@@ -79,8 +78,6 @@ class MethodStubCreator(graph: ScalaGraph) extends CpgPass(graph) {
         "ANY",
         None,
         None,
-        None,
-        None
       )
 
       dstGraph.addNode(methodParameterIn)
@@ -93,12 +90,11 @@ class MethodStubCreator(graph: ScalaGraph) extends CpgPass(graph) {
       "ANY",
       None,
       None,
-      None
     )
     dstGraph.addNode(methodReturn)
     dstGraph.addEdge(methodNode, methodReturn, EdgeTypes.AST)
 
-    val blockNode = new NewBlock("", 1, 1, "ANY", None, None, None, None)
+    val blockNode = new NewBlock("", 1, 1, "ANY", None, None)
     dstGraph.addNode(blockNode)
     dstGraph.addEdge(methodNode, blockNode, EdgeTypes.AST)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/methoddecorations/MethodDecoratorPass.scala
@@ -41,9 +41,7 @@ class MethodDecoratorPass(graph: ScalaGraph) extends CpgPass(graph) {
               parameterIn.evaluationStrategy,
               parameterIn.typeFullName,
               parameterIn.lineNumber,
-              parameterIn.lineNumberEnd,
               parameterIn.columnNumber,
-              parameterIn.columnNumberEnd
             )
 
             val method =


### PR DESCRIPTION
gracefully warn about deprecated properties instead of throwing an
exception.
The properties have been removed in order to save memory.