### PR TITLE
Rework CpgLoaderConfig

### DIFF
--- a/codepropertygraph/src/main/java/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.java
+++ b/codepropertygraph/src/main/java/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.java
@@ -19,7 +19,7 @@ public class ProtoCpgLoader {
   private static final Logger logger = LogManager.getLogger(ProtoCpgLoader.class);
 
   public static Cpg loadFromProtoZip(String filename) {
-    return loadFromProtoZip(filename, Optional.of(OnDiskOverflowConfig.defaultForJava()));
+    return loadFromProtoZip(filename, OnDiskOverflowConfig.defaultForJava());
   }
 
   /**
@@ -28,7 +28,7 @@ public class ProtoCpgLoader {
    */
   public static Cpg loadFromProtoZip(
     String filename,
-    Optional<OnDiskOverflowConfig> onDiskOverflowConfig) {
+    OnDiskOverflowConfig onDiskOverflowConfig) {
     try {
       ProtoToCpg builder = new ProtoToCpg(onDiskOverflowConfig);
 
@@ -97,7 +97,7 @@ public class ProtoCpgLoader {
    **/
   public static Cpg loadFromListOfProtos(
     List<CpgStruct> cpgs,
-    Optional<OnDiskOverflowConfig> onDiskOverflowConfig) {
+    OnDiskOverflowConfig onDiskOverflowConfig) {
     ProtoToCpg builder = new ProtoToCpg(onDiskOverflowConfig);
 
     for (CpgStruct cpgStruct : cpgs)

--- a/codepropertygraph/src/main/java/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.java
+++ b/codepropertygraph/src/main/java/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.java
@@ -24,18 +24,18 @@ public class ProtoToCpg {
   private TinkerGraph tinkerGraph;
 
   public ProtoToCpg() {
-    this(Optional.of(OnDiskOverflowConfig.defaultForJava()));
+    this(OnDiskOverflowConfig.defaultForJava());
   }
 
   public ProtoToCpg(
-    Optional<OnDiskOverflowConfig> onDiskOverflowConfig) {
+    OnDiskOverflowConfig onDiskOverflowConfig) {
     Configuration configuration = TinkerGraph.EMPTY_CONFIGURATION();
-    if (onDiskOverflowConfig.isPresent()) {
-      OnDiskOverflowConfig config = onDiskOverflowConfig.get();
+    if (onDiskOverflowConfig.enabled()) {
+
       configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_ONDISK_OVERFLOW_ENABLED, true);
       configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_OVERFLOW_HEAP_PERCENTAGE_THRESHOLD,
-        config.heapPercentageThreshold());
-      config.graphLocationAsJava().ifPresent(path ->
+              onDiskOverflowConfig.heapPercentageThreshold());
+      onDiskOverflowConfig.graphLocationAsJava().ifPresent(path ->
         configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_GRAPH_LOCATION, path));
     } else {
       configuration.setProperty(TinkerGraph.GREMLIN_TINKERGRAPH_ONDISK_OVERFLOW_ENABLED, false);

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -39,7 +39,7 @@ private class CpgLoader {
 
   private val logger = LogManager.getLogger(getClass)
 
-  def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.withoutOverflow): Cpg = {
+  def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.default.withoutOverflow): Cpg = {
     logger.debug("Loading " + filename)
 
     import scala.compat.java8.OptionConverters._

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -39,13 +39,12 @@ private class CpgLoader {
 
   private val logger = LogManager.getLogger(getClass)
 
-  def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.default.withoutOverflow): Cpg = {
+  def load(filename: String,
+           config: CpgLoaderConfig = CpgLoaderConfig.default.withOverflowConfig(OnDiskOverflowConfig.disabled)): Cpg = {
     logger.debug("Loading " + filename)
 
-    import scala.compat.java8.OptionConverters._
-
     val cpg =
-      ProtoCpgLoader.loadFromProtoZip(filename, config.onDiskOverflowConfig.asJava)
+      ProtoCpgLoader.loadFromProtoZip(filename, config.onDiskOverflowConfig)
     if (config.createIndexes) { createIndexes(cpg) }
     cpg
   }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -46,7 +46,7 @@ private class CpgLoader {
 
     val cpg =
       ProtoCpgLoader.loadFromProtoZip(filename, config.onDiskOverflowConfig.asJava)
-    if (config.createIndices) { createIndexes(cpg) }
+    if (config.createIndexes) { createIndexes(cpg) }
     cpg
   }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
@@ -2,25 +2,27 @@ package io.shiftleft.codepropertygraph.cpgloading
 
 object CpgLoaderConfig {
 
+  // To add a new option, please add a default value below and corresponding
+  // methods in the case class.
+
   def default =
     CpgLoaderConfig(
       createIndices = true,
       onDiskOverflowConfig = Some(OnDiskOverflowConfig()),
-      ignoredProtoEntries = None
     )
 
+  @deprecated("Use CpgLoaderConfig.default.withStorage instead", "Jul 19")
   def withStorage(path: String) =
     CpgLoaderConfig(
       createIndices = true,
       onDiskOverflowConfig = Some(OnDiskOverflowConfig(graphLocation = Some(path))),
-      ignoredProtoEntries = None
     )
 
+  @deprecated("Use CpgLoaderConfig.default.withoutStorage instead", "Jul 19")
   def withoutOverflow =
     CpgLoaderConfig(
       createIndices = true,
-      onDiskOverflowConfig = None,
-      ignoredProtoEntries = None
+      onDiskOverflowConfig = None
     )
 
 }
@@ -30,6 +32,31 @@ object CpgLoaderConfig {
   * @param createIndices indicate whether to create indices or not
   * @param onDiskOverflowConfig configuration for the on-disk-overflow feature
   */
-case class CpgLoaderConfig(createIndices: Boolean,
-                           onDiskOverflowConfig: Option[OnDiskOverflowConfig],
-                           ignoredProtoEntries: Option[IgnoredProtoEntries])
+case class CpgLoaderConfig(createIndices: Boolean, onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {
+
+  /**
+    * Existing configuration with overflowdb path as specified
+    * @param path the path of the on disk overflow database
+    * */
+  def withStorage(path: String): CpgLoaderConfig =
+    this.copy(onDiskOverflowConfig = Some(OnDiskOverflowConfig(graphLocation = Some(path))))
+
+  /**
+    * Existing configuration with overflowdb turned off.
+    * */
+  def withoutOverflow: CpgLoaderConfig =
+    this.copy(onDiskOverflowConfig = None)
+
+  /**
+    * Existing configuration without indexing on load.
+    * */
+  def doNotCreateIndicesOnLoad: CpgLoaderConfig =
+    this.copy(createIndices = false)
+
+  /**
+    * Existing configuration but with indexing on load.
+    * */
+  def createIndicesOnLoad: CpgLoaderConfig =
+    this.copy(createIndices = true)
+
+}

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
@@ -7,21 +7,21 @@ object CpgLoaderConfig {
 
   def default =
     CpgLoaderConfig(
-      createIndices = true,
+      createIndexes = true,
       onDiskOverflowConfig = Some(OnDiskOverflowConfig()),
     )
 
   @deprecated("Use CpgLoaderConfig.default.withStorage instead", "")
   def withStorage(path: String) =
     CpgLoaderConfig(
-      createIndices = true,
+      createIndexes = true,
       onDiskOverflowConfig = Some(OnDiskOverflowConfig(graphLocation = Some(path))),
     )
 
   @deprecated("Use CpgLoaderConfig.default.withoutStorage instead", "")
   def withoutOverflow =
     CpgLoaderConfig(
-      createIndices = true,
+      createIndexes = true,
       onDiskOverflowConfig = None
     )
 
@@ -29,10 +29,10 @@ object CpgLoaderConfig {
 
 /**
   * Configuration for the CPG loader
-  * @param createIndices indicate whether to create indices or not
+  * @param createIndexes indicate whether to create indices or not
   * @param onDiskOverflowConfig configuration for the on-disk-overflow feature
   */
-case class CpgLoaderConfig(createIndices: Boolean, onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {
+case class CpgLoaderConfig(createIndexes: Boolean, onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {
 
   /**
     * Existing configuration with overflowdb path as specified
@@ -50,13 +50,13 @@ case class CpgLoaderConfig(createIndices: Boolean, onDiskOverflowConfig: Option[
   /**
     * Existing configuration without indexing on load.
     * */
-  def doNotCreateIndicesOnLoad: CpgLoaderConfig =
-    this.copy(createIndices = false)
+  def doNotCreateIndexesOnLoad: CpgLoaderConfig =
+    this.copy(createIndexes = false)
 
   /**
     * Existing configuration but with indexing on load.
     * */
-  def createIndicesOnLoad: CpgLoaderConfig =
-    this.copy(createIndices = true)
+  def createIndexesOnLoad: CpgLoaderConfig =
+    this.copy(createIndexes = true)
 
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
@@ -11,14 +11,14 @@ object CpgLoaderConfig {
       onDiskOverflowConfig = Some(OnDiskOverflowConfig()),
     )
 
-  @deprecated("Use CpgLoaderConfig.default.withStorage instead", "Jul 19")
+  @deprecated("Use CpgLoaderConfig.default.withStorage instead", "")
   def withStorage(path: String) =
     CpgLoaderConfig(
       createIndices = true,
       onDiskOverflowConfig = Some(OnDiskOverflowConfig(graphLocation = Some(path))),
     )
 
-  @deprecated("Use CpgLoaderConfig.default.withoutStorage instead", "Jul 19")
+  @deprecated("Use CpgLoaderConfig.default.withoutStorage instead", "")
   def withoutOverflow =
     CpgLoaderConfig(
       createIndices = true,

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
@@ -11,6 +11,9 @@ object CpgLoaderConfig {
       onDiskOverflowConfig = OnDiskOverflowConfig.default,
     )
 
+  // This is required because `default` is a keyword in Java
+  def defaultForJava: CpgLoaderConfig = default
+
   @deprecated("Use CpgLoaderConfig.default.withStorage instead", "")
   def withStorage(path: String) =
     CpgLoaderConfig(

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderConfig.scala
@@ -8,21 +8,21 @@ object CpgLoaderConfig {
   def default =
     CpgLoaderConfig(
       createIndexes = true,
-      onDiskOverflowConfig = Some(OnDiskOverflowConfig()),
+      onDiskOverflowConfig = OnDiskOverflowConfig.default,
     )
 
   @deprecated("Use CpgLoaderConfig.default.withStorage instead", "")
   def withStorage(path: String) =
     CpgLoaderConfig(
       createIndexes = true,
-      onDiskOverflowConfig = Some(OnDiskOverflowConfig(graphLocation = Some(path))),
+      onDiskOverflowConfig = OnDiskOverflowConfig.default.withGraphLocation(path),
     )
 
   @deprecated("Use CpgLoaderConfig.default.withoutStorage instead", "")
   def withoutOverflow =
     CpgLoaderConfig(
       createIndexes = true,
-      onDiskOverflowConfig = None
+      onDiskOverflowConfig = OnDiskOverflowConfig.default.disabled
     )
 
 }
@@ -32,20 +32,7 @@ object CpgLoaderConfig {
   * @param createIndexes indicate whether to create indices or not
   * @param onDiskOverflowConfig configuration for the on-disk-overflow feature
   */
-case class CpgLoaderConfig(createIndexes: Boolean, onDiskOverflowConfig: Option[OnDiskOverflowConfig]) {
-
-  /**
-    * Existing configuration with overflowdb path as specified
-    * @param path the path of the on disk overflow database
-    * */
-  def withStorage(path: String): CpgLoaderConfig =
-    this.copy(onDiskOverflowConfig = Some(OnDiskOverflowConfig(graphLocation = Some(path))))
-
-  /**
-    * Existing configuration with overflowdb turned off.
-    * */
-  def withoutOverflow: CpgLoaderConfig =
-    this.copy(onDiskOverflowConfig = None)
+case class CpgLoaderConfig(createIndexes: Boolean, onDiskOverflowConfig: OnDiskOverflowConfig) {
 
   /**
     * Existing configuration without indexing on load.
@@ -58,5 +45,11 @@ case class CpgLoaderConfig(createIndexes: Boolean, onDiskOverflowConfig: Option[
     * */
   def createIndexesOnLoad: CpgLoaderConfig =
     this.copy(createIndexes = true)
+
+  /**
+    * Return existing configuration but with overflowdb config set to `overflowConfig`.
+    * */
+  def withOverflowConfig(overflowConfig: OnDiskOverflowConfig): CpgLoaderConfig =
+    this.copy(onDiskOverflowConfig = overflowConfig)
 
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/IgnoredProtoEntries.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/IgnoredProtoEntries.scala
@@ -1,5 +1,0 @@
-package io.shiftleft.codepropertygraph.cpgloading
-
-/* some non-public frontends (e.g. java2cpg) use cpg proto entries that are `UNRECOGNIZED` by cpg-public.
- we'll ignore those during the import */
-case class IgnoredProtoEntries(nodeTypes: Set[Int], nodeKeys: Set[Int])

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/OnDiskOverflowConfig.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/OnDiskOverflowConfig.scala
@@ -5,12 +5,34 @@ import scala.compat.java8.OptionConverters._
 /** configure graphdb to use ondisk overflow.
   * if `graphLocation` is specified, graph will be saved there on close, and can be reloaded by just instantiating one with the same setting
   * otherwise, system tmp directory is used (e.g. `/tmp`) and graph won't be saved on close */
-case class OnDiskOverflowConfig(graphLocation: Option[String] = None,
+case class OnDiskOverflowConfig(enabled: Boolean = true,
+                                graphLocation: Option[String] = None,
                                 heapPercentageThreshold: Int = OnDiskOverflowConfig.defaultHeapPercentageThreshold) {
   lazy val graphLocationAsJava = graphLocation.asJava
+
+  /**
+    * Return this configuration but with disabled overflowdb
+    * */
+  def disabled: OnDiskOverflowConfig = this.copy(enabled = false)
+
+  /**
+    * Return this configuration but with overflowdb graph location set to `path`
+    * */
+  def withGraphLocation(path: String): OnDiskOverflowConfig = this.copy(graphLocation = Some(path))
+
+  /**
+    * Return this configuration with with heap percentage threshold set to `threshold`
+    * */
+  def withHeapPercentageThreshold(threshold: Int): OnDiskOverflowConfig = this.copy(heapPercentageThreshold = threshold)
+
 }
 
 object OnDiskOverflowConfig {
+
+  def default: OnDiskOverflowConfig = OnDiskOverflowConfig()
+
+  def disabled: OnDiskOverflowConfig = OnDiskOverflowConfig.default.disabled
+
   val defaultForJava = OnDiskOverflowConfig()
   val defaultHeapPercentageThreshold: Int = 80
 }

--- a/cpg2overflowdb/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToOverflowDbTest.scala
+++ b/cpg2overflowdb/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToOverflowDbTest.scala
@@ -11,7 +11,8 @@ class ProtoToOverflowDbTest extends WordSpec with Matchers {
 
   "imports cpg.bin.zip into overflowdb.bin" ignore {
     val cpgBinZip = "resources/cpgs/namespace/cpg.bin.zip"
-    val reference = CpgLoader.load(cpgBinZip, CpgLoaderConfig.default.withoutOverflow).scalaGraph
+    val reference =
+      CpgLoader.load(cpgBinZip, CpgLoaderConfig.default.withOverflowConfig(OnDiskOverflowConfig.disabled)).scalaGraph
 
     val referenceNodeCount = reference.V.count.head
     val referenceEdgeCount = reference.E.count.head

--- a/cpg2overflowdb/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToOverflowDbTest.scala
+++ b/cpg2overflowdb/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToOverflowDbTest.scala
@@ -11,7 +11,7 @@ class ProtoToOverflowDbTest extends WordSpec with Matchers {
 
   "imports cpg.bin.zip into overflowdb.bin" ignore {
     val cpgBinZip = "resources/cpgs/namespace/cpg.bin.zip"
-    val reference = CpgLoader.load(cpgBinZip, CpgLoaderConfig.withoutOverflow).scalaGraph
+    val reference = CpgLoader.load(cpgBinZip, CpgLoaderConfig.default.withoutOverflow).scalaGraph
 
     val referenceNodeCount = reference.V.count.head
     val referenceEdgeCount = reference.E.count.head

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -27,7 +27,7 @@ class CpgFactory(frontend: LanguageFrontend, semanticsFilename: String) {
 
     val cpgFile = frontend.execute(tmpDir)
 
-    val config = CpgLoaderConfig.withoutOverflow
+    val config = CpgLoaderConfig.default.withoutOverflow
     val cpg = CpgLoader.load(cpgFile.getAbsolutePath, config)
 
     val semantics = new SemanticsLoader(semanticsFilename).load()

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgFactory.scala
@@ -5,7 +5,7 @@ import java.nio.file.Files
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
+import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig, OnDiskOverflowConfig}
 import io.shiftleft.layers.{DataFlowRunner, EnhancementRunner}
 import io.shiftleft.semanticsloader.SemanticsLoader
 
@@ -27,7 +27,7 @@ class CpgFactory(frontend: LanguageFrontend, semanticsFilename: String) {
 
     val cpgFile = frontend.execute(tmpDir)
 
-    val config = CpgLoaderConfig.default.withoutOverflow
+    val config = CpgLoaderConfig.default.withOverflowConfig(OnDiskOverflowConfig.disabled)
     val cpg = CpgLoader.load(cpgFile.getAbsolutePath, config)
 
     val semantics = new SemanticsLoader(semanticsFilename).load()

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
@@ -2,12 +2,13 @@ package io.shiftleft.cpgqueryingtests.codepropertygraph
 
 import gremlin.scala.{Graph, ScalaGraph}
 import io.shiftleft.SerializedCpg
-import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
+import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig, OnDiskOverflowConfig}
 import io.shiftleft.layers.{DataFlowRunner, EnhancementRunner}
 import io.shiftleft.semanticsloader.SemanticsLoader
 
 class CpgTestFixture(projectName: String) {
-  lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", CpgLoaderConfig.default.withoutOverflow)
+  lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip",
+                                CpgLoaderConfig.default.withOverflowConfig(OnDiskOverflowConfig.disabled))
   new EnhancementRunner().run(cpg, new SerializedCpg())
   new DataFlowRunner(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg());
   implicit val graph: Graph = cpg.graph

--- a/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
+++ b/cpgqueryingtests/src/main/scala/io/shiftleft/cpgqueryingtests/codepropertygraph/CpgTestFixture.scala
@@ -7,7 +7,7 @@ import io.shiftleft.layers.{DataFlowRunner, EnhancementRunner}
 import io.shiftleft.semanticsloader.SemanticsLoader
 
 class CpgTestFixture(projectName: String) {
-  lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", CpgLoaderConfig.withoutOverflow)
+  lazy val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", CpgLoaderConfig.default.withoutOverflow)
   new EnhancementRunner().run(cpg, new SerializedCpg())
   new DataFlowRunner(SemanticsLoader.emptySemantics).run(cpg, new SerializedCpg());
   implicit val graph: Graph = cpg.graph

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
@@ -1,11 +1,11 @@
 package io.shiftleft.cpgvalidator
 
-import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
+import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig, OnDiskOverflowConfig}
 
 object CpgValidatorMain extends App {
   val cpgFileName = args(0)
 
-  val loaderConfig = new CpgLoaderConfig(createIndexes = true, onDiskOverflowConfig = None)
+  val loaderConfig = CpgLoaderConfig.default.withOverflowConfig(OnDiskOverflowConfig.disabled)
   val cpg = CpgLoader.load(cpgFileName, loaderConfig)
 
   val validator = new CpgValidator(cpg)

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 object CpgValidatorMain extends App {
   val cpgFileName = args(0)
 
-  val loaderConfig = new CpgLoaderConfig(createIndices = true, onDiskOverflowConfig = None)
+  val loaderConfig = new CpgLoaderConfig(createIndexes = true, onDiskOverflowConfig = None)
   val cpg = CpgLoader.load(cpgFileName, loaderConfig)
 
   val validator = new CpgValidator(cpg)

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 object CpgValidatorMain extends App {
   val cpgFileName = args(0)
 
-  val loaderConfig = new CpgLoaderConfig(createIndices = true, onDiskOverflowConfig = None, ignoredProtoEntries = None)
+  val loaderConfig = new CpgLoaderConfig(createIndices = true, onDiskOverflowConfig = None)
   val cpg = CpgLoader.load(cpgFileName, loaderConfig)
 
   val validator = new CpgValidator(cpg)

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
@@ -9,7 +9,7 @@ import io.shiftleft.semanticsloader.SemanticsLoader
 import org.apache.tinkerpop.gremlin.structure.Graph
 
 class Fixture(projectName: String) {
-  val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", CpgLoaderConfig.withoutOverflow)
+  val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", CpgLoaderConfig.default.withoutOverflow)
   new EnhancementRunner().run(cpg, new SerializedCpg())
   new DataFlowRunner(SemanticsLoader.emptySemantics)
   val scalaGraph: ScalaGraph = cpg.graph

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/Fixture.scala
@@ -2,14 +2,15 @@ package io.shiftleft.semanticcpg
 
 import gremlin.scala._
 import io.shiftleft.SerializedCpg
-import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
+import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig, OnDiskOverflowConfig}
 import io.shiftleft.passes.methoddecorations.MethodDecoratorPass
 import io.shiftleft.layers.{DataFlowRunner, EnhancementRunner}
 import io.shiftleft.semanticsloader.SemanticsLoader
 import org.apache.tinkerpop.gremlin.structure.Graph
 
 class Fixture(projectName: String) {
-  val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip", CpgLoaderConfig.default.withoutOverflow)
+  val cpg = CpgLoader.load(s"resources/cpgs/$projectName/cpg.bin.zip",
+                           CpgLoaderConfig.default.withOverflowConfig(OnDiskOverflowConfig.disabled))
   new EnhancementRunner().run(cpg, new SerializedCpg())
   new DataFlowRunner(SemanticsLoader.emptySemantics)
   val scalaGraph: ScalaGraph = cpg.graph


### PR DESCRIPTION
I am currently documenting `CpgLoader`, and I found that following problems:
- there was no nice way of disabling indices and overflow at the same time, or in general, to take default values and change a subset of the config options
- `ignoredProtoEntries` is not required anymore. This feature was never documented, so I doubt customers are using it.

This PR adds methods to the `CpgLoaderConfig` to allow for a builder-like Config construction. It also removes `ignoredProtoEntries`. The methods `withStorage` and ``withoutStorage` in the `CpgLoaderConfig` object are kept but deprecated.