### PR TITLE
Fix cpgvalidator error reporting

### DIFF
--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
@@ -6,9 +6,10 @@ import io.shiftleft.cpgvalidator.validators.CpgValidator
 object CpgValidatorMain extends App {
   val cpgFileName = args(0)
   val cpg = CpgLoader.load(cpgFileName, CpgLoaderConfig.withoutOverflow)
-  val validator = new CpgValidator()
+  val errorRegistry = new ValidationErrorRegistry
+  val validator = new CpgValidator(errorRegistry)
   val cpgValid = validator.validate(cpg)
-  validator.logValidationErrors()
+  errorRegistry.logValidationErrors()
 
   if (cpgValid) {
     System.exit(0)

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/CpgValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/CpgValidator.scala
@@ -3,11 +3,10 @@ package io.shiftleft.cpgvalidator.validators
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.cpgvalidator.ValidationErrorRegistry
 
-class CpgValidator extends Validator {
+class CpgValidator(errorRegistry: ValidationErrorRegistry) {
   private val validators =
-    Seq(new OutFactsValidator(), new InFactsValidator(), new KeysValidator())
+    Seq(new OutFactsValidator(errorRegistry), new InFactsValidator(errorRegistry), new KeysValidator(errorRegistry))
 
-  override def validate(notEnhancedCpg: Cpg): Boolean =
+  def validate(notEnhancedCpg: Cpg): Boolean =
     validators.forall(_.validate(notEnhancedCpg))
-
 }

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/InFactsValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/InFactsValidator.scala
@@ -9,7 +9,7 @@ import org.apache.tinkerpop.gremlin.structure.Direction
 
 import scala.collection.JavaConverters._
 
-class InFactsValidator extends Validator {
+class InFactsValidator(errorRegistry: ValidationErrorRegistry) extends Validator {
 
   override def validate(notEnhancedCpg: Cpg): Boolean = {
     validateInFacts(notEnhancedCpg)

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/KeysValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/KeysValidator.scala
@@ -9,7 +9,7 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty
 
 import scala.collection.JavaConverters._
 
-class KeysValidator extends Validator {
+class KeysValidator(errorRegistry: ValidationErrorRegistry) extends Validator {
 
   override def validate(notEnhancedCpg: Cpg): Boolean = {
     validateKeysFacts(notEnhancedCpg)

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/OutFactsValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/OutFactsValidator.scala
@@ -9,7 +9,7 @@ import org.apache.tinkerpop.gremlin.structure.Direction
 
 import scala.collection.JavaConverters._
 
-class OutFactsValidator extends Validator {
+class OutFactsValidator(errorRegistry: ValidationErrorRegistry) extends Validator {
 
   override def validate(notEnhancedCpg: Cpg): Boolean = {
     validateOutFacts(notEnhancedCpg)

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/Validator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/Validator.scala
@@ -3,12 +3,6 @@ package io.shiftleft.cpgvalidator.validators
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.cpgvalidator.ValidationErrorRegistry
 
-abstract class Validator {
-  protected val errorRegistry = new ValidationErrorRegistry()
-
+abstract class Validator() {
   def validate(notEnhancedCpg: Cpg): Boolean
-
-  def logValidationErrors(): Unit =
-    errorRegistry.logValidationErrors()
-
 }

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
@@ -1,0 +1,27 @@
+package io.shiftleft.cpgvalidator
+
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.cpgvalidator.validators.CpgValidator
+import gremlin.scala._
+import io.shiftleft.OverflowDbTestInstance
+import io.shiftleft.codepropertygraph.Cpg
+import org.scalatest.{Matchers, WordSpec}
+
+class CpgValidatorTest extends WordSpec with Matchers {
+  private def withNewBaseCpg[T](fun: Cpg => T): T = {
+    val graph = OverflowDbTestInstance.create
+    val cpg = Cpg(graph)
+    try fun(cpg)
+    finally cpg.close()
+  }
+
+  "CpgValidator reports errors from nested validators" in {
+    withNewBaseCpg { cpg =>
+      val errorRegistry = new ValidationErrorRegistry()
+      val validator = new CpgValidator(errorRegistry)
+      cpg.graph + NodeTypes.METHOD
+      validator.validate(cpg) shouldBe false
+      errorRegistry.getErrorCount shouldBe 2
+    }
+  }
+}


### PR DESCRIPTION
Currently, all the validators inherit from the `Validator` class.
The `Validator` holds a property `errorRegistry`, which is supposed to be
filled in by the children classes. After validation, the base class
prints all the errors found by its children classes. The children
classes, however, get their own copy of the `errorRegistry` and save
errors into it, leaving the `errorRegistry` of the base class empty.
So the base class then prints all the errors from an empty
`errorRegistry`.

This patch makes sure that only one `errorRegistry` exists and is shared
between all the validators.