### PR TITLE
Improvements for AST traversals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         secure: z5qFzk8TezOPD/KUseNsP1hbf4UQb4WwxazAaQq8kK96jSdkfWefqCBF06MOzHz4xuLFvY6MdYJqB+ySLS9qmH4xSyQDZUkoD8pEY7Esa9gjw4P1mZn4efkFYVSoGrugbEHRYJU+5on6d3S+agyfaJMtlRIVGDFqnPWvyVoWsH20hJM+uIOb80Lo1oRqJ+YIVuuPTrN2NEBIqSny1gy7p4wUp5y5piLC3Qjq+wfVTaXEpaGVMfhjzf0wcbeFoxHHmoAnFT4WIDzyD3z//7zFnspMZb63JRfcooEMjWBpeGJeNPCnN9k3mmsKjOTZ9716i/8HL/dPPLBE6h/zKRxseBQU7fnKItPdYOSmaoOY3M8VTCTRNzPZm4pmunCn8I+dtJ+UiixYthc8SM9fWiewmpLA9gvCAm8yTZ9NxUu/k84vOgARUqlisVBcSRaLrxeg2BSSAnKkRcjWdXV8rklrBN4LN3BN736HGPinTK6b1TjncOljpsRsTPI+ZKmMl2QSoJSfNHT5veqiwfS2kzq3NNn7ka9yenmUwfE407kwe5HuLb23VDbUGw+yjRxMN0glcXpwRSAjEtIR2ZriET3GB+JQGLtILMrgKplSs4WmCNYqVArbpSIGUb9gM5rZOguXcCUFbPMxp5wK3lKMQLIwqbqp1ubEl/3DuPfnfKYk8wo=
 
   - language: scala
-    jdk: oraclejdk8
+    jdk: openjdk8
     branches:
       only:
       - master

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -65,7 +65,7 @@
 
         {"id" : 38,
          "name": "FILE",
-         "keys": ["NAME"],
+         "keys": ["NAME", "ORDER"],
          "comment": "Node representing a source file. Often also the AST root",
          "outEdges": [
              {"edgeName": "AST", "inNodes": ["NAMESPACE_BLOCK"]}
@@ -77,7 +77,7 @@
 
         {"id" : 1, "name" : "METHOD",
          "keys": ["NAME", "FULL_NAME", "SIGNATURE", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME",
-           "LINE_NUMBER", "COLUMN_NUMBER"],
+		  "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
          "comment" : "A method/function/procedure",
          "is": ["DECLARATION", "CFG_NODE", "AST_NODE"],
          "outEdges" : [
@@ -94,12 +94,12 @@
         },
 
         {"id" : 3, "name" : "METHOD_RETURN",
-         "keys": ["CODE", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": ["CODE", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
          "comment" : "A formal method return",
          "is": ["CFG_NODE", "TRACKING_POINT"]
         },
         {"id" : 300, "name" : "MODIFIER",
-         "keys" : ["MODIFIER_TYPE"],
+         "keys" : ["MODIFIER_TYPE", "ORDER"],
          "comment" : "A modifier, e.g., static, public, private",
          "outEdges": [],
 	 "is" : ["AST_NODE"]
@@ -115,7 +115,7 @@
          ]
         },
         {"id" : 46, "name" : "TYPE_DECL",
-         "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME", "ALIAS_TYPE_FULL_NAME"],
+         "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME", "ALIAS_TYPE_FULL_NAME", "ORDER"],
          "comment" : "A type declaration",
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["TYPE_PARAMETER", "MEMBER", "MODIFIER"]},
@@ -130,7 +130,7 @@
 	 "is" : ["AST_NODE"]
         },
         {"id" : 48, "name" : "TYPE_ARGUMENT",
-         "keys" : [],
+         "keys" : ["ORDER"],
          "comment" : "Argument for a TYPE_PARAMETER that belongs to a TYPE or METHOD_INST. It binds another TYPE to a TYPE_PARAMETER",
          "outEdges" : [
              {"edgeName": "REF", "inNodes": ["TYPE"]},
@@ -140,7 +140,7 @@
         },
 
         {"id" : 9, "name" : "MEMBER",
-         "keys" : [ "CODE", "NAME", "TYPE_FULL_NAME"],
+         "keys" : [ "CODE", "NAME", "TYPE_FULL_NAME", "ORDER"],
          "comment" : "Member of a class struct or union",
          "is": ["DECLARATION", "AST_NODE"]
         },
@@ -148,7 +148,7 @@
         {
             "id":41,
             "name": "NAMESPACE_BLOCK",
-            "keys": ["NAME", "FULL_NAME"],
+            "keys": ["NAME", "FULL_NAME", "ORDER"],
             "comment": "A reference to a namespace",
 	    "is" : ["AST_NODE"]
         },
@@ -175,7 +175,7 @@
          ]
         },
         {"id":23, "name" : "LOCAL",
-         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
          "comment": "A local variable",
          "is": ["DECLARATION", "LOCAL_LIKE", "AST_NODE"]
         },
@@ -207,7 +207,7 @@
          ]
         },
         {"id":32, "name":"METHOD_INST",
-         "keys":["NAME", "FULL_NAME", "SIGNATURE", "METHOD_FULL_NAME"],
+         "keys":["NAME", "FULL_NAME", "SIGNATURE", "METHOD_FULL_NAME", "ORDER"],
          "comment":"A method instance which always has to reference a method and may have type argument children if the referred to method is a template",
          "outEdges": [
              {"edgeName": "AST", "inNodes": ["TYPE_ARGUMENT"]}
@@ -265,7 +265,7 @@
       { "name" : "CFG_NODE", "comment" : "Any node that can occur as part of a control flow graph", "hasKeys" : ["LINE_NUMBER", "COLUMN_NUMBER"], "extends": ["WITHIN_METHOD", "AST_NODE"]},
       { "name" : "TRACKING_POINT", "comment" : "Any node that can occur in a data flow", "hasKeys" : [], "extends": ["WITHIN_METHOD"]},
       { "name" : "WITHIN_METHOD", "comment" : "Any node that can exist in a method", "hasKeys" : []},
-      { "name" : "AST_NODE", "comment": "Any node that can exist in an abstract syntax tree.", "hasKeys" : []},
+      { "name" : "AST_NODE", "comment": "Any node that can exist in an abstract syntax tree.", "hasKeys" : ["ORDER"]},
       { "name" : "CALL_REPR", "comment": "Call representation", "hasKeys" : ["CODE", "NAME", "SIGNATURE"], "extends": []}
     ],
 

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -13,7 +13,7 @@
     "nodeTypes" : [
       {
         "id":307,"name" : "IMPLICIT_CALL",
-        "keys" : ["CODE", "NAME", "SIGNATURE", "LINE_NUMBER", "COLUMN_NUMBER"],
+          "keys" : ["CODE", "NAME", "SIGNATURE", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
         "comment" : "An implicit call site hidden in a method indicated by METHOD_MAP policy entries",
         "is": ["CALL_REPR", "CFG_NODE", "TRACKING_POINT"],
         "outEdges" : []
@@ -27,7 +27,7 @@
         {
             "id":40,
             "name": "NAMESPACE",
-            "keys": ["NAME"],
+            "keys": ["NAME", "ORDER"],
             "comment": "This node represents a namespace as a whole whereas the NAMESPACE_BLOCK is used for each grouping occurrence of a namespace in code. Single representing NAMESPACE node is required for easier navigation in the query language",
           "is" : ["AST_NODE"],
           "outEdges": []

--- a/codepropertygraph/src/main/resources/schemas/java-specific.json
+++ b/codepropertygraph/src/main/resources/schemas/java-specific.json
@@ -10,7 +10,7 @@
         // This is only intended for Java.
 
         {"id" : 5, "name" : "ANNOTATION",
-         "keys": ["CODE", "NAME", "FULL_NAME"],
+         "keys": ["CODE", "NAME", "FULL_NAME", "ORDER"],
          "comment" : "A method annotation",
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["ANNOTATION_PARAMETER_ASSIGN"]}
@@ -19,7 +19,7 @@
         },
 
         {"id" : 6, "name" : "ANNOTATION_PARAMETER_ASSIGN",
-         "keys" : ["CODE"],
+         "keys" : ["CODE", "ORDER"],
          "comment" : "Assignment of annotation argument to annotation parameter",
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["ANNOTATION_PARAMETER", "ARRAY_INITIALIZER", "ANNOTATION_LITERAL", "ANNOTATION"]}
@@ -28,7 +28,7 @@
         },
 
         {"id" : 7, "name" : "ANNOTATION_PARAMETER",
-         "keys" : ["CODE"],
+         "keys" : ["CODE", "ORDER"],
          "comment" : "Formal annotation parameter",
          "outEdges": [],
           "is" : ["AST_NODE"]

--- a/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/ControlStructure.scala
+++ b/query-primitives/src/main/scala/io/shiftleft/queryprimitives/steps/types/expressions/ControlStructure.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.queryprimitives.steps.types.expressions
 
-import gremlin.scala.GremlinScala
+import gremlin.scala.{BranchCase, BranchOtherwise, GremlinScala}
 import io.shiftleft.codepropertygraph.generated.{NodeKeys, nodes}
 import io.shiftleft.queryprimitives.steps.NodeSteps
 import io.shiftleft.queryprimitives.steps.types.expressions.generalizations.{AstNode, Expression, ExpressionBase}
@@ -25,8 +25,23 @@ class ControlStructure[Labels <: HList](raw: GremlinScala.Aux[nodes.ControlStruc
   /**
     * The expression introduced by this control structure, if any
     * */
-  def condition: Expression[Labels] =
-    new Expression(raw.out.has(NodeKeys.ORDER, new Integer(1)).cast[nodes.Expression])
+  def condition: Expression[Labels] = {
+    new Expression(
+      // I wanted to use flatmap here instead of
+      // map ... filterOnEnd(_.isDefined).map(_.get)
+      // not quite sure why it doesn't work.
+      map { node =>
+        if (isForLoop(node)) {
+          node.start.astChildren.order(2).headOption
+        } else {
+          node.start.astChildren.order(1).headOption
+        }
+      }.filterOnEnd(_.isDefined).map(_.get).raw.cast[nodes.Expression]
+    )
+  }
+
+  private def isForLoop(node: nodes.AstNode): Boolean =
+    node.start.astChildren.l.size == 4
 
   /**
     * Only those control structures where condition matched `regex`

--- a/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -62,7 +62,8 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
       "<global>",
       None,
       None,
-      None,
+      0,
+      None
     )
     dstGraph.addNode(methodNode)
 


### PR DESCRIPTION
- Fixed `condition` for for-loops. It returned the initializer earlier
- Introduced `inAst` and `inAstMinusLeaf` to walk upwards in the AST
- Ensure that AST nodes always have an "order" property

@tuxology this should allow you the traversal you were asking for.