### PR TITLE
upgrade release plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 matrix:
   include:
   - language: scala
-    dist: bionic
-    jdk: openjdk10
+    dist: xenial
+    jdk: openjdk8
     if: tag IS blank
     branches:
       only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 matrix:
   include:
   - language: scala
-    jdk: openjdk8
+    dist: bionic
+    jdk: openjdk10
+    if: tag IS blank
     branches:
       only:
       - master
@@ -9,9 +11,9 @@ matrix:
     - git fetch --tags
     - git lfs fetch --all
     - if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "push" ]]; then
-      openssl aes-256-cbc -K $encrypted_663dec309dc8_key -iv $encrypted_663dec309dc8_iv
-      -in private-key.pem.enc -out private-key.pem -d; gpg --import private-key.pem;
-      gpg --list-keys; fi
+        openssl aes-256-cbc -K $encrypted_663dec309dc8_key -iv $encrypted_663dec309dc8_iv -in private-key.pem.enc -out private-key.pem -d;
+        gpg --import --batch private-key.pem;
+      fi
     env:
     - PROTOC_PKG=protoc-3.6.0-linux-x86_64.zip
     - PROTOC_RELEASE=https://github.com/google/protobuf/releases/download/v3.6.0/$PROTOC_PKG

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,8 @@ lazy val cpgvalidator = Projects.cpgvalidator
 lazy val cpg2overflowdb = Projects.cpg2overflowdb
 lazy val console = Projects.console
 
-ThisBuild/publishTo := sonatypePublishTo.value
+ThisBuild/publishTo := sonatypePublishToBundle.value
+Global/useGpgPinentry := true
 ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 ThisBuild/compile/javacOptions ++= Seq("-g") //debug symbols
 

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ lazy val cpg2overflowdb = Projects.cpg2overflowdb
 lazy val console = Projects.console
 
 ThisBuild/publishTo := sonatypePublishToBundle.value
-Global/useGpgPinentry := true
+Global / useGpg := false
 ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 ThisBuild/compile/javacOptions ++= Seq("-g") //debug symbols
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
-// coursier doesn't work together with oracle's repository :(
-// addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M7")
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.4")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
-addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.0.18")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.1.8")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.13")
 addSbtPlugin("org.scalatra.sbt" % "sbt-scalatra" % "1.0.2")


### PR DESCRIPTION
Latest release plugin supports sonatype bundle upload which is much faster and should result in less timeouts. Also uses the latest sbt-pgp release which uses the command line `gpg` signer.