### PR TITLE
Moved isGenericMemberAccessName into utils package

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/passes/dataflows/steps/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/passes/dataflows/steps/TrackingPoint.scala
@@ -7,7 +7,7 @@ import shapeless.HList
 import io.shiftleft.queryprimitives
 import io.shiftleft.queryprimitives.steps.types.structure.Method
 import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
-import io.shiftleft.queryprimitives.utils.ExpandTo
+import io.shiftleft.queryprimitives.utils.{ExpandTo, MemberAccess}
 import org.apache.tinkerpop.gremlin.structure.Direction
 
 import scala.collection.JavaConverters._
@@ -126,7 +126,7 @@ class TrackingPoint[Labels <: HList](raw: GremlinScala.Aux[nodes.TrackingPoint, 
     }
 
     val callName = vertex.value2(NodeKeys.NAME)
-    queryprimitives.isGenericMemberAccessName(callName)
+    MemberAccess.isGenericMemberAccessName(callName)
   }
 
 }

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/package.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/package.scala
@@ -95,18 +95,4 @@ import io.shiftleft.codepropertygraph.generated.Operators
   * }}}
   *
   **/
-package object queryprimitives {
-
-  /**
-    * For a given name, determine whether it is the
-    * name of a "member access" operation, e.g.,
-    * "<operator>.memberAccess".
-    * */
-  def isGenericMemberAccessName(name: String): Boolean = {
-    (name == Operators.memberAccess) ||
-    (name == Operators.indirectComputedMemberAccess) ||
-    (name == Operators.indirectMemberAccess) ||
-    (name == Operators.computedMemberAccess) ||
-    (name == Operators.indirection)
-  }
-}
+package object queryprimitives {}

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/visitormixins/TrackPointToCfgNode.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/visitormixins/TrackPointToCfgNode.scala
@@ -4,7 +4,7 @@ package visitormixins
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes.NodeVisitor
-import io.shiftleft.queryprimitives.utils.ExpandTo
+import io.shiftleft.queryprimitives.utils.{ExpandTo, MemberAccess}
 
 object TrackPointToCfgNode extends NodeVisitor[nodes.CfgNode] with ExpressionGeneralization[nodes.CfgNode] {
   override def visit(node: nodes.MethodParameterIn): nodes.CfgNode = {
@@ -22,7 +22,7 @@ object TrackPointToCfgNode extends NodeVisitor[nodes.CfgNode] with ExpressionGen
   }
 
   override def visit(node: nodes.Call): nodes.CfgNode = {
-    if (isGenericMemberAccessName(node.name)) {
+    if (MemberAccess.isGenericMemberAccessName(node.name)) {
       ExpandTo.argumentToCallOrReturn(node)
     } else {
       node

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/ExpandTo.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/ExpandTo.scala
@@ -32,7 +32,7 @@ object ExpandTo {
     val parent = argument.vertices(Direction.IN, EdgeTypes.AST).nextChecked
 
     parent match {
-      case call: nodes.Call if queryprimitives.isGenericMemberAccessName(call.name) =>
+      case call: nodes.Call if MemberAccess.isGenericMemberAccessName(call.name) =>
         argumentToCallOrReturn(call)
       case expression: nodes.Expression =>
         expression

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/MemberAccess.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/utils/MemberAccess.scala
@@ -1,0 +1,20 @@
+package io.shiftleft.queryprimitives.utils
+
+import io.shiftleft.codepropertygraph.generated.Operators
+
+object MemberAccess {
+
+  /**
+    * For a given name, determine whether it is the
+    * name of a "member access" operation, e.g.,
+    * "<operator>.memberAccess".
+    * */
+  def isGenericMemberAccessName(name: String): Boolean = {
+    (name == Operators.memberAccess) ||
+    (name == Operators.indirectComputedMemberAccess) ||
+    (name == Operators.indirectMemberAccess) ||
+    (name == Operators.computedMemberAccess) ||
+    (name == Operators.indirection)
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/reachingdef/ReachingDefPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/reachingdef/ReachingDefPass.scala
@@ -6,10 +6,11 @@ import io.shiftleft.diffgraph.DiffGraph
 import io.shiftleft.passes.CpgPass
 import io.shiftleft.queryprimitives
 import io.shiftleft.queryprimitives.steps.Implicits.JavaIteratorDeco
-import io.shiftleft.queryprimitives.utils.ExpandTo
+import io.shiftleft.queryprimitives.utils.{ExpandTo, MemberAccess}
 import java.nio.file.Paths
 
 import org.apache.tinkerpop.gremlin.structure.Direction
+
 import scala.collection.JavaConverters._
 
 class ReachingDefPass(graph: ScalaGraph) extends CpgPass(graph) {
@@ -208,7 +209,7 @@ class ReachingDefPass(graph: ScalaGraph) extends CpgPass(graph) {
     }
 
     val callName = vertex.value2(NodeKeys.NAME)
-    queryprimitives.isGenericMemberAccessName(callName)
+    MemberAccess.isGenericMemberAccessName(callName)
   }
 
 }


### PR DESCRIPTION
There was a single method called `isGenericMemberAccessName` in the package object of query-primitives. This is a utility method used in different passes and in the `ExpandTo` utility class. I have moved this method into a new object in the utils package so that it is in a less prominent place. I also believe we should not expose this beyond query-primitives, but that is a change for another day.