### PR TITLE
RIP `Labels` type parameter

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Flows.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Flows.scala
@@ -3,7 +3,7 @@ package io.shiftleft.dataflowengine.language
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.Steps
 
-class Flows(step: Steps[List[nodes.TrackingPoint], _]) {
+class Flows(step: Steps[List[nodes.TrackingPoint]]) {
   def p(): List[String] = {
     step.l.map { flow =>
       FlowPrettyPrinter.prettyPrint(flow)

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/package.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/package.scala
@@ -2,7 +2,6 @@ package io.shiftleft.dataflowengine
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.Steps
-import shapeless.HList
 
 import io.shiftleft.semanticcpg.language._
 
@@ -19,8 +18,7 @@ package object language {
   implicit def trackingPointBaseMethodsQp(node: nodes.TrackingPointBase): TrackingPointMethods =
     new TrackingPointMethods(node.asInstanceOf[nodes.TrackingPoint])
 
-  implicit def toTrackingPoint[NodeType <: nodes.TrackingPointBase, Labels <: HList](
-      steps: Steps[NodeType, Labels]): TrackingPoint[Labels] =
-    new TrackingPoint[Labels](steps.raw.cast[nodes.TrackingPoint])
+  implicit def toTrackingPoint[NodeType <: nodes.TrackingPointBase](steps: Steps[NodeType]): TrackingPoint =
+    new TrackingPoint(steps.raw.cast[nodes.TrackingPoint])
 
 }

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CpgDataFlowTests.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CpgDataFlowTests.scala
@@ -7,7 +7,6 @@ import io.shiftleft.semanticcpg.language.nodemethods.CfgNodeMethods
 import io.shiftleft.semanticcpg.language.types.expressions.Literal
 import io.shiftleft.semanticcpg.language.types.structure.{Member, Method}
 import org.scalatest.{Matchers, WordSpec}
-import shapeless.HNil
 
 class CpgDataFlowTests extends WordSpec with Matchers {
 
@@ -15,15 +14,15 @@ class CpgDataFlowTests extends WordSpec with Matchers {
     Some(x)
   }
 
-  protected def getMemberOfType(cpg: Cpg, typeName: String, memberName: String): Member[HNil] = {
+  protected def getMemberOfType(cpg: Cpg, typeName: String, memberName: String): Member = {
     cpg.typeDecl.nameExact(typeName).member.nameExact(memberName)
   }
 
-  protected def getMethodOfType(cpg: Cpg, typeName: String, methodName: String): Method[HNil] = {
+  protected def getMethodOfType(cpg: Cpg, typeName: String, methodName: String): Method = {
     cpg.typeDecl.nameExact(typeName).method.nameExact(methodName)
   }
 
-  protected def getLiteralOfType(cpg: Cpg, typeName: String, literalName: String): Literal[HNil] = {
+  protected def getLiteralOfType(cpg: Cpg, typeName: String, literalName: String): Literal = {
     cpg.typeDecl.nameExact(typeName).method.isLiteral.codeExact(literalName)
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewNodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewNodeSteps.scala
@@ -5,10 +5,8 @@ import io.shiftleft.codepropertygraph.generated.edges.ContainsNode
 import io.shiftleft.codepropertygraph.generated.EdgeKeys
 import gremlin.scala._
 import io.shiftleft.passes.DiffGraph
-import shapeless.HList
 
-class NewNodeSteps[A <: NewNode, Labels <: HList](override val raw: GremlinScala.Aux[A, Labels])
-    extends Steps[A, Labels](raw) {
+class NewNodeSteps[A <: NewNode](override val raw: GremlinScala[A]) extends Steps[A](raw) {
 
   def store()(implicit graph: DiffGraph): Unit =
     raw.sideEffect(storeRecursively).iterate()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -5,21 +5,19 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.types.structure.File
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import org.json4s.native.Serialization.{write, writePretty}
-import shapeless.HList
 
 /**
   * Steps for all node types
   *
   * This is the base class for all steps defined on nodes.
   * */
-class NodeSteps[NodeType <: nodes.StoredNode, Labels <: HList](raw: GremlinScala.Aux[NodeType, Labels])
-    extends Steps[NodeType, Labels](raw) {
+class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) extends Steps[NodeType](raw) {
 
   /**
     * Traverse to source file
     * */
-  def file: File[Labels] =
-    new File[Labels](
+  def file: File =
+    new File(
       raw
         .choose(
           _.label.is(NodeTypes.NAMESPACE),
@@ -35,8 +33,8 @@ class NodeSteps[NodeType <: nodes.StoredNode, Labels <: HList](raw: GremlinScala
       .repeat(_.in(edgeType))
       .until(_.in(edgeType).count.is(P.eq(0)))
 
-  def toMaps(): Steps[Map[String, Any], Labels] =
-    new Steps[Map[String, Any], Labels](raw.map(_.toMap))
+  def toMaps(): Steps[Map[String, Any]] =
+    new Steps[Map[String, Any]](raw.map(_.toMap))
 
   /**
     Execute traversal and convert the result to json.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -7,7 +7,6 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.structure._
-import shapeless.HNil
 
 class NodeTypeStarters(cpg: Cpg) {
 
@@ -19,122 +18,122 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all nodes.
     */
-  def all: NodeSteps[nodes.StoredNode, HNil] =
-    new NodeSteps[nodes.StoredNode, HNil](scalaGraph.V.cast[nodes.StoredNode])
+  def all: NodeSteps[nodes.StoredNode] =
+    new NodeSteps[nodes.StoredNode](scalaGraph.V.cast[nodes.StoredNode])
 
   /**
     * Traverse to all comments in source-based CPGs.
     * */
-  def comment: Comment[HNil] =
-    new Comment[HNil](scalaGraph.V.hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
+  def comment: Comment =
+    new Comment(scalaGraph.V.hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
 
   /**
     Traverse to all source files
     */
-  def file: File[HNil] =
-    new File[HNil](scalaGraph.V.hasLabel(NodeTypes.FILE).cast[nodes.File])
+  def file: File =
+    new File(scalaGraph.V.hasLabel(NodeTypes.FILE).cast[nodes.File])
 
   /**
     Traverse to all namespaces, e.g., packages in Java.
     */
-  def namespace: Namespace[HNil] =
-    new Namespace[HNil](scalaGraph.V.hasLabel(NodeTypes.NAMESPACE).cast[nodes.Namespace])
+  def namespace: Namespace =
+    new Namespace(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE).cast[nodes.Namespace])
 
   /**
   Traverse to all namespace blocks, e.g., packages in Java.
     */
-  def namespaceBlock: NamespaceBlock[HNil] =
-    new NamespaceBlock[HNil](scalaGraph.V.hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
+  def namespaceBlock: NamespaceBlock =
+    new NamespaceBlock(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
 
   /**
     Traverse to all types, e.g., Set<String>
     */
-  def types: Type[HNil] =
+  def types: Type =
     new Type(scalaGraph.V.hasLabel(NodeTypes.TYPE).cast[nodes.Type])
 
   /**
     Traverse to all declarations, e.g., Set<T>
     */
-  def typeDecl: TypeDecl[HNil] =
+  def typeDecl: TypeDecl =
     new TypeDecl(scalaGraph.V.hasLabel(NodeTypes.TYPE_DECL).cast[nodes.TypeDecl])
 
   /**
     Traverse to all methods
     */
-  def method: Method[HNil] =
+  def method: Method =
     new Method(scalaGraph.V.hasLabel(NodeTypes.METHOD).cast[nodes.Method])
 
   /**
     Traverse to all method instances
     */
-  def methodInstance: MethodInst[HNil] =
+  def methodInstance: MethodInst =
     new MethodInst(scalaGraph.V.hasLabel(NodeTypes.METHOD_INST).cast[nodes.MethodInst])
 
   /**
     Traverse to all formal return parameters
     */
-  def methodReturn: MethodReturn[HNil] =
+  def methodReturn: MethodReturn =
     new MethodReturn(scalaGraph.V.hasLabel(NodeTypes.METHOD_RETURN).cast[nodes.MethodReturn])
 
   /**
     Traverse to all input parameters
     */
-  def parameter: MethodParameter[HNil] =
+  def parameter: MethodParameter =
     new MethodParameter(scalaGraph.V.hasLabel(NodeTypes.METHOD_PARAMETER_IN).cast[nodes.MethodParameterIn])
 
   /**
     Traverse to all class members
     */
-  def member: Member[HNil] =
+  def member: Member =
     new Member(scalaGraph.V.hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
 
   /**
     Traverse to all call sites
     */
-  def call: Call[HNil] =
+  def call: Call =
     new Call(scalaGraph.V.hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**
     Traverse to all local variable declarations
 
     */
-  def local: Local[HNil] =
+  def local: Local =
     new Local(scalaGraph.V.hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
   /**
     Traverse to all literals (constant strings and numbers provided directly in the code).
     */
-  def literal: Literal[HNil] =
+  def literal: Literal =
     new Literal(scalaGraph.V.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
   /**
     Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
     */
-  def identifier: Identifier[HNil] =
+  def identifier: Identifier =
     new Identifier(scalaGraph.V.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     Traverse to all arguments passed to methods
     */
-  def argument: Expression[HNil] =
+  def argument: Expression =
     call.argument
 
   /**
     * Traverse to all meta data entries
     */
-  def metaData: MetaData[HNil] =
+  def metaData: MetaData =
     new MetaData(scalaGraph.V.hasLabel(NodeTypes.META_DATA).cast[nodes.MetaData])
 
   /**
     * Traverse to all method references
     * */
-  def methodRef: MethodRef[HNil] =
+  def methodRef: MethodRef =
     new MethodRef(scalaGraph.V.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
 
   /**
   Begin traversal at set of nodes - specified by their ids
     */
-  def atVerticesWithId[NodeType <: nodes.StoredNode](ids: Seq[Any]): NodeSteps[NodeType, HNil] =
-    if (ids.size == 0) new NodeSteps[NodeType, HNil](scalaGraph.V(-1).cast[NodeType])
-    else new NodeSteps[NodeType, HNil](scalaGraph.V(ids: _*).cast[NodeType])
+  def atVerticesWithId[NodeType <: nodes.StoredNode](ids: Seq[Any]): NodeSteps[NodeType] =
+    if (ids.size == 0) new NodeSteps[NodeType](scalaGraph.V(-1).cast[NodeType])
+    else new NodeSteps[NodeType](scalaGraph.V(ids: _*).cast[NodeType])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.AstNode
-import shapeless.HNil
 
 import io.shiftleft.semanticcpg.language._
 
@@ -11,12 +10,12 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
   /**
     * All nodes of the abstract syntax tree rooted in this node
     * */
-  def ast: AstNode[HNil] = node.start.ast
+  def ast: AstNode = node.start.ast
 
   /**
     * All nodes of the abstract syntax tree rooted in this node,
     * minus this node.
     * */
-  def astMinusRoot: AstNode[HNil] = node.start.astMinusRoot
+  def astMinusRoot: AstNode = node.start.astMinusRoot
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -8,7 +8,6 @@ import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CfgNodeMet
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
-import shapeless.{HList, HNil}
 
 /**
   Language for traversing the code property graph
@@ -32,87 +31,84 @@ package object language {
   // then you need to add an implicit conversion from `Steps[NodeType,Labels]` to your type
   // here.
 
-  implicit def toLiteral[Labels <: HList](steps: Steps[nodes.Literal, Labels]): Literal[Labels] =
-    new Literal[Labels](steps.raw)
+  implicit def toLiteral(steps: Steps[nodes.Literal]): Literal =
+    new Literal(steps.raw)
 
-  implicit def toType[Labels <: HList](steps: Steps[nodes.Type, Labels]): Type[Labels] =
-    new Type[Labels](steps.raw)
+  implicit def toType(steps: Steps[nodes.Type]): Type =
+    new Type(steps.raw)
 
-  implicit def toTypeDecl[Labels <: HList](steps: Steps[nodes.TypeDecl, Labels]): TypeDecl[Labels] =
-    new TypeDecl[Labels](steps.raw)
+  implicit def toTypeDecl(steps: Steps[nodes.TypeDecl]): TypeDecl =
+    new TypeDecl(steps.raw)
 
-  implicit def toCall[Labels <: HList](steps: Steps[nodes.Call, Labels]): Call[Labels] =
-    new Call[Labels](steps.raw)
+  implicit def toCall(steps: Steps[nodes.Call]): Call =
+    new Call(steps.raw)
 
-  implicit def toControlStructure[Labels <: HList](
-      steps: Steps[nodes.ControlStructure, Labels]): ControlStructure[Labels] =
-    new ControlStructure[Labels](steps.raw)
+  implicit def toControlStructure(steps: Steps[nodes.ControlStructure]): ControlStructure =
+    new ControlStructure(steps.raw)
 
-  implicit def toIdentifier[Labels <: HList](steps: Steps[nodes.Identifier, Labels]): Identifier[Labels] =
-    new Identifier[Labels](steps.raw)
+  implicit def toIdentifier(steps: Steps[nodes.Identifier]): Identifier =
+    new Identifier(steps.raw)
 
-  implicit def toMember[Labels <: HList](steps: Steps[nodes.Member, Labels]): Member[Labels] =
-    new Member[Labels](steps.raw)
+  implicit def toMember(steps: Steps[nodes.Member]): Member =
+    new Member(steps.raw)
 
-  implicit def toLocal[Labels <: HList](steps: Steps[nodes.Local, Labels]): Local[Labels] =
-    new Local[Labels](steps.raw)
+  implicit def toLocal(steps: Steps[nodes.Local]): Local =
+    new Local(steps.raw)
 
-  implicit def toMethodInst[Labels <: HList](steps: Steps[nodes.MethodInst, Labels]): MethodInst[Labels] =
-    new MethodInst[Labels](steps.raw)
+  implicit def toMethodInst(steps: Steps[nodes.MethodInst]): MethodInst =
+    new MethodInst(steps.raw)
 
-  implicit def toMethod[Labels <: HList](steps: Steps[nodes.Method, Labels]): Method[Labels] =
-    new Method[Labels](steps.raw)
+  implicit def toMethod(steps: Steps[nodes.Method]): Method =
+    new Method(steps.raw)
 
-  implicit def toMethodParameter[Labels <: HList](
-      steps: Steps[nodes.MethodParameterIn, Labels]): MethodParameter[Labels] =
-    new MethodParameter[Labels](steps.raw)
+  implicit def toMethodParameter(steps: Steps[nodes.MethodParameterIn]): MethodParameter =
+    new MethodParameter(steps.raw)
 
-  implicit def toMethodParameterOut[Labels <: HList](
-      steps: Steps[nodes.MethodParameterOut, Labels]): MethodParameterOut[Labels] =
-    new MethodParameterOut[Labels](steps.raw)
+  implicit def toMethodParameterOut(steps: Steps[nodes.MethodParameterOut]): MethodParameterOut =
+    new MethodParameterOut(steps.raw)
 
-  implicit def toMethodReturn[Labels <: HList](steps: Steps[nodes.MethodReturn, Labels]): MethodReturn[Labels] =
-    new MethodReturn[Labels](steps.raw)
+  implicit def toMethodReturn(steps: Steps[nodes.MethodReturn]): MethodReturn =
+    new MethodReturn(steps.raw)
 
-  implicit def toNamespace[Labels <: HList](steps: Steps[nodes.Namespace, Labels]): Namespace[Labels] =
-    new Namespace[Labels](steps.raw)
+  implicit def toNamespace(steps: Steps[nodes.Namespace]): Namespace =
+    new Namespace(steps.raw)
 
-  implicit def toNamespaceBlock[Labels <: HList](steps: Steps[nodes.NamespaceBlock, Labels]): NamespaceBlock[Labels] =
-    new NamespaceBlock[Labels](steps.raw)
+  implicit def toNamespaceBlock(steps: Steps[nodes.NamespaceBlock]): NamespaceBlock =
+    new NamespaceBlock(steps.raw)
 
-  implicit def toModifier[Labels <: HList](steps: Steps[nodes.Modifier, Labels]): Modifier[Labels] =
-    new Modifier[Labels](steps.raw)
+  implicit def toModifier(steps: Steps[nodes.Modifier]): Modifier =
+    new Modifier(steps.raw)
 
-  implicit def toExpression[Labels <: HList](steps: Steps[nodes.Expression, Labels]): Expression[Labels] =
-    new Expression[Labels](steps.raw)
+  implicit def toExpression(steps: Steps[nodes.Expression]): Expression =
+    new Expression(steps.raw)
 
-  implicit def toDeclaration[Labels <: HList](steps: Steps[nodes.Declaration, Labels]): Declaration[Labels] =
-    new Declaration[Labels](steps.raw)
+  implicit def toDeclaration(steps: Steps[nodes.Declaration]): Declaration =
+    new Declaration(steps.raw)
 
-  implicit def toCfgNode[Labels <: HList](steps: Steps[nodes.CfgNode, Labels]): CfgNode[Labels] =
-    new CfgNode[Labels](steps.raw)
+  implicit def toCfgNode(steps: Steps[nodes.CfgNode]): CfgNode =
+    new CfgNode(steps.raw)
 
-  implicit def toAstNode[Labels <: HList](steps: Steps[nodes.AstNode, Labels]): AstNode[Labels] =
-    new AstNode[Labels](steps.raw)
+  implicit def toAstNode(steps: Steps[nodes.AstNode]): AstNode =
+    new AstNode(steps.raw)
 
-  implicit def toFile[Labels <: HList](steps: Steps[nodes.File, Labels]): File[Labels] =
-    new File[Labels](steps.raw)
+  implicit def toFile(steps: Steps[nodes.File]): File =
+    new File(steps.raw)
 
-  implicit def toBlock[Labels <: HList](steps: Steps[nodes.Block, Labels]): Block[Labels] =
-    new Block[Labels](steps.raw)
+  implicit def toBlock(steps: Steps[nodes.Block]): Block =
+    new Block(steps.raw)
 
-  implicit class GremlinScalaDeco[End, Labels <: HList](raw: GremlinScala.Aux[End, Labels]) {
+  implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing
      * from a known nodeType via AST edges, so we have to cast */
-    def cast[NodeType]: GremlinScala.Aux[NodeType, Labels] =
-      raw.asInstanceOf[GremlinScala.Aux[NodeType, Labels]]
+    def cast[NodeType]: GremlinScala[NodeType] =
+      raw.asInstanceOf[GremlinScala[NodeType]]
   }
 
   implicit def toNodeTypeStarters(cpg: Cpg): NodeTypeStarters =
     new NodeTypeStarters(cpg)
 
   private def newAnonymousTraversalWithAssociatedGraph[NodeType <: StoredNode](
-      seq: NodeType*): GremlinScala.Aux[NodeType, HNil] = {
+      seq: NodeType*): GremlinScala[NodeType] = {
     val anonymousTraversal = __[NodeType](seq: _*)
     if (seq.nonEmpty) {
       anonymousTraversal.traversal.asAdmin().setGraph(seq.head.graph)
@@ -125,8 +121,8 @@ package object language {
     /**
     Start a new traversal from this node
       */
-    def start: NodeSteps[NodeType, HNil] =
-      new NodeSteps[NodeType, HNil](newAnonymousTraversalWithAssociatedGraph(node))
+    def start: NodeSteps[NodeType] =
+      new NodeSteps[NodeType](newAnonymousTraversalWithAssociatedGraph(node))
   }
 
   implicit class NodeTypeDecoForSeq[NodeType <: nodes.StoredNode](seq: Seq[NodeType]) {
@@ -134,8 +130,8 @@ package object language {
     /**
     Start a new traversal from these nodes
       */
-    def start: NodeSteps[NodeType, HNil] =
-      new NodeSteps[NodeType, HNil](newAnonymousTraversalWithAssociatedGraph(seq: _*))
+    def start: NodeSteps[NodeType] =
+      new NodeSteps[NodeType](newAnonymousTraversalWithAssociatedGraph(seq: _*))
   }
 
   implicit class NewNodeTypeDeco[NodeType <: nodes.NewNode](node: NodeType) {
@@ -143,8 +139,8 @@ package object language {
     /**
     Start a new traversal from this node
       */
-    def start: NewNodeSteps[NodeType, HNil] =
-      new NewNodeSteps[NodeType, HNil](__[NodeType](node))
+    def start: NewNodeSteps[NodeType] =
+      new NewNodeSteps[NodeType](__[NodeType](node))
   }
 
   implicit class NewNodeTypeDecoForSeq[NodeType <: nodes.NewNode](seq: Seq[NodeType]) {
@@ -152,8 +148,8 @@ package object language {
     /**
     Start a new traversal from these nodes
       */
-    def start: NewNodeSteps[NodeType, HNil] =
-      new NewNodeSteps[NodeType, HNil](__[NodeType](seq: _*))
+    def start: NewNodeSteps[NodeType] =
+      new NewNodeSteps[NodeType](__[NodeType](seq: _*))
   }
 
   implicit class BaseNodeTypeDeco[NodeType <: nodes.Node](node: NodeType) {
@@ -161,8 +157,8 @@ package object language {
     /**
     Start a new traversal from this node
       */
-    def start: Steps[NodeType, HNil] =
-      new Steps[NodeType, HNil](__[NodeType](node))
+    def start: Steps[NodeType] =
+      new Steps[NodeType](__[NodeType](node))
   }
 
   implicit class BaseNodeTypeDecoForSeq[NodeType <: nodes.Node](seq: Seq[NodeType]) {
@@ -170,8 +166,8 @@ package object language {
     /**
     Start a new traversal from these nodes
       */
-    def start: Steps[NodeType, HNil] =
-      new Steps[NodeType, HNil](__[NodeType](seq: _*))
+    def start: Steps[NodeType] =
+      new Steps[NodeType](__[NodeType](seq: _*))
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -8,50 +8,49 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.structure.{Member, Method, MethodInst, MethodReturn}
-import shapeless.HList
 
 /**
   A call site
   */
-class Call[Labels <: HList](raw: GremlinScala.Aux[nodes.Call, Labels])
-    extends NodeSteps[nodes.Call, Labels](raw)
-    with CodeAccessors[nodes.Call, Labels]
-    with NameAccessors[nodes.Call, Labels]
-    with OrderAccessors[nodes.Call, Labels]
-    with SignatureAccessors[nodes.Call, Labels]
-    with DispatchTypeAccessors[nodes.Call, Labels]
-    with LineNumberAccessors[nodes.Call, Labels]
-    with EvalTypeAccessors[nodes.Call, Labels]
-    with ExpressionBase[nodes.Call, Labels] {
+class Call(raw: GremlinScala[nodes.Call])
+    extends NodeSteps[nodes.Call](raw)
+    with CodeAccessors[nodes.Call]
+    with NameAccessors[nodes.Call]
+    with OrderAccessors[nodes.Call]
+    with SignatureAccessors[nodes.Call]
+    with DispatchTypeAccessors[nodes.Call]
+    with LineNumberAccessors[nodes.Call]
+    with EvalTypeAccessors[nodes.Call]
+    with ExpressionBase[nodes.Call] {
 
   /**
     Only statically dispatched calls
     */
-  def isStatic: Call[Labels] = dispatchType("STATIC_DISPATCH")
+  def isStatic: Call = dispatchType("STATIC_DISPATCH")
 
   /**
     Only dynamically dispatched calls
     */
-  def isDynamic: Call[Labels] = dispatchType("DYNAMIC_DISPATCH")
+  def isDynamic: Call = dispatchType("DYNAMIC_DISPATCH")
 
   /**
     The caller
     */
-  override def method: Method[Labels] =
-    new Method[Labels](raw.in(EdgeTypes.CONTAINS).hasLabel(NodeTypes.METHOD).cast[nodes.Method])
+  override def method: Method =
+    new Method(raw.in(EdgeTypes.CONTAINS).hasLabel(NodeTypes.METHOD).cast[nodes.Method])
 
   /**
     The callee method
     */
-  def calledMethod(implicit callResolver: ICallResolver): Method[Labels] = {
+  def calledMethod(implicit callResolver: ICallResolver): Method = {
     calledMethodInstance(callResolver).method
   }
 
   /**
    The callee method instance
     */
-  def calledMethodInstance(implicit callResolver: ICallResolver): MethodInst[Labels] =
-    new MethodInst[Labels](
+  def calledMethodInstance(implicit callResolver: ICallResolver): MethodInst =
+    new MethodInst(
       sideEffect(callResolver.resolveDynamicCallSite).raw
         .out(EdgeTypes.CALL)
         .cast[nodes.MethodInst])
@@ -59,20 +58,20 @@ class Call[Labels <: HList](raw: GremlinScala.Aux[nodes.Call, Labels])
   /**
     Arguments of the call
     */
-  def argument: Expression[Labels] =
-    new Expression[Labels](raw.out(EdgeTypes.AST).cast[nodes.Expression])
+  def argument: Expression =
+    new Expression(raw.out(EdgeTypes.AST).cast[nodes.Expression])
 
   /**
     `i'th` arguments of the call
     */
-  def argument(i: Integer): Expression[Labels] =
+  def argument(i: Integer): Expression =
     argument.order(i)
 
   /**
     To formal method return parameter
     */
-  def toMethodReturn: MethodReturn[Labels] =
-    new MethodReturn[Labels](
+  def toMethodReturn: MethodReturn =
+    new MethodReturn(
       raw
         .out(EdgeTypes.CALL)
         .out(EdgeTypes.REF)
@@ -83,7 +82,7 @@ class Call[Labels <: HList](raw: GremlinScala.Aux[nodes.Call, Labels])
   /**
     * Traverse to referenced members
     * */
-  def referencedMember: Member[Labels] = new Member(
+  def referencedMember: Member = new Member(
     raw.out(EdgeTypes.REF).cast[nodes.Member]
   )
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{AstNode, Expression, ExpressionBase}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.ParserTypeNameAccessors
 import io.shiftleft.semanticcpg.language._
-import shapeless.HList
 
 object ControlStructure {
 
@@ -14,30 +13,30 @@ object ControlStructure {
 
 }
 
-class ControlStructure[Labels <: HList](raw: GremlinScala.Aux[nodes.ControlStructure, Labels])
-    extends NodeSteps[nodes.ControlStructure, Labels](raw)
-    with ParserTypeNameAccessors[nodes.ControlStructure, Labels]
-    with ExpressionBase[nodes.ControlStructure, Labels] {
+class ControlStructure(raw: GremlinScala[nodes.ControlStructure])
+    extends NodeSteps[nodes.ControlStructure](raw)
+    with ParserTypeNameAccessors[nodes.ControlStructure]
+    with ExpressionBase[nodes.ControlStructure] {
 
   import ControlStructure._
 
   /**
     * The expression introduced by this control structure, if any
     * */
-  def condition: Expression[Labels] =
+  def condition: Expression =
     new Expression(raw.out(EdgeTypes.CONDITION).cast[nodes.Expression])
 
   /**
     * Only those control structures where condition matched `regex`
     * */
-  def condition(regex: String): ControlStructure[Labels] =
+  def condition(regex: String): ControlStructure =
     new ControlStructure(this.filterOnEnd(_.code.matches(regex)).raw)
 
-  def whenTrue: AstNode[Labels] = new AstNode(
+  def whenTrue: AstNode = new AstNode(
     raw.out.has(NodeKeys.ORDER, secondChildIndex).cast[nodes.AstNode]
   )
 
-  def whenFalse: AstNode[Labels] = new AstNode(
+  def whenFalse: AstNode = new AstNode(
     raw.out.has(NodeKeys.ORDER, thirdChildIndex).cast[nodes.AstNode]
   )
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
@@ -6,24 +6,23 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
-import shapeless.HList
 
 /**
   An identifier, e.g., an instance of a local variable, or a temporary variable
   */
-class Identifier[Labels <: HList](raw: GremlinScala.Aux[nodes.Identifier, Labels])
-    extends NodeSteps[nodes.Identifier, Labels](raw)
-    with ExpressionBase[nodes.Identifier, Labels]
-    with CodeAccessors[nodes.Identifier, Labels]
-    with NameAccessors[nodes.Identifier, Labels]
-    with OrderAccessors[nodes.Identifier, Labels]
-    with LineNumberAccessors[nodes.Identifier, Labels]
-    with EvalTypeAccessors[nodes.Identifier, Labels] {
+class Identifier(raw: GremlinScala[nodes.Identifier])
+    extends NodeSteps[nodes.Identifier](raw)
+    with ExpressionBase[nodes.Identifier]
+    with CodeAccessors[nodes.Identifier]
+    with NameAccessors[nodes.Identifier]
+    with OrderAccessors[nodes.Identifier]
+    with LineNumberAccessors[nodes.Identifier]
+    with EvalTypeAccessors[nodes.Identifier] {
 
   /**
     * Traverse to all declarations of this identifier
     * */
-  def refsTo: Declaration[Labels] =
-    new Declaration[Labels](raw.out(EdgeTypes.REF).cast[nodes.Declaration])
+  def refsTo: Declaration =
+    new Declaration(raw.out(EdgeTypes.REF).cast[nodes.Declaration])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
@@ -6,23 +6,22 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 import io.shiftleft.semanticcpg.language.types.structure.Method
-import shapeless.HList
 
 /**
   A literal, e.g., a constant string or number
   */
-class Literal[Labels <: HList](raw: GremlinScala.Aux[nodes.Literal, Labels])
-    extends NodeSteps[nodes.Literal, Labels](raw)
-    with ExpressionBase[nodes.Literal, Labels]
-    with CodeAccessors[nodes.Literal, Labels]
-    with LineNumberAccessors[nodes.Literal, Labels]
-    with EvalTypeAccessors[nodes.Literal, Labels] {
+class Literal(raw: GremlinScala[nodes.Literal])
+    extends NodeSteps[nodes.Literal](raw)
+    with ExpressionBase[nodes.Literal]
+    with CodeAccessors[nodes.Literal]
+    with LineNumberAccessors[nodes.Literal]
+    with EvalTypeAccessors[nodes.Literal] {
 
   /**
     * Traverse to method hosting this literal
     * */
-  override def method: Method[Labels] =
-    new Method[Labels](
+  override def method: Method =
+    new Method(
       raw
         .cast[nodes.StoredNode]
         .repeat(_.in(EdgeTypes.AST).cast[nodes.StoredNode])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRef.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRef.scala
@@ -5,10 +5,9 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.ExpressionBase
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{LineNumberAccessors, MethodInstFullNameAccessors}
-import shapeless.HList
 
-class MethodRef[Labels <: HList](raw: GremlinScala.Aux[nodes.MethodRef, Labels])
-    extends NodeSteps[nodes.MethodRef, Labels](raw)
-    with ExpressionBase[nodes.MethodRef, Labels]
-    with LineNumberAccessors[nodes.MethodRef, Labels]
-    with MethodInstFullNameAccessors[nodes.MethodRef, Labels] {}
+class MethodRef(raw: GremlinScala[nodes.MethodRef])
+    extends NodeSteps[nodes.MethodRef](raw)
+    with ExpressionBase[nodes.MethodRef]
+    with LineNumberAccessors[nodes.MethodRef]
+    with MethodInstFullNameAccessors[nodes.MethodRef] {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Return.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Return.scala
@@ -10,14 +10,13 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
   LineNumberAccessors,
   OrderAccessors
 }
-import shapeless.HList
 
 // TODO: ColumnNumberAccessor missing
 
-class Return[Labels <: HList](raw: GremlinScala.Aux[nodes.Return, Labels])
-    extends NodeSteps[nodes.Return, Labels](raw)
-    with ExpressionBase[nodes.Return, Labels]
-    with LineNumberAccessors[nodes.Return, Labels]
-    with OrderAccessors[nodes.Return, Labels]
-    with ArgumentIndexAccessors[nodes.Return, Labels]
-    with CodeAccessors[nodes.Return, Labels] {}
+class Return(raw: GremlinScala[nodes.Return])
+    extends NodeSteps[nodes.Return](raw)
+    with ExpressionBase[nodes.Return]
+    with LineNumberAccessors[nodes.Return]
+    with OrderAccessors[nodes.Return]
+    with ArgumentIndexAccessors[nodes.Return]
+    with CodeAccessors[nodes.Return] {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -4,43 +4,42 @@ import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.{ICallResolver, NodeSteps}
 import io.shiftleft.semanticcpg.language.types.structure.Block
-import shapeless.HList
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.OrderAccessors
 
-class AstNode[Labels <: HList](raw: GremlinScala.Aux[nodes.AstNode, Labels])
-    extends NodeSteps[nodes.AstNode, Labels](raw)
-    with AstNodeBase[nodes.AstNode, Labels]
-    with OrderAccessors[nodes.AstNode, Labels] {}
+class AstNode(raw: GremlinScala[nodes.AstNode])
+    extends NodeSteps[nodes.AstNode](raw)
+    with AstNodeBase[nodes.AstNode]
+    with OrderAccessors[nodes.AstNode] {}
 
-trait AstNodeBase[NodeType <: nodes.AstNode, Labels <: HList] { this: NodeSteps[NodeType, Labels] =>
+trait AstNodeBase[NodeType <: nodes.AstNode] { this: NodeSteps[NodeType] =>
 
   /**
     * Nodes of the AST rooted in this node, including the node itself.
     * */
-  def ast: AstNode[Labels] = new AstNode[Labels](raw.emit.repeat(_.out(EdgeTypes.AST)).cast[nodes.AstNode])
+  def ast: AstNode = new AstNode(raw.emit.repeat(_.out(EdgeTypes.AST)).cast[nodes.AstNode])
 
   /**
     * Nodes of the AST rooted in this node, minus the node itself
     * */
-  def astMinusRoot: AstNode[Labels] = new AstNode[Labels](raw.repeat(_.out(EdgeTypes.AST)).emit.cast[nodes.AstNode])
+  def astMinusRoot: AstNode = new AstNode(raw.repeat(_.out(EdgeTypes.AST)).emit.cast[nodes.AstNode])
 
   /**
     * Direct children of node in the AST
     * */
-  def astChildren: AstNode[Labels] = new AstNode[Labels](raw.out(EdgeTypes.AST).cast[nodes.AstNode])
+  def astChildren: AstNode = new AstNode(raw.out(EdgeTypes.AST).cast[nodes.AstNode])
 
   /**
     * Parent AST node
     * */
-  def astParent: AstNode[Labels] = new AstNode[Labels](raw.in(EdgeTypes.AST).cast[nodes.AstNode])
+  def astParent: AstNode = new AstNode(raw.in(EdgeTypes.AST).cast[nodes.AstNode])
 
   /**
     * Nodes of the AST obtained by expanding AST edges backwards until the method root is reached
     * */
-  def inAst: AstNode[Labels] =
-    new AstNode[Labels](
+  def inAst: AstNode =
+    new AstNode(
       raw.emit
         .until(_.hasLabel(NodeTypes.METHOD))
         .repeat(_.in(EdgeTypes.AST))
@@ -49,8 +48,8 @@ trait AstNodeBase[NodeType <: nodes.AstNode, Labels <: HList] { this: NodeSteps[
   /**
     * Nodes of the AST obtained by expanding AST edges backwards until the method root is reached, minus this node
     * */
-  def inAstMinusLeaf: AstNode[Labels] =
-    new AstNode[Labels](
+  def inAstMinusLeaf: AstNode =
+    new AstNode(
       raw
         .until(_.hasLabel(NodeTypes.METHOD))
         .repeat(_.in(EdgeTypes.AST))
@@ -60,65 +59,65 @@ trait AstNodeBase[NodeType <: nodes.AstNode, Labels <: HList] { this: NodeSteps[
   /**
     * Traverse only to those AST nodes that are also control flow graph nodes
     * */
-  def isCfgNode: CfgNode[Labels] =
-    new CfgNode[Labels](raw.filterOnEnd(_.isInstanceOf[nodes.CfgNode]).cast[nodes.CfgNode])
+  def isCfgNode: CfgNode =
+    new CfgNode(raw.filterOnEnd(_.isInstanceOf[nodes.CfgNode]).cast[nodes.CfgNode])
 
   /**
     * Traverse only to those AST nodes that are blocks
     * */
-  def isBlock: Block[Labels] = new Block[Labels](
+  def isBlock: Block = new Block(
     raw.hasLabel(NodeTypes.BLOCK).cast[nodes.Block]
   )
 
   /**
     * Traverse only to those AST nodes that are control structures
     * */
-  def isControlStructure: ControlStructure[Labels] =
-    new ControlStructure[Labels](raw.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
+  def isControlStructure: ControlStructure =
+    new ControlStructure(raw.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
 
   /**
     * Traverse only to AST nodes that are expressions
     * */
-  def isExpression: Expression[Labels] = new Expression[Labels](
+  def isExpression: Expression = new Expression(
     raw.filterOnEnd(_.isInstanceOf[nodes.Expression]).cast[nodes.Expression]
   )
   @deprecated("replaced by isCall", "July 19")
-  def call: Call[Labels] = isCall
+  def call: Call = isCall
 
   @deprecated("replaced by isLiteral", "July 19")
-  def literal: Literal[Labels] = isLiteral
+  def literal: Literal = isLiteral
 
   /**
     * Traverse only to AST nodes that are calls
     * */
-  def isCall: Call[Labels] = new Call[Labels](
+  def isCall: Call = new Call(
     raw.hasLabel(NodeTypes.CALL).cast[nodes.Call]
   )
 
   /**
   Cast to call if applicable and filter for callee fullName `calleeRegex`
     */
-  def isCall(calleeRegex: String)(implicit callResolver: ICallResolver): Call[Labels] =
+  def isCall(calleeRegex: String)(implicit callResolver: ICallResolver): Call =
     isCall.filter(_.calledMethod.fullName(calleeRegex))
 
   /**
     * Traverse only to AST nodes that are literals
     * */
-  def isLiteral: Literal[Labels] = new Literal[Labels](
+  def isLiteral: Literal = new Literal(
     raw.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal]
   )
 
   /**
     * Traverse only to AST nodes that are identifier
     * */
-  def isIdentifier: Identifier[Labels] = new Identifier[Labels](
+  def isIdentifier: Identifier = new Identifier(
     raw.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier]
   )
 
   /**
     * Traverse only to AST nodes that are return nodes
     * */
-  def isReturnNode: Return[Labels] = new Return[Labels](
+  def isReturnNode: Return = new Return(
     raw.hasLabel(NodeTypes.RETURN).cast[nodes.Return]
   )
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -6,18 +6,17 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.CodeAccessors
 import io.shiftleft.semanticcpg.language.types.structure.Method
 import io.shiftleft.semanticcpg.utils.ExpandTo
-import shapeless.HList
 
-class CfgNode[Labels <: HList](raw: GremlinScala.Aux[nodes.CfgNode, Labels])
-    extends NodeSteps[nodes.CfgNode, Labels](raw)
-    with CodeAccessors[nodes.CfgNode, Labels]
-    with AstNodeBase[nodes.CfgNode, Labels] {
+class CfgNode(raw: GremlinScala[nodes.CfgNode])
+    extends NodeSteps[nodes.CfgNode](raw)
+    with CodeAccessors[nodes.CfgNode]
+    with AstNodeBase[nodes.CfgNode] {
 
   /**
   Traverse to enclosing method
     */
-  def method: Method[Labels] = {
-    new Method[Labels](
+  def method: Method = {
+    new Method(
       raw
         .map {
           case method: nodes.Method =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Declaration.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Declaration.scala
@@ -3,13 +3,12 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import shapeless.HList
 
-class Declaration[Labels <: HList](raw: GremlinScala.Aux[nodes.Declaration, Labels])
-    extends NodeSteps[nodes.Declaration, Labels](raw)
-    with DeclarationBase[nodes.Declaration, Labels]
+class Declaration(raw: GremlinScala[nodes.Declaration])
+    extends NodeSteps[nodes.Declaration](raw)
+    with DeclarationBase[nodes.Declaration]
 
-trait DeclarationBase[NodeType <: nodes.Declaration, Labels <: HList] {
-  this: NodeSteps[NodeType, Labels] =>
+trait DeclarationBase[NodeType <: nodes.Declaration] {
+  this: NodeSteps[NodeType] =>
   // TODO: steps for Declarations go here
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -7,34 +7,33 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.Call
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 import io.shiftleft.semanticcpg.language.types.structure.{Method, MethodParameter, Type}
-import shapeless.HList
 
 /**
   An expression (base type)
   */
-class Expression[Labels <: HList](raw: GremlinScala.Aux[nodes.Expression, Labels])
-    extends NodeSteps[nodes.Expression, Labels](raw)
-    with ExpressionBase[nodes.Expression, Labels] {}
+class Expression(raw: GremlinScala[nodes.Expression])
+    extends NodeSteps[nodes.Expression](raw)
+    with ExpressionBase[nodes.Expression] {}
 
-trait ExpressionBase[NodeType <: nodes.Expression, Labels <: HList]
-    extends OrderAccessors[NodeType, Labels]
-    with ArgumentIndexAccessors[NodeType, Labels]
-    with EvalTypeAccessors[NodeType, Labels]
-    with CodeAccessors[NodeType, Labels]
-    with LineNumberAccessors[NodeType, Labels]
-    with AstNodeBase[NodeType, Labels] { this: NodeSteps[NodeType, Labels] =>
+trait ExpressionBase[NodeType <: nodes.Expression]
+    extends OrderAccessors[NodeType]
+    with ArgumentIndexAccessors[NodeType]
+    with EvalTypeAccessors[NodeType]
+    with CodeAccessors[NodeType]
+    with LineNumberAccessors[NodeType]
+    with AstNodeBase[NodeType] { this: NodeSteps[NodeType] =>
 
   /**
     Traverse to enclosing expression
     */
-  def expressionUp: Expression[Labels] =
-    new Expression[Labels](raw.in(EdgeTypes.AST).not(_.hasLabel(NodeTypes.LOCAL)).cast[nodes.Expression])
+  def expressionUp: Expression =
+    new Expression(raw.in(EdgeTypes.AST).not(_.hasLabel(NodeTypes.LOCAL)).cast[nodes.Expression])
 
   /**
     Traverse to sub expressions
     */
-  def expressionDown: Expression[Labels] =
-    new Expression[Labels](
+  def expressionDown: Expression =
+    new Expression(
       raw
         .out(EdgeTypes.AST)
         .not(_.hasLabel(NodeTypes.LOCAL))
@@ -43,8 +42,8 @@ trait ExpressionBase[NodeType <: nodes.Expression, Labels <: HList]
   /**
     If the expression is used as receiver for a call, this traverses to the call.
     */
-  def receivedCall: Call[Labels] =
-    new Call[Labels](
+  def receivedCall: Call =
+    new Call(
       raw
         .in(EdgeTypes.RECEIVER)
         .cast[nodes.Call]
@@ -53,8 +52,8 @@ trait ExpressionBase[NodeType <: nodes.Expression, Labels <: HList]
   /**
     Traverse to related parameter
     */
-  def toParameter: MethodParameter[Labels] = {
-    new MethodParameter[Labels](
+  def toParameter: MethodParameter = {
+    new MethodParameter(
       raw
         .sack((sack: Integer, node: nodes.Expression) => node.value2(NodeKeys.ARGUMENT_INDEX))
         .in(EdgeTypes.AST)
@@ -73,14 +72,14 @@ trait ExpressionBase[NodeType <: nodes.Expression, Labels <: HList]
   /**
     Traverse to enclosing method
     */
-  def method: Method[Labels] =
-    new Method[Labels](raw.in(EdgeTypes.CONTAINS).cast[nodes.Method])
+  def method: Method =
+    new Method(raw.in(EdgeTypes.CONTAINS).cast[nodes.Method])
 
   /**
     * Traverse to next expression in CFG.
     */
-  def cfgNext: Expression[Labels] =
-    new Expression[Labels](
+  def cfgNext: Expression =
+    new Expression(
       raw
         .out(EdgeTypes.CFG)
         .filterNot(_.hasLabel(NodeTypes.METHOD_RETURN))
@@ -90,8 +89,8 @@ trait ExpressionBase[NodeType <: nodes.Expression, Labels <: HList]
   /**
     * Traverse to previous expression in CFG.
     */
-  def cfgPrev: Expression[Labels] =
-    new Expression[Labels](
+  def cfgPrev: Expression =
+    new Expression(
       raw
         .in(EdgeTypes.CFG)
         .filterNot(_.hasLabel(NodeTypes.METHOD))
@@ -101,6 +100,6 @@ trait ExpressionBase[NodeType <: nodes.Expression, Labels <: HList]
   /**
     * Traverse to expression evaluation type
     * */
-  def typ: Type[Labels] =
+  def typ: Type =
     new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Modifier.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Modifier.scala
@@ -4,17 +4,15 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
 /**
   * Modifier, e.g., "static", "public",
   * */
-class Modifier[Labels <: HList](raw: GremlinScala.Aux[nodes.Modifier, Labels])
-    extends NodeSteps[nodes.Modifier, Labels](raw) {
+class Modifier(raw: GremlinScala[nodes.Modifier]) extends NodeSteps[nodes.Modifier](raw) {
 
   // TODO: This looks wrong. Modifier does not have a code field. It has a
   // ModifierType field.
 
-  def code(): Steps[String, Labels] =
-    new Steps[String, Labels](raw.value(NodeKeys.CODE))
+  def code(): Steps[String] =
+    new Steps[String](raw.value(NodeKeys.CODE))
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ArgumentIndexAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ArgumentIndexAccessors.scala
@@ -3,21 +3,20 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait ArgumentIndexAccessors[T <: StoredNode, Labels <: HList] extends PropertyAccessors[T, Labels] {
-  def argIndex(): Steps[Integer, Labels] =
+trait ArgumentIndexAccessors[T <: StoredNode] extends PropertyAccessors[T] {
+  def argIndex(): Steps[Integer] =
     property(NodeKeys.ARGUMENT_INDEX)
 
-  def argIndex(value: Integer): NodeSteps[T, Labels] =
+  def argIndex(value: Integer): NodeSteps[T] =
     propertyFilter(NodeKeys.ARGUMENT_INDEX, value)
 
-  def argIndex(value: Integer*): NodeSteps[T, Labels] =
+  def argIndex(value: Integer*): NodeSteps[T] =
     propertyFilterMultiple(NodeKeys.ARGUMENT_INDEX, value: _*)
 
-  def argIndexNot(value: Integer): NodeSteps[T, Labels] =
+  def argIndexNot(value: Integer): NodeSteps[T] =
     propertyFilterNot(NodeKeys.ARGUMENT_INDEX, value)
 
-  def argIndexNot[Out](values: Integer*): NodeSteps[T, Labels] =
+  def argIndexNot[Out](values: Integer*): NodeSteps[T] =
     propertyFilterNotMultiple(NodeKeys.ARGUMENT_INDEX, values: _*)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/CodeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/CodeAccessors.scala
@@ -3,28 +3,27 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait CodeAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
-  def code(): Steps[String, Labels] =
+trait CodeAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+  def code(): Steps[String] =
     stringProperty(NodeKeys.CODE)
 
-  def code(value: String): NodeSteps[T, Labels] =
+  def code(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.CODE, value)
 
-  def code(value: String*): NodeSteps[T, Labels] =
+  def code(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.CODE, value: _*)
 
-  def codeExact(value: String): NodeSteps[T, Labels] =
+  def codeExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.CODE, value)
 
-  def codeExact(values: String*): NodeSteps[T, Labels] =
+  def codeExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.CODE, values: _*)
 
-  def codeNot(value: String): NodeSteps[T, Labels] =
+  def codeNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.CODE, value)
 
-  def codeNot(values: String*): NodeSteps[T, Labels] =
+  def codeNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.CODE, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DependencyGroupIdAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DependencyGroupIdAccessors.scala
@@ -3,27 +3,26 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait DependencyGroupIdAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
-  def dependencyGroupId(): Steps[String, Labels] =
+trait DependencyGroupIdAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+  def dependencyGroupId(): Steps[String] =
     stringProperty(NodeKeys.DEPENDENCY_GROUP_ID)
 
-  def dependencyGroupId(value: String): NodeSteps[T, Labels] =
+  def dependencyGroupId(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.DEPENDENCY_GROUP_ID, value)
 
-  def dependencyGroupId(value: String*): NodeSteps[T, Labels] =
+  def dependencyGroupId(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.DEPENDENCY_GROUP_ID, value: _*)
 
-  def dependencyGroupIdExact(value: String): NodeSteps[T, Labels] =
+  def dependencyGroupIdExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.DEPENDENCY_GROUP_ID, value)
 
-  def dependencyGroupIdExact(values: String*): NodeSteps[T, Labels] =
+  def dependencyGroupIdExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.DEPENDENCY_GROUP_ID, values: _*)
 
-  def dependencyGroupIdNot(value: String): NodeSteps[T, Labels] =
+  def dependencyGroupIdNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.DEPENDENCY_GROUP_ID, value)
 
-  def dependencyGroupIdNot(values: String*): NodeSteps[T, Labels] =
+  def dependencyGroupIdNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.DEPENDENCY_GROUP_ID, values: _*)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DispatchTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DispatchTypeAccessors.scala
@@ -3,50 +3,49 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait DispatchTypeAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
+trait DispatchTypeAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
 
   /**
     * Traverse to dispatchType
     * */
-  def dispatchType(): Steps[String, Labels] =
+  def dispatchType(): Steps[String] =
     stringProperty(NodeKeys.DISPATCH_TYPE)
 
   /**
     * Traverse to nodes where the dispatchType matches the regular expression `value`
     * */
-  def dispatchType(value: String): NodeSteps[T, Labels] =
+  def dispatchType(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.DISPATCH_TYPE, value)
 
   /**
     * Traverse to nodes where the dispatchType matches at least one of the regular expressions in `values`
     * */
-  def dispatchType(value: String*): NodeSteps[T, Labels] =
+  def dispatchType(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.DISPATCH_TYPE, value: _*)
 
   /**
     * Traverse to nodes where dispatchType matches `value` exactly.
     * */
-  def dispatchTypeExact(value: String): NodeSteps[T, Labels] =
+  def dispatchTypeExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.DISPATCH_TYPE, value)
 
   /**
     * Traverse to nodes where dispatchType matches one of the elements in `values` exactly.
     * */
-  def dispatchTypeExact(values: String*): NodeSteps[T, Labels] =
+  def dispatchTypeExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.DISPATCH_TYPE, values: _*)
 
   /**
     * Traverse to nodes where dispatchType does not match the regular expression `value`.
     * */
-  def dispatchTypeNot(value: String): NodeSteps[T, Labels] =
+  def dispatchTypeNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.DISPATCH_TYPE, value)
 
   /**
     * Traverse to nodes where dispatchType does not match any of the regular expressions in `values`.
     * */
-  def dispatchTypeNot(values: String*): NodeSteps[T, Labels] =
+  def dispatchTypeNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.DISPATCH_TYPE, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
@@ -5,24 +5,23 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys}
 import io.shiftleft.codepropertygraph.predicates.Text.textRegex
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait EvalTypeAccessors[T <: StoredNode, Labels <: HList] {
-  def raw: GremlinScala.Aux[T, Labels]
+trait EvalTypeAccessors[T <: StoredNode] {
+  def raw: GremlinScala[T]
 
-  def evalType(): Steps[String, Labels] =
-    new Steps[String, Labels](raw.out(EdgeTypes.EVAL_TYPE).out(EdgeTypes.REF).value(NodeKeys.FULL_NAME))
+  def evalType(): Steps[String] =
+    new Steps[String](raw.out(EdgeTypes.EVAL_TYPE).out(EdgeTypes.REF).value(NodeKeys.FULL_NAME))
 
-  def evalType(_value: String): NodeSteps[T, Labels] =
-    new NodeSteps[T, Labels](
+  def evalType(_value: String): NodeSteps[T] =
+    new NodeSteps[T](
       raw.filter(
         _.out(EdgeTypes.EVAL_TYPE)
           .out(EdgeTypes.REF)
           .has(NodeKeys.FULL_NAME, textRegex(_value))))
 
-  def evalType(_values: String*): NodeSteps[T, Labels] =
+  def evalType(_values: String*): NodeSteps[T] =
     if (_values.nonEmpty) {
-      new NodeSteps[T, Labels](
+      new NodeSteps[T](
         raw.filter(
           _.out(EdgeTypes.EVAL_TYPE)
             .out(EdgeTypes.REF)
@@ -31,19 +30,19 @@ trait EvalTypeAccessors[T <: StoredNode, Labels <: HList] {
               trav.has(NodeKeys.FULL_NAME, textRegex(_value))
             }: _*)))
     } else {
-      new NodeSteps[T, Labels](raw.filterOnEnd(_ => false))
+      new NodeSteps[T](raw.filterOnEnd(_ => false))
     }
 
-  def evalTypeExact(_value: String): NodeSteps[T, Labels] =
-    new NodeSteps[T, Labels](
+  def evalTypeExact(_value: String): NodeSteps[T] =
+    new NodeSteps[T](
       raw.filter(
         _.out(EdgeTypes.EVAL_TYPE)
           .out(EdgeTypes.REF)
           .has(NodeKeys.FULL_NAME, _value)))
 
-  def evalTypeExact(_values: String*): NodeSteps[T, Labels] =
+  def evalTypeExact(_values: String*): NodeSteps[T] =
     if (_values.nonEmpty) {
-      new NodeSteps[T, Labels](
+      new NodeSteps[T](
         raw.filter(
           _.out(EdgeTypes.EVAL_TYPE)
             .out(EdgeTypes.REF)
@@ -52,19 +51,19 @@ trait EvalTypeAccessors[T <: StoredNode, Labels <: HList] {
               trav.has(NodeKeys.FULL_NAME, _value)
             }: _*)))
     } else {
-      new NodeSteps[T, Labels](raw.filterOnEnd(_ => false))
+      new NodeSteps[T](raw.filterOnEnd(_ => false))
     }
 
-  def evalTypeNot(_value: String): NodeSteps[T, Labels] =
-    new NodeSteps[T, Labels](
+  def evalTypeNot(_value: String): NodeSteps[T] =
+    new NodeSteps[T](
       raw.filter(
         _.out(EdgeTypes.EVAL_TYPE)
           .out(EdgeTypes.REF)
           .hasNot(NodeKeys.FULL_NAME, textRegex(_value))))
 
-  def evalTypeNot(_values: String*): NodeSteps[T, Labels] =
+  def evalTypeNot(_values: String*): NodeSteps[T] =
     if (_values.nonEmpty) {
-      new NodeSteps[T, Labels](
+      new NodeSteps[T](
         raw.filter(
           _.out(EdgeTypes.EVAL_TYPE)
             .out(EdgeTypes.REF)
@@ -73,6 +72,6 @@ trait EvalTypeAccessors[T <: StoredNode, Labels <: HList] {
               trav.hasNot(NodeKeys.FULL_NAME, textRegex(_value))
             }: _*)))
     } else {
-      new NodeSteps[T, Labels](raw)
+      new NodeSteps[T](raw)
     }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/FullNameAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/FullNameAccessors.scala
@@ -3,28 +3,27 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait FullNameAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
-  def fullName(): Steps[String, Labels] =
+trait FullNameAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+  def fullName(): Steps[String] =
     stringProperty(NodeKeys.FULL_NAME)
 
-  def fullName(value: String): NodeSteps[T, Labels] =
+  def fullName(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.FULL_NAME, value)
 
-  def fullName(value: String*): NodeSteps[T, Labels] =
+  def fullName(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.FULL_NAME, value: _*)
 
-  def fullNameExact(value: String): NodeSteps[T, Labels] =
+  def fullNameExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.FULL_NAME, value)
 
-  def fullNameExact(values: String*): NodeSteps[T, Labels] =
+  def fullNameExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.FULL_NAME, values: _*)
 
-  def fullNameNot(value: String): NodeSteps[T, Labels] =
+  def fullNameNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.FULL_NAME, value)
 
-  def fullNameNot(values: String*): NodeSteps[T, Labels] =
+  def fullNameNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.FULL_NAME, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/IsExternalAccessor.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/IsExternalAccessor.scala
@@ -4,22 +4,21 @@ import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 import java.lang.{Boolean => JBoolean}
-import shapeless.HList
 
-trait IsExternalAccessor[T <: StoredNode, Labels <: HList] extends PropertyAccessors[T, Labels] {
-  def isExternal(): Steps[JBoolean, Labels] =
+trait IsExternalAccessor[T <: StoredNode] extends PropertyAccessors[T] {
+  def isExternal(): Steps[JBoolean] =
     property(NodeKeys.IS_EXTERNAL)
 
-  def isExternal(value: JBoolean): NodeSteps[T, Labels] =
+  def isExternal(value: JBoolean): NodeSteps[T] =
     propertyFilter(NodeKeys.IS_EXTERNAL, value)
 
-  def isExternal(value: JBoolean*): NodeSteps[T, Labels] =
+  def isExternal(value: JBoolean*): NodeSteps[T] =
     propertyFilterMultiple(NodeKeys.IS_EXTERNAL, value: _*)
 
-  def isExternalNot(value: JBoolean): NodeSteps[T, Labels] =
+  def isExternalNot(value: JBoolean): NodeSteps[T] =
     propertyFilterNot(NodeKeys.IS_EXTERNAL, value)
 
-  def isExternalNot(values: JBoolean*): NodeSteps[T, Labels] =
+  def isExternalNot(values: JBoolean*): NodeSteps[T] =
     propertyFilterNotMultiple(NodeKeys.IS_EXTERNAL, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/LineNumberAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/LineNumberAccessors.scala
@@ -3,22 +3,21 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait LineNumberAccessors[T <: StoredNode, Labels <: HList] extends PropertyAccessors[T, Labels] {
-  def lineNumber(): Steps[Integer, Labels] =
+trait LineNumberAccessors[T <: StoredNode] extends PropertyAccessors[T] {
+  def lineNumber(): Steps[Integer] =
     property(NodeKeys.LINE_NUMBER)
 
-  def lineNumber(value: Integer): NodeSteps[T, Labels] =
+  def lineNumber(value: Integer): NodeSteps[T] =
     propertyFilter(NodeKeys.LINE_NUMBER, value)
 
-  def lineNumber(value: Integer*): NodeSteps[T, Labels] =
+  def lineNumber(value: Integer*): NodeSteps[T] =
     propertyFilterMultiple(NodeKeys.LINE_NUMBER, value: _*)
 
-  def lineNumberNot(value: Integer): NodeSteps[T, Labels] =
+  def lineNumberNot(value: Integer): NodeSteps[T] =
     propertyFilterNot(NodeKeys.LINE_NUMBER, value)
 
-  def lineNumberNot(values: Integer*): NodeSteps[T, Labels] =
+  def lineNumberNot(values: Integer*): NodeSteps[T] =
     propertyFilterNotMultiple(NodeKeys.LINE_NUMBER, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/MethodInstFullNameAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/MethodInstFullNameAccessors.scala
@@ -3,23 +3,22 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait MethodInstFullNameAccessors[T <: StoredNode, Labels <: HList] extends PropertyAccessors[T, Labels] {
+trait MethodInstFullNameAccessors[T <: StoredNode] extends PropertyAccessors[T] {
 
-  def methodInstFullName(): Steps[String, Labels] =
+  def methodInstFullName(): Steps[String] =
     property(NodeKeys.METHOD_INST_FULL_NAME)
 
-  def methodInstFullName(value: String): NodeSteps[T, Labels] =
+  def methodInstFullName(value: String): NodeSteps[T] =
     propertyFilter(NodeKeys.METHOD_INST_FULL_NAME, value)
 
-  def methodInstFullName(value: String*): NodeSteps[T, Labels] =
+  def methodInstFullName(value: String*): NodeSteps[T] =
     propertyFilterMultiple(NodeKeys.METHOD_INST_FULL_NAME, value: _*)
 
-  def methodInstFullNameNot(value: String): NodeSteps[T, Labels] =
+  def methodInstFullNameNot(value: String): NodeSteps[T] =
     propertyFilterNot(NodeKeys.METHOD_INST_FULL_NAME, value)
 
-  def methodInstFullNameNot[Out](values: String*): NodeSteps[T, Labels] =
+  def methodInstFullNameNot[Out](values: String*): NodeSteps[T] =
     propertyFilterNotMultiple(NodeKeys.METHOD_INST_FULL_NAME, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/NameAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/NameAccessors.scala
@@ -3,50 +3,49 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait NameAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
+trait NameAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
 
   /**
     * Traverse to name
     * */
-  def name(): Steps[String, Labels] =
+  def name(): Steps[String] =
     stringProperty(NodeKeys.NAME)
 
   /**
     * Traverse to nodes where the name matches the regular expression `value`
     * */
-  def name(value: String): NodeSteps[T, Labels] =
+  def name(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.NAME, value)
 
   /**
     * Traverse to nodes where the name matches at least one of the regular expressions in `values`
     * */
-  def name(value: String*): NodeSteps[T, Labels] =
+  def name(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.NAME, value: _*)
 
   /**
     * Traverse to nodes where name matches `value` exactly.
     * */
-  def nameExact(value: String): NodeSteps[T, Labels] =
+  def nameExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.NAME, value)
 
   /**
     * Traverse to nodes where name matches one of the elements in `values` exactly.
     * */
-  def nameExact(values: String*): NodeSteps[T, Labels] =
+  def nameExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.NAME, values: _*)
 
   /**
     * Traverse to nodes where name does not match the regular expression `value`.
     * */
-  def nameNot(value: String): NodeSteps[T, Labels] =
+  def nameNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.NAME, value)
 
   /**
     * Traverse to nodes where name does not match any of the regular expressions in `values`.
     * */
-  def nameNot(values: String*): NodeSteps[T, Labels] =
+  def nameNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.NAME, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/OrderAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/OrderAccessors.scala
@@ -3,21 +3,20 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait OrderAccessors[T <: StoredNode, Labels <: HList] extends PropertyAccessors[T, Labels] {
-  def order(): Steps[Integer, Labels] =
+trait OrderAccessors[T <: StoredNode] extends PropertyAccessors[T] {
+  def order(): Steps[Integer] =
     property(NodeKeys.ORDER)
 
-  def order(value: Integer): NodeSteps[T, Labels] =
+  def order(value: Integer): NodeSteps[T] =
     propertyFilter(NodeKeys.ORDER, value)
 
-  def order(value: Integer*): NodeSteps[T, Labels] =
+  def order(value: Integer*): NodeSteps[T] =
     propertyFilterMultiple(NodeKeys.ORDER, value: _*)
 
-  def orderNot(value: Integer): NodeSteps[T, Labels] =
+  def orderNot(value: Integer): NodeSteps[T] =
     propertyFilterNot(NodeKeys.ORDER, value)
 
-  def orderNot(values: Integer*): NodeSteps[T, Labels] =
+  def orderNot(values: Integer*): NodeSteps[T] =
     propertyFilterNotMultiple(NodeKeys.ORDER, values: _*)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ParserTypeNameAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ParserTypeNameAccessors.scala
@@ -3,29 +3,28 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait ParserTypeNameAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
+trait ParserTypeNameAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
 
-  def parserTypeName(): Steps[String, Labels] =
+  def parserTypeName(): Steps[String] =
     stringProperty(NodeKeys.PARSER_TYPE_NAME)
 
-  def parserTypeName(value: String): NodeSteps[T, Labels] =
+  def parserTypeName(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.PARSER_TYPE_NAME, value)
 
-  def parserTypeName(value: String*): NodeSteps[T, Labels] =
+  def parserTypeName(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.PARSER_TYPE_NAME, value: _*)
 
-  def parserTypeNameExact(value: String): NodeSteps[T, Labels] =
+  def parserTypeNameExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.PARSER_TYPE_NAME, value)
 
-  def parserTypeNameExact(values: String*): NodeSteps[T, Labels] =
+  def parserTypeNameExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.PARSER_TYPE_NAME, values: _*)
 
-  def parserTypeNameNot(value: String): NodeSteps[T, Labels] =
+  def parserTypeNameNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.PARSER_TYPE_NAME, value)
 
-  def parserTypeNameNot(values: String*): NodeSteps[T, Labels] =
+  def parserTypeNameNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.PARSER_TYPE_NAME, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/PropertyAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/PropertyAccessors.scala
@@ -3,35 +3,34 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait PropertyAccessors[T <: StoredNode, Labels <: HList] {
-  val raw: GremlinScala.Aux[T, Labels]
+trait PropertyAccessors[T <: StoredNode] {
+  val raw: GremlinScala[T]
 
-  def property[P](property: Key[P]): Steps[P, Labels] =
-    new Steps[P, Labels](raw.value(property))
+  def property[P](property: Key[P]): Steps[P] =
+    new Steps[P](raw.value(property))
 
-  def propertyFilter[Out, P](property: Key[P], value: P): NodeSteps[T, Labels] =
-    new NodeSteps[T, Labels](raw.has(property, value))
+  def propertyFilter[Out, P](property: Key[P], value: P): NodeSteps[T] =
+    new NodeSteps[T](raw.has(property, value))
 
-  def propertyFilterMultiple[Out, P](property: Key[P], values: P*): NodeSteps[T, Labels] =
+  def propertyFilterMultiple[Out, P](property: Key[P], values: P*): NodeSteps[T] =
     if (values.nonEmpty) {
-      new NodeSteps[T, Labels](raw.or(values.map { value => (trav: GremlinScala[T]) =>
+      new NodeSteps[T](raw.or(values.map { value => (trav: GremlinScala[T]) =>
         trav.has(property, value)
       }: _*))
     } else {
-      new NodeSteps[T, Labels](raw.filterOnEnd(_ => false))
+      new NodeSteps[T](raw.filterOnEnd(_ => false))
     }
 
-  def propertyFilterNot[Out, P](property: Key[P], value: P): NodeSteps[T, Labels] =
-    new NodeSteps[T, Labels](raw.hasNot(property, value))
+  def propertyFilterNot[Out, P](property: Key[P], value: P): NodeSteps[T] =
+    new NodeSteps[T](raw.hasNot(property, value))
 
-  def propertyFilterNotMultiple[Out, P](property: Key[P], values: P*): NodeSteps[T, Labels] =
+  def propertyFilterNotMultiple[Out, P](property: Key[P], values: P*): NodeSteps[T] =
     if (values.nonEmpty) {
-      new NodeSteps[T, Labels](raw.or(values.map { value => (trav: GremlinScala[T]) =>
+      new NodeSteps[T](raw.or(values.map { value => (trav: GremlinScala[T]) =>
         trav.hasNot(property, value)
       }: _*))
     } else {
-      new NodeSteps[T, Labels](raw)
+      new NodeSteps[T](raw)
     }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/SignatureAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/SignatureAccessors.scala
@@ -3,50 +3,49 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait SignatureAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
+trait SignatureAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
 
   /**
     * Traverse to signature
     * */
-  def signature(): Steps[String, Labels] =
+  def signature(): Steps[String] =
     stringProperty(NodeKeys.SIGNATURE)
 
   /**
     * Traverse to nodes where the signature matches the regular expression `value`
     * */
-  def signature(value: String): NodeSteps[T, Labels] =
+  def signature(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.SIGNATURE, value)
 
   /**
     * Traverse to nodes where the signature matches at least one of the regular expressions in `values`
     * */
-  def signature(value: String*): NodeSteps[T, Labels] =
+  def signature(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.SIGNATURE, value: _*)
 
   /**
     * Traverse to nodes where signature matches `value` exactly.
     * */
-  def signatureExact(value: String): NodeSteps[T, Labels] =
+  def signatureExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.SIGNATURE, value)
 
   /**
     * Traverse to nodes where signature matches one of the elements in `values` exactly.
     * */
-  def signatureExact(values: String*): NodeSteps[T, Labels] =
+  def signatureExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.SIGNATURE, values: _*)
 
   /**
     * Traverse to nodes where signature does not match the regular expression `value`.
     * */
-  def signatureNot(value: String): NodeSteps[T, Labels] =
+  def signatureNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.SIGNATURE, value)
 
   /**
     * Traverse to nodes where signature does not match any of the regular expressions in `values`.
     * */
-  def signatureNot(values: String*): NodeSteps[T, Labels] =
+  def signatureNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.SIGNATURE, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/StringPropertyAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/StringPropertyAccessors.scala
@@ -4,47 +4,46 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.codepropertygraph.predicates.Text.textRegex
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait StringPropertyAccessors[T <: StoredNode, Labels <: HList] {
-  val raw: GremlinScala.Aux[T, Labels]
+trait StringPropertyAccessors[T <: StoredNode] {
+  val raw: GremlinScala[T]
 
   protected def stringProperty(property: Key[String]) =
-    new Steps[String, Labels](raw.value(property))
+    new Steps[String](raw.value(property))
 
-  protected def stringPropertyFilter(property: Key[String], value: String): NodeSteps[T, Labels] =
-    new NodeSteps[T, Labels](raw.has(property, textRegex(value)))
+  protected def stringPropertyFilter(property: Key[String], value: String): NodeSteps[T] =
+    new NodeSteps[T](raw.has(property, textRegex(value)))
 
-  protected def stringPropertyFilterMultiple(property: Key[String], values: String*): NodeSteps[T, Labels] =
+  protected def stringPropertyFilterMultiple(property: Key[String], values: String*): NodeSteps[T] =
     if (values.nonEmpty) {
-      new NodeSteps[T, Labels](raw.or(values.map { value => (trav: GremlinScala[T]) =>
+      new NodeSteps[T](raw.or(values.map { value => (trav: GremlinScala[T]) =>
         trav.has(property, textRegex(value))
       }: _*))
     } else {
-      new NodeSteps[T, Labels](raw.filterOnEnd(_ => false))
+      new NodeSteps[T](raw.filterOnEnd(_ => false))
     }
 
-  protected def stringPropertyFilterExact[Out](property: Key[String], _value: String): NodeSteps[T, Labels] =
-    new NodeSteps[T, Labels](raw.has(property, _value))
+  protected def stringPropertyFilterExact[Out](property: Key[String], _value: String): NodeSteps[T] =
+    new NodeSteps[T](raw.has(property, _value))
 
-  protected def stringPropertyFilterExactMultiple[Out](property: Key[String], values: String*): NodeSteps[T, Labels] =
+  protected def stringPropertyFilterExactMultiple[Out](property: Key[String], values: String*): NodeSteps[T] =
     if (values.nonEmpty) {
-      new NodeSteps[T, Labels](raw.or(values.map { value => (trav: GremlinScala[T]) =>
+      new NodeSteps[T](raw.or(values.map { value => (trav: GremlinScala[T]) =>
         trav.has(property, value)
       }: _*))
     } else {
-      new NodeSteps[T, Labels](raw.filterOnEnd(_ => false))
+      new NodeSteps[T](raw.filterOnEnd(_ => false))
     }
 
-  protected def stringPropertyFilterNot[Out](property: Key[String], value: String): NodeSteps[T, Labels] =
-    new NodeSteps[T, Labels](raw.hasNot(property, textRegex(value)))
+  protected def stringPropertyFilterNot[Out](property: Key[String], value: String): NodeSteps[T] =
+    new NodeSteps[T](raw.hasNot(property, textRegex(value)))
 
-  protected def stringPropertyFilterNotMultiple[Out](property: Key[String], values: String*): NodeSteps[T, Labels] =
+  protected def stringPropertyFilterNotMultiple[Out](property: Key[String], values: String*): NodeSteps[T] =
     if (values.nonEmpty) {
-      new NodeSteps[T, Labels](raw.or(values.map { value => (trav: GremlinScala[T]) =>
+      new NodeSteps[T](raw.or(values.map { value => (trav: GremlinScala[T]) =>
         trav.hasNot(property, textRegex(value))
       }: _*))
     } else {
-      new NodeSteps[T, Labels](raw)
+      new NodeSteps[T](raw)
     }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ValueAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ValueAccessors.scala
@@ -3,28 +3,27 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait ValueAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
-  def value(): Steps[String, Labels] =
+trait ValueAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+  def value(): Steps[String] =
     stringProperty(NodeKeys.VALUE)
 
-  def value(value: String): NodeSteps[T, Labels] =
+  def value(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.VALUE, value)
 
-  def value(value: String*): NodeSteps[T, Labels] =
+  def value(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.VALUE, value: _*)
 
-  def valueExact(value: String): NodeSteps[T, Labels] =
+  def valueExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.VALUE, value)
 
-  def valueExact(values: String*): NodeSteps[T, Labels] =
+  def valueExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.VALUE, values: _*)
 
-  def valueNot(value: String): NodeSteps[T, Labels] =
+  def valueNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.VALUE, value)
 
-  def valueNot(values: String*): NodeSteps[T, Labels] =
+  def valueNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.VALUE, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/VersionAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/VersionAccessors.scala
@@ -3,28 +3,27 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
-import shapeless.HList
 
-trait VersionAccessors[T <: StoredNode, Labels <: HList] extends StringPropertyAccessors[T, Labels] {
-  def version(): Steps[String, Labels] =
+trait VersionAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+  def version(): Steps[String] =
     stringProperty(NodeKeys.VERSION)
 
-  def version(value: String): NodeSteps[T, Labels] =
+  def version(value: String): NodeSteps[T] =
     stringPropertyFilter(NodeKeys.VERSION, value)
 
-  def version(value: String*): NodeSteps[T, Labels] =
+  def version(value: String*): NodeSteps[T] =
     stringPropertyFilterMultiple(NodeKeys.VERSION, value: _*)
 
-  def versionExact(value: String): NodeSteps[T, Labels] =
+  def versionExact(value: String): NodeSteps[T] =
     stringPropertyFilterExact(NodeKeys.VERSION, value)
 
-  def versionExact(values: String*): NodeSteps[T, Labels] =
+  def versionExact(values: String*): NodeSteps[T] =
     stringPropertyFilterExactMultiple(NodeKeys.VERSION, values: _*)
 
-  def versionNot(value: String): NodeSteps[T, Labels] =
+  def versionNot(value: String): NodeSteps[T] =
     stringPropertyFilterNot(NodeKeys.VERSION, value)
 
-  def versionNot(values: String*): NodeSteps[T, Labels] =
+  def versionNot(values: String*): NodeSteps[T] =
     stringPropertyFilterNotMultiple(NodeKeys.VERSION, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Block.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Block.scala
@@ -3,17 +3,14 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.NodeSteps
-import shapeless.HList
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.ExpressionBase
 
-class Block[Labels <: HList](raw: GremlinScala.Aux[nodes.Block, Labels])
-    extends NodeSteps[nodes.Block, Labels](raw)
-    with ExpressionBase[nodes.Block, Labels] {
+class Block(raw: GremlinScala[nodes.Block]) extends NodeSteps[nodes.Block](raw) with ExpressionBase[nodes.Block] {
 
   /**
     * Traverse to locals of this block.
     */
-  def local: Local[Labels] =
-    new Local[Labels](raw.out(EdgeTypes.AST).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
+  def local: Local =
+    new Local(raw.out(EdgeTypes.AST).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Comment.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Comment.scala
@@ -3,15 +3,14 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{CodeAccessors, LineNumberAccessors}
-import shapeless.HList
 import io.shiftleft.semanticcpg.language._
 
-class Comment[Labels <: HList](raw: GremlinScala.Aux[nodes.Comment, Labels])
-    extends NodeSteps[nodes.Comment, Labels](raw)
-    with LineNumberAccessors[nodes.Comment, Labels]
-    with CodeAccessors[nodes.Comment, Labels] {
+class Comment(raw: GremlinScala[nodes.Comment])
+    extends NodeSteps[nodes.Comment](raw)
+    with LineNumberAccessors[nodes.Comment]
+    with CodeAccessors[nodes.Comment] {
 
-  override def file: File[Labels] =
-    new File[Labels](raw.in(EdgeTypes.AST).hasLabel(NodeTypes.FILE).cast[nodes.File])
+  override def file: File =
+    new File(raw.in(EdgeTypes.AST).hasLabel(NodeTypes.FILE).cast[nodes.File])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/File.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/File.scala
@@ -5,30 +5,27 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.NameAccessors
-import shapeless.HList
 
 /**
   * A compilation unit
   * */
-class File[Labels <: HList](raw: GremlinScala.Aux[nodes.File, Labels])
-    extends NodeSteps[nodes.File, Labels](raw)
-    with NameAccessors[nodes.File, Labels] {
+class File(raw: GremlinScala[nodes.File]) extends NodeSteps[nodes.File](raw) with NameAccessors[nodes.File] {
 
-  def typeDecl: TypeDecl[Labels] =
-    new TypeDecl[Labels](
+  def typeDecl: TypeDecl =
+    new TypeDecl(
       raw
         .out(EdgeTypes.AST)
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.TYPE_DECL)
         .cast[nodes.TypeDecl])
 
-  def namespace: Namespace[Labels] =
-    new Namespace[Labels](raw.out(EdgeTypes.AST).out(EdgeTypes.REF).cast[nodes.Namespace])
+  def namespace: Namespace =
+    new Namespace(raw.out(EdgeTypes.AST).out(EdgeTypes.REF).cast[nodes.Namespace])
 
-  def namespaceBlock: NamespaceBlock[Labels] =
-    new NamespaceBlock[Labels](raw.out(EdgeTypes.AST).hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
+  def namespaceBlock: NamespaceBlock =
+    new NamespaceBlock(raw.out(EdgeTypes.AST).hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
 
-  def comment: Comment[Labels] =
-    new Comment[Labels](raw.out(EdgeTypes.AST).hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
+  def comment: Comment =
+    new Comment(raw.out(EdgeTypes.AST).hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -6,47 +6,46 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.Identifier
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.DeclarationBase
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
-import shapeless.HList
 
 /**
   * A local variable
   * */
-class Local[Labels <: HList](raw: GremlinScala.Aux[nodes.Local, Labels])
-    extends NodeSteps[nodes.Local, Labels](raw)
-    with DeclarationBase[nodes.Local, Labels]
-    with CodeAccessors[nodes.Local, Labels]
-    with NameAccessors[nodes.Local, Labels]
-    with OrderAccessors[nodes.Local, Labels]
-    with LineNumberAccessors[nodes.Local, Labels]
-    with EvalTypeAccessors[nodes.Local, Labels] {
+class Local(raw: GremlinScala[nodes.Local])
+    extends NodeSteps[nodes.Local](raw)
+    with DeclarationBase[nodes.Local]
+    with CodeAccessors[nodes.Local]
+    with NameAccessors[nodes.Local]
+    with OrderAccessors[nodes.Local]
+    with LineNumberAccessors[nodes.Local]
+    with EvalTypeAccessors[nodes.Local] {
 
   /**
     * The method hosting this local variable
     * */
-  def method: Method[Labels] = {
+  def method: Method = {
     // TODO The following line of code is here for backwards compatibility.
     // Use the lower commented out line once not required anymore.
-    new Method[Labels](raw.repeat(_.in(EdgeTypes.AST)).until(_.hasLabel(NodeTypes.METHOD)).cast[nodes.Method])
+    new Method(raw.repeat(_.in(EdgeTypes.AST)).until(_.hasLabel(NodeTypes.METHOD)).cast[nodes.Method])
     //definingBlock.method
   }
 
   /**
     * The block in which local is declared.
     */
-  def definingBlock: Block[Labels] =
-    new Block[Labels](raw.in(EdgeTypes.AST).cast[nodes.Block])
+  def definingBlock: Block =
+    new Block(raw.in(EdgeTypes.AST).cast[nodes.Block])
 
   /**
     * Places (identifier) where this local is referenced
     * */
-  def referencingIdentifiers: Identifier[Labels] =
-    new Identifier[Labels](raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def referencingIdentifiers: Identifier =
+    new Identifier(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * The type of the local.
     *
     * Unfortunately, `type` is a keyword, so we use `typ` here.
     * */
-  def typ: Type[Labels] =
-    new Type[Labels](raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+  def typ: Type =
+    new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
@@ -7,63 +7,58 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.Call
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{DeclarationBase, Modifier}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{CodeAccessors, EvalTypeAccessors, NameAccessors}
-import shapeless.HList
 
 /**
   * A member variable of a class/type.
   * */
-class Member[Labels <: HList](raw: GremlinScala.Aux[nodes.Member, Labels])
-    extends NodeSteps[nodes.Member, Labels](raw)
-    with DeclarationBase[nodes.Member, Labels]
-    with CodeAccessors[nodes.Member, Labels]
-    with NameAccessors[nodes.Member, Labels]
-    with EvalTypeAccessors[nodes.Member, Labels] {
+class Member(raw: GremlinScala[nodes.Member])
+    extends NodeSteps[nodes.Member](raw)
+    with DeclarationBase[nodes.Member]
+    with CodeAccessors[nodes.Member]
+    with NameAccessors[nodes.Member]
+    with EvalTypeAccessors[nodes.Member] {
 
   /**
     * The type declaration this member is defined in
     * */
-  def typeDecl: TypeDecl[Labels] =
-    new TypeDecl[Labels](raw.in(EdgeTypes.AST).cast[nodes.TypeDecl])
+  def typeDecl: TypeDecl =
+    new TypeDecl(raw.in(EdgeTypes.AST).cast[nodes.TypeDecl])
 
   /**
     * Places where
     * */
-  def ref: Call[Labels] =
-    new Call[Labels](raw.in(EdgeTypes.REF).cast[nodes.Call])
+  def ref: Call =
+    new Call(raw.in(EdgeTypes.REF).cast[nodes.Call])
 
   /**
     * Public members
     * */
-  def isPublic: Member[Labels] =
-    new Member[Labels](
-      raw.filter(_.out.hasLabel(NodeTypes.MODIFIER).has(NodeKeys.MODIFIER_TYPE -> ModifierTypes.PUBLIC)))
+  def isPublic: Member =
+    new Member(raw.filter(_.out.hasLabel(NodeTypes.MODIFIER).has(NodeKeys.MODIFIER_TYPE -> ModifierTypes.PUBLIC)))
 
   /**
     * Private members
     * */
-  def isPrivate: Member[Labels] =
-    new Member[Labels](
-      raw.filter(_.out.hasLabel(NodeTypes.MODIFIER).has(NodeKeys.MODIFIER_TYPE -> ModifierTypes.PRIVATE)))
+  def isPrivate: Member =
+    new Member(raw.filter(_.out.hasLabel(NodeTypes.MODIFIER).has(NodeKeys.MODIFIER_TYPE -> ModifierTypes.PRIVATE)))
 
   /**
     * Protected members
     * */
-  def isProtected: Member[Labels] =
-    new Member[Labels](
-      raw.filter(_.out.hasLabel(NodeTypes.MODIFIER).has(NodeKeys.MODIFIER_TYPE -> ModifierTypes.PROTECTED)))
+  def isProtected: Member =
+    new Member(raw.filter(_.out.hasLabel(NodeTypes.MODIFIER).has(NodeKeys.MODIFIER_TYPE -> ModifierTypes.PROTECTED)))
 
   /**
     * Static members
     * */
-  def isStatic: Member[Labels] =
-    new Member[Labels](
-      raw.filter(_.out.hasLabel(NodeTypes.MODIFIER).has(NodeKeys.MODIFIER_TYPE -> ModifierTypes.STATIC)))
+  def isStatic: Member =
+    new Member(raw.filter(_.out.hasLabel(NodeTypes.MODIFIER).has(NodeKeys.MODIFIER_TYPE -> ModifierTypes.STATIC)))
 
   /**
     * Traverse to method modifiers, e.g., "static", "public".
     * */
-  def modifier: Modifier[Labels] =
-    new Modifier[Labels](
+  def modifier: Modifier =
+    new Modifier(
       raw.out
         .hasLabel(NodeTypes.MODIFIER)
         .cast[nodes.Modifier]
@@ -72,6 +67,6 @@ class Member[Labels <: HList](raw: GremlinScala.Aux[nodes.Member, Labels])
   /**
     * Traverse to member type
     * */
-  def typ: Type[Labels] =
+  def typ: Type =
     new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MetaData.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MetaData.scala
@@ -4,19 +4,18 @@ import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.VersionAccessors
-import shapeless.HList
 
 /**
   * A meta data entry
   * */
-class MetaData[Labels <: HList](raw: GremlinScala.Aux[nodes.MetaData, Labels])
-    extends NodeSteps[nodes.MetaData, Labels](raw)
-    with VersionAccessors[nodes.MetaData, Labels] {
+class MetaData(raw: GremlinScala[nodes.MetaData])
+    extends NodeSteps[nodes.MetaData](raw)
+    with VersionAccessors[nodes.MetaData] {
 
   /**
     * Returns the programming language of the code for which this CPG was
     * generated from.
     * */
-  def language: GremlinScala.Aux[String, Labels] = raw.map(_.language)
+  def language: GremlinScala[String] = raw.map(_.language)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodInst.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodInst.scala
@@ -6,16 +6,15 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.{Call, Literal}
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Modifier
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{FullNameAccessors, NameAccessors, SignatureAccessors}
-import shapeless.HList
 
-class MethodInst[Labels <: HList](override val raw: GremlinScala.Aux[nodes.MethodInst, Labels])
-    extends NodeSteps[nodes.MethodInst, Labels](raw)
-    with NameAccessors[nodes.MethodInst, Labels]
-    with FullNameAccessors[nodes.MethodInst, Labels]
-    with SignatureAccessors[nodes.MethodInst, Labels] {
+class MethodInst(override val raw: GremlinScala[nodes.MethodInst])
+    extends NodeSteps[nodes.MethodInst](raw)
+    with NameAccessors[nodes.MethodInst]
+    with FullNameAccessors[nodes.MethodInst]
+    with SignatureAccessors[nodes.MethodInst] {
 
-  def method: Method[Labels] = {
-    new Method[Labels](
+  def method: Method = {
+    new Method(
       raw.out(EdgeTypes.REF).cast[nodes.Method]
     )
   }
@@ -23,60 +22,60 @@ class MethodInst[Labels <: HList](override val raw: GremlinScala.Aux[nodes.Metho
   /**
     * Traverse to parameters of method.
     * */
-  def parameter: MethodParameter[Labels] = {
+  def parameter: MethodParameter = {
     method.parameter
   }
 
   /**
     * Traverse to formal return parameter of method.
     * */
-  def methodReturn: MethodReturn[Labels] = {
+  def methodReturn: MethodReturn = {
     method.methodReturn
   }
 
   /**
     * Traverse to the type declarations were method is in the VTable.
     */
-  def inVTableOfTypeDecl: TypeDecl[Labels] = {
+  def inVTableOfTypeDecl: TypeDecl = {
     method.inVTableOfTypeDecl
   }
 
   /**
     * Traverse to direct and transitive callers of the method.
     * */
-  def calledBy(sourceTrav: Method[Labels])(implicit callResolver: ICallResolver): Method[Labels] = {
+  def calledBy(sourceTrav: Method)(implicit callResolver: ICallResolver): Method = {
     caller(callResolver).calledByIncludingSink(sourceTrav)(callResolver)
   }
 
   /**
     * Traverse to direct and transitive callers of the method.
     * */
-  def calledBy(sourceTrav: MethodInst[Labels])(implicit callResolver: ICallResolver): Method[Labels] = {
+  def calledBy(sourceTrav: MethodInst)(implicit callResolver: ICallResolver): Method = {
     caller(callResolver).calledByIncludingSink(sourceTrav.method)(callResolver)
   }
 
   /**
     * Traverse to direct callers of this method
     * */
-  def caller(implicit callResolver: ICallResolver): Method[Labels] = {
+  def caller(implicit callResolver: ICallResolver): Method = {
     callIn(callResolver).method
   }
 
   /**
     * Traverse to methods called by method.
     * */
-  def callee(implicit callResolver: ICallResolver): Method[Labels] = {
+  def callee(implicit callResolver: ICallResolver): Method = {
     method.callee(callResolver)
   }
 
   /**
     * Incoming call sites
     * */
-  def callIn(implicit callResolver: ICallResolver): Call[Labels] = {
+  def callIn(implicit callResolver: ICallResolver): Call = {
     // Check whether possible call sides are resolved or resolve them.
     // We only do this for virtual method calls.
     // TODO Also resolve function pointers.
-    new Call[Labels](
+    new Call(
       sideEffect(callResolver.resolveDynamicMethodInstCallSites).raw
         .in(EdgeTypes.CALL)
         .cast[nodes.Call])
@@ -85,112 +84,112 @@ class MethodInst[Labels <: HList](override val raw: GremlinScala.Aux[nodes.Metho
   /**
     * Outgoing call sites of method.
     * */
-  def callOut: Call[Labels] = {
+  def callOut: Call = {
     method.callOut
   }
 
   /**
     * The type declaration associated with method.
     * */
-  def definingTypeDecl: TypeDecl[Labels] = {
+  def definingTypeDecl: TypeDecl = {
     method.definingTypeDecl
   }
 
   /**
     * The method in which the method is defined.
     * */
-  def definingMethod: Method[Labels] = {
+  def definingMethod: Method = {
     method.definingMethod
   }
 
   /**
     * Traverse only to methods that are stubs, e.g., their code is not available
     * */
-  def isStub: MethodInst[Labels] = {
+  def isStub: MethodInst = {
     filter(_.method.isStub)
   }
 
   /**
     * Traverse only to methods that are not stubs.
     * */
-  def isNotStub: MethodInst[Labels] = {
+  def isNotStub: MethodInst = {
     filter(_.method.isNotStub)
   }
 
   /**
     * Traverse to public methods
     * */
-  def isPublic: MethodInst[Labels] = {
+  def isPublic: MethodInst = {
     filter(_.method.isPublic)
   }
 
   /**
     * Traverse to private methods
     * */
-  def isPrivate: MethodInst[Labels] = {
+  def isPrivate: MethodInst = {
     filter(_.method.isPublic)
   }
 
   /**
     * Traverse to protected methods
     * */
-  def isProtected: MethodInst[Labels] = {
+  def isProtected: MethodInst = {
     filter(_.method.isProtected)
   }
 
   /**
     * Traverse to abstract methods
     * */
-  def isAbstract: MethodInst[Labels] = {
+  def isAbstract: MethodInst = {
     filter(_.method.isAbstract)
   }
 
   /**
     * Traverse to static methods
     * */
-  def isStatic: MethodInst[Labels] = {
+  def isStatic: MethodInst = {
     filter(_.method.isStatic)
   }
 
   /**
     * Traverse to native methods
     * */
-  def isNative: MethodInst[Labels] = {
+  def isNative: MethodInst = {
     filter(_.method.isNative)
   }
 
   /**
     * Traverse to constructors, that is, keep methods that are constructors
     * */
-  def isConstructor: MethodInst[Labels] = {
+  def isConstructor: MethodInst = {
     filter(_.method.isConstructor)
   }
 
   /**
     * Traverse to virtual method
     * */
-  def isVirtual: MethodInst[Labels] = {
+  def isVirtual: MethodInst = {
     filter(_.method.isVirtual)
   }
 
   /**
     * Traverse to method modifiers of method.
     * */
-  def modifier: Modifier[Labels] = {
+  def modifier: Modifier = {
     method.modifier
   }
 
   /**
     * Traverse to the methods local variables.
     * */
-  def local: Local[Labels] = {
+  def local: Local = {
     method.local
   }
 
   /**
     * Traverse to literals used in method.
     * */
-  def literal: Literal[Labels] = {
+  def literal: Literal = {
     method.literal
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -6,49 +6,48 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{DeclarationBase, Expression}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
-import shapeless.HList
 
 /**
   * Formal method input parameter
   * */
-class MethodParameter[Labels <: HList](raw: GremlinScala.Aux[nodes.MethodParameterIn, Labels])
-    extends NodeSteps[nodes.MethodParameterIn, Labels](raw)
-    with DeclarationBase[nodes.MethodParameterIn, Labels]
-    with CodeAccessors[nodes.MethodParameterIn, Labels]
-    with NameAccessors[nodes.MethodParameterIn, Labels]
-    with OrderAccessors[nodes.MethodParameterIn, Labels]
-    with LineNumberAccessors[nodes.MethodParameterIn, Labels]
-    with EvalTypeAccessors[nodes.MethodParameterIn, Labels] {
+class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
+    extends NodeSteps[nodes.MethodParameterIn](raw)
+    with DeclarationBase[nodes.MethodParameterIn]
+    with CodeAccessors[nodes.MethodParameterIn]
+    with NameAccessors[nodes.MethodParameterIn]
+    with OrderAccessors[nodes.MethodParameterIn]
+    with LineNumberAccessors[nodes.MethodParameterIn]
+    with EvalTypeAccessors[nodes.MethodParameterIn] {
 
   /**
     * Traverse to all `num`th parameters
     * */
-  def index(num: Int): MethodParameter[Labels] =
+  def index(num: Int): MethodParameter =
     order(num)
 
   /**
     * Traverse to all parameters with index greater or equal than `num`
     * */
-  def indexFrom(num: Int): MethodParameter[Labels] =
-    new MethodParameter[Labels](raw.has(NodeKeys.METHOD_PARAMETER_IN.ORDER, P.gte(num: Integer)))
+  def indexFrom(num: Int): MethodParameter =
+    new MethodParameter(raw.has(NodeKeys.METHOD_PARAMETER_IN.ORDER, P.gte(num: Integer)))
 
   /**
     * Traverse to all parameters with index smaller or equal than `num`
     * */
-  def indexTo(num: Int): MethodParameter[Labels] =
-    new MethodParameter[Labels](raw.has(NodeKeys.METHOD_PARAMETER_IN.ORDER, P.lte(num: Integer)))
+  def indexTo(num: Int): MethodParameter =
+    new MethodParameter(raw.has(NodeKeys.METHOD_PARAMETER_IN.ORDER, P.lte(num: Integer)))
 
   /**
     * Traverse to method associated with this formal parameter
     * */
-  def method: Method[Labels] =
-    new Method[Labels](raw.in(EdgeTypes.AST).cast[nodes.Method])
+  def method: Method =
+    new Method(raw.in(EdgeTypes.AST).cast[nodes.Method])
 
   /**
     * Traverse to arguments (actual parameters) associated with this formal parameter
     * */
   def argument() = {
-    new Expression[Labels](
+    new Expression(
       raw
         .sack((_: Integer, node: nodes.MethodParameterIn) => node.value2(NodeKeys.ORDER))
         .in(EdgeTypes.AST)
@@ -66,13 +65,13 @@ class MethodParameter[Labels <: HList](raw: GremlinScala.Aux[nodes.MethodParamet
   /**
     * Traverse to corresponding formal output parameter
     * */
-  def asOutput: MethodParameterOut[Labels] =
-    new MethodParameterOut[Labels](raw.out(EdgeTypes.PARAMETER_LINK).cast[nodes.MethodParameterOut])
+  def asOutput: MethodParameterOut =
+    new MethodParameterOut(raw.out(EdgeTypes.PARAMETER_LINK).cast[nodes.MethodParameterOut])
 
   /**
     * Traverse to parameter type
     * */
-  def typ: Type[Labels] =
+  def typ: Type =
     new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -6,36 +6,35 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{DeclarationBase, Expression}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
-import shapeless.HList
 
-class MethodParameterOut[Labels <: HList](raw: GremlinScala.Aux[nodes.MethodParameterOut, Labels])
-    extends NodeSteps[nodes.MethodParameterOut, Labels](raw)
-    with DeclarationBase[nodes.MethodParameterOut, Labels]
-    with CodeAccessors[nodes.MethodParameterOut, Labels]
-    with NameAccessors[nodes.MethodParameterOut, Labels]
-    with OrderAccessors[nodes.MethodParameterOut, Labels]
-    with LineNumberAccessors[nodes.MethodParameterOut, Labels]
-    with EvalTypeAccessors[nodes.MethodParameterOut, Labels] {
+class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
+    extends NodeSteps[nodes.MethodParameterOut](raw)
+    with DeclarationBase[nodes.MethodParameterOut]
+    with CodeAccessors[nodes.MethodParameterOut]
+    with NameAccessors[nodes.MethodParameterOut]
+    with OrderAccessors[nodes.MethodParameterOut]
+    with LineNumberAccessors[nodes.MethodParameterOut]
+    with EvalTypeAccessors[nodes.MethodParameterOut] {
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def index(num: Int): MethodParameterOut[Labels] =
+  def index(num: Int): MethodParameterOut =
     order(num)
 
   /* get all parameters from (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def indexFrom(num: Int): MethodParameterOut[Labels] =
-    new MethodParameterOut[Labels](raw.has(NodeKeys.METHOD_PARAMETER_OUT.ORDER, P.gte(num: Integer)))
+  def indexFrom(num: Int): MethodParameterOut =
+    new MethodParameterOut(raw.has(NodeKeys.METHOD_PARAMETER_OUT.ORDER, P.gte(num: Integer)))
 
   /* get all parameters up to (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def indexTo[Out](num: Int): MethodParameterOut[Labels] =
-    new MethodParameterOut[Labels](raw.has(NodeKeys.METHOD_PARAMETER_OUT.ORDER, P.lte(num: Integer)))
+  def indexTo[Out](num: Int): MethodParameterOut =
+    new MethodParameterOut(raw.has(NodeKeys.METHOD_PARAMETER_OUT.ORDER, P.lte(num: Integer)))
 
-  def method: Method[Labels] =
-    new Method[Labels](raw.in(EdgeTypes.AST).cast[nodes.Method])
+  def method: Method =
+    new Method(raw.in(EdgeTypes.AST).cast[nodes.Method])
 
-  def argument: Expression[Labels] = {
-    new Expression[Labels](
+  def argument: Expression = {
+    new Expression(
       raw
         .sack((_: Integer, node: nodes.MethodParameterOut) => node.value2(NodeKeys.ORDER))
         .in(EdgeTypes.AST)
@@ -50,12 +49,12 @@ class MethodParameterOut[Labels <: HList](raw: GremlinScala.Aux[nodes.MethodPara
     )
   }
 
-  def asInput: MethodParameter[Labels] =
-    new MethodParameter[Labels](raw.in(EdgeTypes.PARAMETER_LINK).cast[nodes.MethodParameterIn])
+  def asInput: MethodParameter =
+    new MethodParameter(raw.in(EdgeTypes.PARAMETER_LINK).cast[nodes.MethodParameterIn])
 
   /**
     * Traverse to parameter type
     * */
-  def typ: Type[Labels] =
+  def typ: Type =
     new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
@@ -7,19 +7,18 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.Call
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{CodeAccessors, EvalTypeAccessors, LineNumberAccessors}
-import shapeless.HList
 
-class MethodReturn[Labels <: HList](raw: GremlinScala.Aux[nodes.MethodReturn, Labels])
-    extends NodeSteps[nodes.MethodReturn, Labels](raw)
-    with CodeAccessors[nodes.MethodReturn, Labels]
-    with LineNumberAccessors[nodes.MethodReturn, Labels]
-    with EvalTypeAccessors[nodes.MethodReturn, Labels] {
+class MethodReturn(raw: GremlinScala[nodes.MethodReturn])
+    extends NodeSteps[nodes.MethodReturn](raw)
+    with CodeAccessors[nodes.MethodReturn]
+    with LineNumberAccessors[nodes.MethodReturn]
+    with EvalTypeAccessors[nodes.MethodReturn] {
 
-  def method: Method[Labels] =
-    new Method[Labels](raw.in(EdgeTypes.AST).cast[nodes.Method])
+  def method: Method =
+    new Method(raw.in(EdgeTypes.AST).cast[nodes.Method])
 
-  def returnUser: Call[Labels] = {
-    new Call[Labels](
+  def returnUser: Call = {
+    new Call(
       raw.in(EdgeTypes.AST).in(EdgeTypes.REF).in(EdgeTypes.CALL).cast[nodes.Call]
     )
   }
@@ -28,14 +27,14 @@ class MethodReturn[Labels <: HList](raw: GremlinScala.Aux[nodes.MethodReturn, La
     *  Traverse to last expressions in CFG.
     *  Can be multiple.
     */
-  def cfgLast: Expression[Labels] =
-    new Expression[Labels](
+  def cfgLast: Expression =
+    new Expression(
       raw.in(EdgeTypes.CFG).cast[nodes.Expression]
     )
 
   /**
     * Traverse to return type
     * */
-  def typ: Type[Labels] =
+  def typ: Type =
     new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Namespace.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Namespace.scala
@@ -5,20 +5,19 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.NameAccessors
-import shapeless.HList
 
 /**
   * A namespace, e.g., Java package or C# namespace
   * */
-class Namespace[Labels <: HList](raw: GremlinScala.Aux[nodes.Namespace, Labels])
-    extends NodeSteps[nodes.Namespace, Labels](raw)
-    with NameAccessors[nodes.Namespace, Labels] {
+class Namespace(raw: GremlinScala[nodes.Namespace])
+    extends NodeSteps[nodes.Namespace](raw)
+    with NameAccessors[nodes.Namespace] {
 
   /**
     * The type declarations defined in this namespace
     * */
-  def typeDecl: TypeDecl[Labels] =
-    new TypeDecl[Labels](
+  def typeDecl: TypeDecl =
+    new TypeDecl(
       raw
         .in(EdgeTypes.REF)
         .out(EdgeTypes.AST)
@@ -28,8 +27,8 @@ class Namespace[Labels <: HList](raw: GremlinScala.Aux[nodes.Namespace, Labels])
   /**
     * Methods defined in this namespace
     * */
-  def method: Method[Labels] =
-    new Method[Labels](
+  def method: Method =
+    new Method(
       raw
         .in(EdgeTypes.REF)
         .out(EdgeTypes.AST)
@@ -40,14 +39,14 @@ class Namespace[Labels <: HList](raw: GremlinScala.Aux[nodes.Namespace, Labels])
     * External namespaces - any namespaces
     * which contain one or more external type.
     * */
-  def external: Namespace[Labels] =
+  def external: Namespace =
     new Namespace(filter(_.typeDecl.external).raw)
 
   /**
     * Internal namespaces - any namespaces
     * which contain one or more internal type
     * */
-  def internal: Namespace[Labels] =
+  def internal: Namespace =
     new Namespace(filter(_.typeDecl.internal).raw)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
@@ -4,23 +4,22 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.NameAccessors
-import shapeless.HList
 
-class NamespaceBlock[Labels <: HList](raw: GremlinScala.Aux[nodes.NamespaceBlock, Labels])
-    extends NodeSteps[nodes.NamespaceBlock, Labels](raw)
-    with NameAccessors[nodes.NamespaceBlock, Labels] {
+class NamespaceBlock(raw: GremlinScala[nodes.NamespaceBlock])
+    extends NodeSteps[nodes.NamespaceBlock](raw)
+    with NameAccessors[nodes.NamespaceBlock] {
 
   /**
     * Namespaces for namespace blocks.
     * */
-  def namespaces: Namespace[Labels] =
-    new Namespace[Labels](raw.out(EdgeTypes.REF).cast[nodes.Namespace])
+  def namespaces: Namespace =
+    new Namespace(raw.out(EdgeTypes.REF).cast[nodes.Namespace])
 
   /**
     * The type declarations defined in this namespace
     * */
-  def typeDecl: TypeDecl[Labels] =
-    new TypeDecl[Labels](
+  def typeDecl: TypeDecl =
+    new TypeDecl(
       raw
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.TYPE_DECL)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -6,106 +6,105 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{FullNameAccessors, NameAccessors}
-import shapeless.HList
 
-class Type[Labels <: HList](raw: GremlinScala.Aux[nodes.Type, Labels])
-    extends NodeSteps[nodes.Type, Labels](raw)
-    with NameAccessors[nodes.Type, Labels]
-    with FullNameAccessors[nodes.Type, Labels] {
+class Type(raw: GremlinScala[nodes.Type])
+    extends NodeSteps[nodes.Type](raw)
+    with NameAccessors[nodes.Type]
+    with FullNameAccessors[nodes.Type] {
 
   /**
     * Namespaces in which the corresponding type declaration is defined.
     * */
-  def namespace: Namespace[Labels] =
+  def namespace: Namespace =
     referencedTypeDecl.namespace
 
   /**
     * Methods defined on the corresponding type declaration.
     * */
-  def method: Method[Labels] =
+  def method: Method =
     referencedTypeDecl.method
 
   /**
     * Filter for types whos corresponding type declaration is in the analyzed jar.
     * */
-  def internal: Type[Labels] =
+  def internal: Type =
     filter(_.referencedTypeDecl.internal)
 
   /**
     * Filter for types whos corresponding type declaration is not in the analyzed jar.
     * */
-  def external: Type[Labels] =
+  def external: Type =
     filter(_.referencedTypeDecl.external)
 
   /**
     * Member variables of the corresponding type declaration.
     * */
-  def member: Member[Labels] =
+  def member: Member =
     referencedTypeDecl.member
 
   /**
     * Direct base types of the corresponding type declaration in the inheritance graph.
     * */
-  def baseType: Type[Labels] =
+  def baseType: Type =
     referencedTypeDecl.baseType
 
   /**
     * Direct and transitive base types of the corresponding type declaration.
     * */
-  def baseTypeTransitive: Type[Labels] = {
+  def baseTypeTransitive: Type = {
     repeat(_.baseType).emit()
   }
 
   /**
     * Direct derived types.
     * */
-  def derivedType: Type[Labels] =
+  def derivedType: Type =
     derivedTypeDecl.referencingType
 
   /**
     * Direct and transitive derived types.
     * */
-  def derivedTypeTransitive: Type[Labels] =
+  def derivedTypeTransitive: Type =
     repeat(_.derivedType).emit()
 
   /**
     * Type declaration which is referenced by this type.
     */
-  def referencedTypeDecl: TypeDecl[Labels] =
-    new TypeDecl[Labels](raw.out(EdgeTypes.REF).cast[nodes.TypeDecl])
+  def referencedTypeDecl: TypeDecl =
+    new TypeDecl(raw.out(EdgeTypes.REF).cast[nodes.TypeDecl])
 
   /**
     * Type declarations which derive from this type.
     */
-  def derivedTypeDecl: TypeDecl[Labels] =
-    new TypeDecl[Labels](raw.in(EdgeTypes.INHERITS_FROM).cast[nodes.TypeDecl])
+  def derivedTypeDecl: TypeDecl =
+    new TypeDecl(raw.in(EdgeTypes.INHERITS_FROM).cast[nodes.TypeDecl])
 
   /**
     * Direct alias type declarations.
     */
-  def aliasTypeDecl: TypeDecl[Labels] = {
-    new TypeDecl[Labels](raw.in(EdgeTypes.ALIAS_OF).cast[nodes.TypeDecl])
+  def aliasTypeDecl: TypeDecl = {
+    new TypeDecl(raw.in(EdgeTypes.ALIAS_OF).cast[nodes.TypeDecl])
   }
 
   /**
     * Direct alias types.
     */
-  def aliasType: Type[Labels] = {
+  def aliasType: Type = {
     aliasTypeDecl.referencingType
   }
 
   /**
     * Direct and transitive alias types.
     */
-  def aliasTypeTransitive: Type[Labels] = {
+  def aliasTypeTransitive: Type = {
     repeat(_.aliasType).emit()
   }
 
-  def localsOfType: Local[Labels] =
-    new Local[Labels](raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
+  def localsOfType: Local =
+    new Local(raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
-  def expressionOfType: Expression[Labels] =
-    new Expression[Labels](
+  def expressionOfType: Expression =
+    new Expression(
       raw
         .in(EdgeTypes.EVAL_TYPE)
         .hasLabel(NodeTypes.IDENTIFIER, NodeTypes.CALL, NodeTypes.LITERAL)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -7,29 +7,28 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Modifier
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{FullNameAccessors, IsExternalAccessor, NameAccessors}
 import org.apache.tinkerpop.gremlin.structure.Direction
-import shapeless.HList
 
 /**
   * Type declaration - possibly a template that requires instantiation
   * */
-class TypeDecl[Labels <: HList](raw: GremlinScala.Aux[nodes.TypeDecl, Labels])
-    extends NodeSteps[nodes.TypeDecl, Labels](raw)
-    with NameAccessors[nodes.TypeDecl, Labels]
-    with FullNameAccessors[nodes.TypeDecl, Labels]
-    with IsExternalAccessor[nodes.TypeDecl, Labels] {
+class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
+    extends NodeSteps[nodes.TypeDecl](raw)
+    with NameAccessors[nodes.TypeDecl]
+    with FullNameAccessors[nodes.TypeDecl]
+    with IsExternalAccessor[nodes.TypeDecl] {
   import TypeDecl._
 
   /**
     * Types referencing to this type declaration.
     * */
-  def referencingType: Type[Labels] =
-    new Type[Labels](raw.in(EdgeTypes.REF).cast[nodes.Type])
+  def referencingType: Type =
+    new Type(raw.in(EdgeTypes.REF).cast[nodes.Type])
 
   /**
     * Namespace in which this type declaration is defined
     * */
-  def namespace: Namespace[Labels] =
-    new Namespace[Labels](
+  def namespace: Namespace =
+    new Namespace(
       raw
         .in(EdgeTypes.AST)
         .hasLabel(NodeTypes.NAMESPACE_BLOCK)
@@ -39,62 +38,62 @@ class TypeDecl[Labels <: HList](raw: GremlinScala.Aux[nodes.TypeDecl, Labels])
   /**
     * Methods defined as part of this type
     * */
-  def method: Method[Labels] =
-    new Method[Labels](canonicalType.raw.out(EdgeTypes.AST).hasLabel(NodeTypes.METHOD).cast[nodes.Method])
+  def method: Method =
+    new Method(canonicalType.raw.out(EdgeTypes.AST).hasLabel(NodeTypes.METHOD).cast[nodes.Method])
 
   /**
     * Filter for type declarations contained in the analyzed code.
     * */
-  def internal: TypeDecl[Labels] =
-    new TypeDecl[Labels](canonicalType.raw.has(NodeKeys.IS_EXTERNAL -> false))
+  def internal: TypeDecl =
+    new TypeDecl(canonicalType.raw.has(NodeKeys.IS_EXTERNAL -> false))
 
   /**
     * Filter for type declarations not contained in the analyzed code.
     * */
-  def external: TypeDecl[Labels] =
-    new TypeDecl[Labels](canonicalType.raw.has(NodeKeys.IS_EXTERNAL -> true))
+  def external: TypeDecl =
+    new TypeDecl(canonicalType.raw.has(NodeKeys.IS_EXTERNAL -> true))
 
   /**
     * Member variables
     * */
-  def member: Member[Labels] =
-    new Member[Labels](canonicalType.raw.out().hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
+  def member: Member =
+    new Member(canonicalType.raw.out().hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
 
   /**
     * Direct base types in the inheritance graph.
     * */
-  def baseType: Type[Labels] =
+  def baseType: Type =
     new Type(canonicalType.raw.out(EdgeTypes.INHERITS_FROM).cast[nodes.Type])
 
   /**
     * Direct base type declaration.
     * */
-  def derivedTypeDecl: TypeDecl[Labels] =
+  def derivedTypeDecl: TypeDecl =
     referencingType.derivedTypeDecl
 
   /**
     * Direct and transitive base type declaration.
     * */
-  def derivedTypeDeclTransitive: TypeDecl[Labels] =
+  def derivedTypeDeclTransitive: TypeDecl =
     repeat(_.derivedTypeDecl).emit()
 
   /**
     * Direct base type declaration.
     */
-  def baseTypeDecl: TypeDecl[Labels] =
+  def baseTypeDecl: TypeDecl =
     baseType.referencedTypeDecl
 
   /**
     * Direct and transitive base type declaration.
     */
-  def baseTypeDeclTransitive: TypeDecl[Labels] =
+  def baseTypeDeclTransitive: TypeDecl =
     repeat(_.baseTypeDecl).emit()
 
   /**
     * Traverse to the methods which are part of the VTables of this type declaration.
     */
-  def vtableMethod: Method[Labels] = {
-    new Method[Labels](
+  def vtableMethod: Method = {
+    new Method(
       canonicalType.raw.out(EdgeTypes.VTABLE).cast[nodes.Method]
     )
   }
@@ -102,8 +101,8 @@ class TypeDecl[Labels <: HList](raw: GremlinScala.Aux[nodes.TypeDecl, Labels])
   /**
     * Traverse to method modifiers, e.g., "static", "public".
     * */
-  def modifier: Modifier[Labels] =
-    new Modifier[Labels](
+  def modifier: Modifier =
+    new Modifier(
       canonicalType.raw.out
         .hasLabel(NodeTypes.MODIFIER)
         .cast[nodes.Modifier]
@@ -112,23 +111,23 @@ class TypeDecl[Labels <: HList](raw: GremlinScala.Aux[nodes.TypeDecl, Labels])
   /**
     * Traverse to alias type declarations.
     */
-  def isAlias: TypeDecl[Labels] = {
-    new TypeDecl[Labels](raw.filterOnEnd(_.aliasTypeFullName.isDefined))
+  def isAlias: TypeDecl = {
+    new TypeDecl(raw.filterOnEnd(_.aliasTypeFullName.isDefined))
   }
 
   /**
     * Traverse to canonical type declarations.
     */
-  def isCanonical: TypeDecl[Labels] = {
-    new TypeDecl[Labels](raw.filterOnEnd(_.aliasTypeFullName.isEmpty))
+  def isCanonical: TypeDecl = {
+    new TypeDecl(raw.filterOnEnd(_.aliasTypeFullName.isEmpty))
   }
 
   /**
     * If this is an alias type declaration, go to its underlying type declaration
     * else unchanged.
     */
-  def unravelAlias: TypeDecl[Labels] = {
-    new TypeDecl[Labels](raw.map { typeDecl =>
+  def unravelAlias: TypeDecl = {
+    new TypeDecl(raw.map { typeDecl =>
       if (typeDecl.aliasTypeFullName.isDefined) {
         typeDecl
           .vertices(Direction.OUT, EdgeTypes.ALIAS_OF)
@@ -147,13 +146,13 @@ class TypeDecl[Labels <: HList](raw: GremlinScala.Aux[nodes.TypeDecl, Labels])
     * Traverse to canonical type which means unravel aliases until we find
     * a non alias type declaration.
     */
-  def canonicalType: TypeDecl[Labels] = {
+  def canonicalType: TypeDecl = {
     // We cannot use this compact form because the gremlin implementation at least
     // in some case seems to have problems with nested "repeat" steps. Since this
     // step is used in other repeat steps we do not use it here.
     //until(_.isCanonical).repeat(_.unravelAlias)
 
-    new TypeDecl[Labels](raw.map { typeDecl =>
+    new TypeDecl(raw.map { typeDecl =>
       var currentTypeDecl = typeDecl
       var aliasExpansionCounter = 0
       while (currentTypeDecl.aliasTypeFullName.isDefined && aliasExpansionCounter < maxAliasExpansions) {
@@ -173,14 +172,14 @@ class TypeDecl[Labels <: HList](raw: GremlinScala.Aux[nodes.TypeDecl, Labels])
   /**
     *  Direct alias type declarations.
     */
-  def aliasTypeDecl: TypeDecl[Labels] = {
+  def aliasTypeDecl: TypeDecl = {
     referencingType.aliasTypeDecl
   }
 
   /**
     *  Direct and transitive alias type declarations.
     */
-  def alisTypeDeclTransitive: TypeDecl[Labels] = {
+  def alisTypeDeclTransitive: TypeDecl = {
     repeat(_.aliasTypeDecl).emit()
   }
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -6,7 +6,6 @@ import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.json4s.JString
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.{Matchers, WordSpec}
-import shapeless.HNil
 
 import scala.collection.mutable
 
@@ -103,47 +102,6 @@ class StepsTest extends WordSpec with Matchers {
     var i = 0
     fixture.cpg.method.sideEffect(_ => i = i + 1).exec
     i should be > 0
-  }
-
-  "as/select" should {
-    "select all by default" in ExistingCpgFixture("splitmeup") { fixture =>
-      val results: List[(nodes.Method, nodes.MethodReturn)] =
-        fixture.cpg.method.as("method").methodReturn.as("methodReturn").select.toList
-
-      results.size should be > 0
-    }
-
-    "allow to select a single label" in ExistingCpgFixture("splitmeup") { fixture =>
-      val methodReturnLabel = StepLabel[nodes.MethodReturn]("methodReturn")
-      val methodLabel = StepLabel[nodes.Method]("method")
-      val results: List[nodes.MethodReturn] =
-        fixture.cpg.method.as(methodLabel).methodReturn.as(methodReturnLabel).select(methodReturnLabel).toList
-
-      results.size should be > 0
-    }
-
-    "allow to select multiple labels" in ExistingCpgFixture("splitmeup") { fixture =>
-      val methodReturnLabel = StepLabel[nodes.MethodReturn]("methodReturn")
-      val methodLabel = StepLabel[nodes.Method]("method")
-      val results: List[(nodes.MethodReturn, nodes.Method)] =
-        fixture.cpg.method
-          .as(methodLabel)
-          .methodReturn
-          .as(methodReturnLabel)
-          .select((methodReturnLabel, methodLabel))
-          .toList
-
-      results.size should be > 0
-    }
-  }
-
-  "raw traversals" should {
-    "allow typed as/select" in ExistingCpgFixture("splitmeup") { fixture =>
-      val raw = fixture.cpg.namespace.raw.asInstanceOf[GremlinScala.Aux[Vertex, HNil]]
-      val _: List[(Vertex, Edge)] = raw.as("a").outE.as("b").select.toList
-    // all that matters is that the result type is (Vertex, Edge)
-    // for more options with as/select on raw, see https://github.com/mpollmeier/gremlin-scala/blob/master/gremlin-scala/src/test/scala/gremlin/scala/SelectSpec.scala
-    }
   }
 
   "toJson" in ExistingCpgFixture("splitmeup") { fixture =>


### PR DESCRIPTION
The `Labels` type parameter allowed us to refer back to previous steps
in a type-safe manner, using the `as/select` construct. This was neat,
but we never really used this feature. Since managing the type
parameter is quite a lot of code, which is especially hard to read for
newcomers to this codebase and/or scala, we're now dropping it altogether.