### PR TITLE
Fix annotation values

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/java-specific.json
+++ b/codepropertygraph/src/main/resources/schemas/java-specific.json
@@ -38,7 +38,7 @@
          "keys" : ["CODE", "NAME", "ORDER"],
          "comment" : "A literal value assigned to an ANNOTATION_PARAMETER",
          "outEdges" : [ ],
-          "is" : ["AST_NODE"]
+          "is" : ["EXPRESSION"]
         },
 
         {"name" : "ARRAY_INITIALIZER",
@@ -46,7 +46,8 @@
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["LITERAL"]},
              {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
-         ]
+         ],
+	 "is" : ["EXPRESSION"]
         },
 
         // Modifications to existing node types

--- a/codepropertygraph/src/main/resources/schemas/java-specific.json
+++ b/codepropertygraph/src/main/resources/schemas/java-specific.json
@@ -35,14 +35,14 @@
         },
 
         {"id" : 49, "name" : "ANNOTATION_LITERAL",
-         "keys" : ["CODE", "NAME", "ORDER"],
+         "keys" : ["CODE", "NAME", "ORDER", "COLUMN_NUMBER", "LINE_NUMBER"],
          "comment" : "A literal value assigned to an ANNOTATION_PARAMETER",
          "outEdges" : [ ],
           "is" : ["EXPRESSION"]
         },
 
         {"name" : "ARRAY_INITIALIZER",
-         "keys" : ["CODE"],
+         "keys" : ["CODE", "COLUMN_NUMBER", "LINE_NUMBER", "ORDER"],
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["LITERAL"]},
              {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}


### PR DESCRIPTION
For Java annotations, values need to be expressions, but they were only AST nodes.
Fixes https://github.com/ShiftLeftSecurity/codescience/issues/2671