### PR TITLE
Cleanup package layout of dataflowengine

### DIFF
--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerController.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerController.scala
@@ -100,7 +100,6 @@ class CpgServerController(impl: ServerImpl, system: ActorSystem = ActorSystem())
       e.eval(s"""
                 import io.shiftleft.codepropertygraph.Cpg
                 | import io.shiftleft.semanticcpg.language._
-                | import io.shiftleft.dataflowengine.language._
                 | import io.shiftleft.semanticcpg.language.NoResolve
                 | implicit val resolver = NoResolve
                 | val cpg = aCpg.asInstanceOf[io.shiftleft.codepropertygraph.Cpg]

--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerController.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerController.scala
@@ -100,6 +100,7 @@ class CpgServerController(impl: ServerImpl, system: ActorSystem = ActorSystem())
       e.eval(s"""
                 import io.shiftleft.codepropertygraph.Cpg
                 | import io.shiftleft.semanticcpg.language._
+                | import io.shiftleft.dataflowengine.language._
                 | import io.shiftleft.semanticcpg.language.NoResolve
                 | implicit val resolver = NoResolve
                 | val cpg = aCpg.asInstanceOf[io.shiftleft.codepropertygraph.Cpg]

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/FlowPrettyPrinter.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/FlowPrettyPrinter.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.passes.dataflows.steps
+package io.shiftleft.dataflowengine.language
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Flows.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Flows.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.passes.dataflows.steps
+package io.shiftleft.dataflowengine.language
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.Steps

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.passes.dataflows.steps
+package io.shiftleft.dataflowengine.language
 
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated._

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPointMethods.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPointMethods.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.passes.dataflows.steps
+package io.shiftleft.dataflowengine.language
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.nodemethods.generalizations.TrackingPointToCfgNode

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/package.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/package.scala
@@ -1,11 +1,12 @@
-package io.shiftleft.semanticcpg.language.ext
+package io.shiftleft.dataflowengine
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.passes.dataflows.steps.{TrackingPoint, TrackingPointMethods}
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.Steps
 import shapeless.HList
 
-package object dataflowengine {
+import io.shiftleft.semanticcpg.language._
+
+package object language {
 
   // TODO MP: rather use `start` mechanism?
   // alternative: move to `nodes` package object?
@@ -21,4 +22,5 @@ package object dataflowengine {
   implicit def toTrackingPoint[NodeType <: nodes.TrackingPointBase, Labels <: HList](
       steps: Steps[NodeType, Labels]): TrackingPoint[Labels] =
     new TrackingPoint[Labels](steps.raw.cast[nodes.TrackingPoint])
+
 }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/dataflows/DataFlowRunner.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/dataflows/DataFlowRunner.scala
@@ -1,10 +1,10 @@
-package io.shiftleft.passes.dataflows
+package io.shiftleft.dataflowengine.passes.dataflows
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.propagateedges.PropagateEdgePass
-import io.shiftleft.passes.reachingdef.ReachingDefPass
-import io.shiftleft.semanticsloader.Semantics
+import io.shiftleft.dataflowengine.passes.propagateedges.PropagateEdgePass
+import io.shiftleft.dataflowengine.passes.reachingdef.ReachingDefPass
+import io.shiftleft.dataflowengine.semanticsloader.Semantics
 
 class DataFlowRunner(semantics: Semantics) {
 

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/propagateedges/PropagateEdgePass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/propagateedges/PropagateEdgePass.scala
@@ -1,10 +1,10 @@
-package io.shiftleft.passes.propagateedges
+package io.shiftleft.dataflowengine.passes.propagateedges
 
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.passes.{CpgPass, DiffGraph}
-import io.shiftleft.semanticsloader.Semantics
+import io.shiftleft.dataflowengine.semanticsloader.Semantics
 import org.apache.logging.log4j.{LogManager, Logger}
 import org.apache.tinkerpop.gremlin.structure.Direction
 

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.passes.reachingdef
+package io.shiftleft.dataflowengine.passes.reachingdef
 
 import java.nio.file.Paths
 

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/semanticsloader/SemanticsLoader.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/semanticsloader/SemanticsLoader.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.semanticsloader
+package io.shiftleft.dataflowengine.semanticsloader
 
 import org.apache.logging.log4j.LogManager
 

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CDataFlowTests.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CDataFlowTests.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.passes.dataflows.steps
+package io.shiftleft.dataflowengine.language
 
 import io.shiftleft.semanticcpg.language._
 

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CpgDataFlowTests.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CpgDataFlowTests.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.passes.dataflows.steps
+package io.shiftleft.dataflowengine.language
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
@@ -1,11 +1,11 @@
-package io.shiftleft.passes.dataflows.steps
+package io.shiftleft.dataflowengine.language
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.dataflows.DataFlowRunner
+import io.shiftleft.dataflowengine.passes.dataflows.DataFlowRunner
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
 import io.shiftleft.semanticcpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
-import io.shiftleft.semanticsloader.SemanticsLoader
+import io.shiftleft.dataflowengine.semanticsloader.SemanticsLoader
 
 object DataFlowCodeToCpgFixture {
 

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowTests.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowTests.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.passes.dataflows.steps
+package io.shiftleft.dataflowengine.language
 
 import org.scalatest.{Matchers, WordSpec}
 import io.shiftleft.semanticcpg.language._


### PR DESCRIPTION
Cleaned up package layout of `dataflowengine` to reflect that of `semanticcpg`, that is, all code is in `io.shiftleft.$projectName`, and the language is imported via `io.shiftleft.$projectName.language._`. Finally, passes are in `io.shiftleft.$projectName.passes`. Test layout works the same way.