### PR TITLE
fix compiler warning about null|None check

### DIFF
--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -686,7 +686,7 @@ object DomainClassCreator {
             .mkString(",\n")
 
           val baseCase = s"""
-            Map($forKeys).filterNot { case (k,v) =>
+            Map($forKeys).asInstanceOf[Map[String, Any]].filterNot { case (k,v) =>
                 v == null || v == None
               }
             """


### PR DESCRIPTION
in some cases the compiler infers that it's useless to check for both
null and None, but we don't really care. stop warning to not confuse
people