### PR TITLE
Intern duplicate string/symbols in the CPG Loader

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
@@ -1,8 +1,10 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
 import java.lang.{Boolean => JBoolean, Integer => JInt, Long => JLong}
+import java.util
 import java.util.{NoSuchElementException, Collection => JCollection, Iterator => JIterator}
 
+import gnu.trove.map.hash.THashMap
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.{Edge, Node}
 import io.shiftleft.proto.cpg.Cpg.PropertyValue
@@ -14,26 +16,30 @@ import io.shiftleft.overflowdb.OdbGraph
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import io.shiftleft.overflowdb.OdbConfig
+import io.shiftleft.utils.StringInterner
 
 object ProtoToCpg {
   val logger: Logger = LogManager.getLogger(classOf[ProtoToCpg])
 
-  def addProperties(keyValues: ArrayBuffer[AnyRef], name: String, value: PropertyValue): Unit = {
+  def addProperties(keyValues: ArrayBuffer[AnyRef],
+                    name: String,
+                    value: PropertyValue,
+                    interner: StringInterner = StringInterner.noop): Unit = {
     import io.shiftleft.proto.cpg.Cpg.PropertyValue.ValueCase._
     value.getValueCase match {
       case INT_VALUE =>
-        keyValues += name
+        keyValues += interner.intern(name)
         keyValues += (value.getIntValue: JInt)
       case STRING_VALUE =>
-        keyValues += name
-        keyValues += value.getStringValue
+        keyValues += interner.intern(name)
+        keyValues += interner.intern(value.getStringValue)
       case BOOL_VALUE =>
-        keyValues += name
+        keyValues += interner.intern(name)
         keyValues += (value.getBoolValue: JBoolean)
       case STRING_LIST =>
         value.getStringList.getValuesList.asScala.foreach { elem: String =>
-          keyValues += name
-          keyValues += elem
+          keyValues += interner.intern(name)
+          keyValues += interner.intern(elem)
         }
       case VALUE_NOT_SET => ()
       case _ =>
@@ -49,6 +55,7 @@ class ProtoToCpg(overflowConfig: OdbConfig = OdbConfig.withoutOverflow) {
     OdbGraph.open(overflowConfig,
                   io.shiftleft.codepropertygraph.generated.nodes.Factories.AllAsJava,
                   io.shiftleft.codepropertygraph.generated.edges.Factories.AllAsJava)
+  private val interner: StringInterner = StringInterner.makeStrongInterner()
 
   def addNodes(nodes: JCollection[Node]): Unit =
     addNodes(nodes.asScala)
@@ -76,7 +83,7 @@ class ProtoToCpg(overflowConfig: OdbConfig = OdbConfig.withoutOverflow) {
       val properties: Seq[Edge.Property] = edge.getPropertyList.asScala
       val keyValues = new ArrayBuffer[AnyRef](2 * properties.size)
       for (edgeProperty <- properties) {
-        addProperties(keyValues, edgeProperty.getName.name(), edgeProperty.getValue)
+        addProperties(keyValues, edgeProperty.getName.name(), edgeProperty.getValue, interner)
       }
       try {
         srcVertex.addEdge(edge.getType.name(), dstVertex, keyValues.toArray: _*)
@@ -113,7 +120,7 @@ class ProtoToCpg(overflowConfig: OdbConfig = OdbConfig.withoutOverflow) {
     keyValues += T.label
     keyValues += node.getType.name()
     for (prop <- props.asScala) {
-      addProperties(keyValues, prop.getName.name, prop.getValue)
+      addProperties(keyValues, prop.getName.name, prop.getValue, interner)
     }
     keyValues.toArray
   }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
@@ -1,10 +1,8 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
 import java.lang.{Boolean => JBoolean, Integer => JInt, Long => JLong}
-import java.util
 import java.util.{NoSuchElementException, Collection => JCollection, Iterator => JIterator}
 
-import gnu.trove.map.hash.THashMap
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.{Edge, Node}
 import io.shiftleft.proto.cpg.Cpg.PropertyValue

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/StringInterner.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/StringInterner.scala
@@ -7,7 +7,7 @@ trait StringInterner {
 }
 
 object StringInterner {
-  val DefaultMaxStringLength: Int = 64
+  val DefaultMaxStringLength: Int = 1024
   val DefaultInitialSize: Int = 64 * 1024
 
   val noop: StringInterner = new StringInterner {

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/StringInterner.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/StringInterner.scala
@@ -1,0 +1,34 @@
+package io.shiftleft.utils
+
+import gnu.trove.map.hash.THashMap
+
+trait StringInterner {
+  def intern(s: String): String
+}
+
+object StringInterner {
+  val DefaultMaxStringLength: Int = 64
+  val DefaultInitialSize: Int = 64 * 1024
+
+  val noop: StringInterner = new StringInterner {
+    override def intern(s: String): String = s
+  }
+  def makeStrongInterner(maxStringLength: Int = DefaultMaxStringLength,
+                         initialSize: Int = DefaultInitialSize): StringInterner = new StringInterner {
+    private val stringCache = new THashMap[String, String](initialSize)
+
+    def intern(s: String): String = {
+      if (s.length < maxStringLength) {
+        val cached = stringCache.get(s)
+        if (cached == null) {
+          stringCache.put(s, s)
+          s
+        } else {
+          cached
+        }
+      } else {
+        s
+      }
+    }
+  }
+}

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/StringInterner.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/StringInterner.scala
@@ -2,6 +2,12 @@ package io.shiftleft.utils
 
 import gnu.trove.map.hash.THashMap
 
+/**
+  * Interface for deduplicating strings used by CPGLoader.
+  * JVM with G1 GC does this automatically but it is not guaranteed to happen
+  * and when performing CPU heavy calculations doing this manually ensures
+  * that we won't run out of memory.
+  */
 trait StringInterner {
   def intern(s: String): String
 }
@@ -13,6 +19,13 @@ object StringInterner {
   val noop: StringInterner = new StringInterner {
     override def intern(s: String): String = s
   }
+
+  /** Creates a string interner that will hold strong references to the interned objects
+    * and they wont be GC'ed until reference to the interner is released.
+    * @param maxStringLength Maximum string length that will be considered for interning
+    * @param initialSize Initial string table size
+    * @return Instance of the StringInterner which uses strong references
+    */
   def makeStrongInterner(maxStringLength: Int = DefaultMaxStringLength,
                          initialSize: Int = DefaultInitialSize): StringInterner = new StringInterner {
     private val stringCache = new THashMap[String, String](initialSize)


### PR DESCRIPTION
Removing duplicate strings frees up to 15% of heap on a moderate size cpg.