### PR TITLE
Move dataflowrunner to `layers`

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.dataflowengine.passes.dataflows
+package io.shiftleft.dataflowengine.layers.dataflows
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
@@ -2,7 +2,7 @@ package io.shiftleft.dataflowengine.language
 
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.dataflowengine.passes.dataflows.DataFlowRunner
+import io.shiftleft.dataflowengine.layers.dataflows.DataFlowRunner
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
 import io.shiftleft.semanticcpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
 import io.shiftleft.dataflowengine.semanticsloader.SemanticsLoader

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -140,7 +140,7 @@ class Linker(cpg: Cpg) extends CpgPass(cpg) {
                            dstGraph: DiffGraph): Unit = {
     var loggedDeprecationWarning = false
     val sourceTraversal = cpg.graph.V.hasLabel(srcLabels.head, srcLabels.tail: _*)
-    val sourceIterator = new Steps(sourceTraversal).toIterator
+    val sourceIterator = new Steps(sourceTraversal).toIterator()
     sourceIterator.foreach { srcNode =>
       if (!srcNode.edges(Direction.OUT, edgeType).hasNext) {
         // for `UNKNOWN` this is not always set, so we're using an Option here


### PR DESCRIPTION
DataFlowRunner creates a layer using passes, and it should therefore be in the package `layers`, not `passes`.