### PR TITLE
Make CALL_REPR trait a subtype of CFG_NODE.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -267,7 +267,7 @@
       { "name" : "TRACKING_POINT", "comment" : "Any node that can occur in a data flow", "hasKeys" : [], "extends": ["WITHIN_METHOD"]},
       { "name" : "WITHIN_METHOD", "comment" : "Any node that can exist in a method", "hasKeys" : []},
       { "name" : "AST_NODE", "comment": "Any node that can exist in an abstract syntax tree.", "hasKeys" : ["ORDER"]},
-      { "name" : "CALL_REPR", "comment": "Call representation", "hasKeys" : ["CODE", "NAME", "SIGNATURE"], "extends": []}
+      { "name" : "CALL_REPR", "comment": "Call representation", "hasKeys" : ["CODE", "NAME", "SIGNATURE"], "extends": ["CFG_NODE"]}
     ],
 
     "edgeTypes" : [

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -15,7 +15,7 @@
         "id":307,"name" : "IMPLICIT_CALL",
           "keys" : ["CODE", "NAME", "SIGNATURE", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
         "comment" : "An implicit call site hidden in a method indicated by METHOD_MAP policy entries",
-        "is": ["CALL_REPR", "CFG_NODE", "TRACKING_POINT"],
+        "is": ["CALL_REPR", "TRACKING_POINT"],
         "outEdges" : []
       },
 


### PR DESCRIPTION
The implementations of CALL_REPR (CALL and IMPLICIT_CALL) have already
been of type CFG_NODE. We now also want their common ancestor type to be
a CFG_NODE.