### PR TITLE
Allow overriding of shutdownHooks and prompt

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -59,14 +59,14 @@ trait BridgeBase {
         readScript(file.toScala)
       }
 
-    val shutdownHooks = List(
-      "interp.beforeExitHooks.append{_ => workspace.loadedCpgs.foreach(_.close)}"
-    )
+    def shutdownHooks: List[String] = List()
+
+    def promptStr(): String = "ocular>"
 
     config.scriptFile match {
       case None =>
         val replConfig = List(
-          "repl.prompt() = \"ocular> \"",
+          "repl.prompt() = \"" + promptStr() + "\"",
           "repl.pprinter() = repl.pprinter().copy(defaultHeight = 99999)",
           "banner()"
         )


### PR DESCRIPTION
A fix for the `BridgeBase` class introduced in my PR yesterday: we need to be able to override the `shutdownHooks` and `prompt` for the Joern shell to start.