### PR TITLE
looks like we have broken git lfs files lying around..?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
       - master
     before_install:
     - git fetch --tags
+    - git lfs fetch --all
     - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" ]]; then
       openssl aes-256-cbc -K $encrypted_663dec309dc8_key -iv $encrypted_663dec309dc8_iv
       -in private-key.pem.enc -out private-key.pem -d; gpg --import private-key.pem;


### PR DESCRIPTION
trying to fix this issue...
```
Unable to find source for object 77aaf7becbc5bca7411a57f338d50dead70cd075dd20a5fd7b80339a6321fea6 (try running git lfs fetch --all): open /home/travis/build/ShiftLeftSecurity/codepropertygraph/resources/cpgs/expression/cpg.bin.zip: no such file or directory

error: failed to push some refs to 'https://[secure]@github.com/ShiftLeftSecurity/codepropertygraph.git'
```