### PR TITLE
refactor domain class generator

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -46,8 +46,9 @@ Compile / sourceGenerators += Def.task {
   if (!outputRoot.exists || CodeGenGlobalState.lastMd5 != currentMd5) {
     val schemaFile = "codepropertygraph/src/main/resources/cpg.json"
     println(s"generating domain classes from $schemaFile")
+    val basePackage = "io.shiftleft.codepropertygraph.generated"
     val outputDir = (Compile / sourceManaged).value
-    new DomainClassCreator(schemaFile).run(outputDir)
+    new DomainClassCreator(schemaFile, basePackage).run(outputDir)
 
     // TODO: port python to jpython, scala or java to avoid system call and pass values in/out
     val cmd = "codepropertygraph/codegen/src/main/python/generateJava.py"

--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -44,8 +44,10 @@ Compile / sourceGenerators += Def.task {
   val outputRoot = new File(sourceManaged.in(Compile).value.getAbsolutePath + "/io/shiftleft/codepropertygraph/generated")
 
   if (!outputRoot.exists || CodeGenGlobalState.lastMd5 != currentMd5) {
-    println("regenerating domain classes")
-    DomainClassCreator.run((Compile / sourceManaged).value)
+    val schemaFile = "codepropertygraph/src/main/resources/cpg.json"
+    println(s"generating domain classes from $schemaFile")
+    val outputDir = (Compile / sourceManaged).value
+    new DomainClassCreator(schemaFile).run(outputDir)
 
     // TODO: port python to jpython, scala or java to avoid system call and pass values in/out
     val cmd = "codepropertygraph/codegen/src/main/python/generateJava.py"

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -865,13 +865,6 @@ object Utils {
 
       getHigherType(property) match {
         case HigherValueType.None =>
-        /** TODO: rather than returning `null`, throw an exception, since this is a schema violation:
-          s"""|var _$name: $tpe = null
-              |def $name: $tpe =
-              |  if (_$name == null) {
-              |    throw new AssertionError("property $name is mandatory but hasn't been initialised yet")
-              |} else { _$name } """.stripMargin
-          */
           s"""|private var _$name: $tpe = null
               |def $name(): $tpe = _$name""".stripMargin
         case HigherValueType.Option =>

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -786,7 +786,6 @@ case class ContainedNode(nodeType: String, localName: String, cardinality: Strin
   lazy val nodeTypeClassName = Utils.camelCase(nodeType).capitalize
 }
 
-// TODO: use better json library which supports enums
 sealed abstract class Cardinality(val name: String)
 object Cardinality {
   case object ZeroOrOne extends Cardinality("zeroOrOne")

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -25,11 +25,15 @@ class Schema(schemaFile: String) {
   lazy val edgeKeys = (jsonRoot \ "edgeKeys").as[List[Property]]
 }
 
-/** Parses schema file and generates a domain model for OverflowDb */
-class DomainClassCreator(schemaFile: String) {
+/** Generates a domain model for OverflowDb traversals based on your domain-specific json schema.
+  * 
+  * @param schemaFile: path to the schema (json file)
+  * @param basePackage: specific for your domain, e.g. `com.example.mydomain`
+  */
+class DomainClassCreator(schemaFile: String, basePackage: String) {
   import Helpers._
-  val nodesPackage = "io.shiftleft.codepropertygraph.generated.nodes"
-  val edgesPackage = "io.shiftleft.codepropertygraph.generated.edges"
+  val nodesPackage = s"$basePackage.nodes"
+  val edgesPackage = s"$basePackage.edges"
   val schema = new Schema(schemaFile)
 
   def run(outputDir: JFile): List[JFile] =
@@ -170,7 +174,9 @@ class DomainClassCreator(schemaFile: String) {
       package $nodesPackage
 
       import gremlin.scala._
-      import io.shiftleft.codepropertygraph.generated.EdgeKeys
+      import $basePackage.EdgeKeys
+      import $basePackage.edges
+      import $basePackage.edges._
       import java.lang.{Boolean => JBoolean, Long => JLong}
       import java.util.{Collections => JCollections, HashMap => JHashMap, Iterator => JIterator, Map => JMap, Set => JSet}
       import org.apache.tinkerpop.gremlin.structure.{Direction, Vertex, VertexProperty}
@@ -178,8 +184,6 @@ class DomainClassCreator(schemaFile: String) {
       import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils
       import scala.collection.JavaConverters._
       import org.slf4j.LoggerFactory
-      import io.shiftleft.codepropertygraph.generated.edges
-      import io.shiftleft.codepropertygraph.generated.edges._
 
       object PropertyErrorRegister {
         private var errorMap = Set[(Class[_], String)]()


### PR DESCRIPTION
A lot of housecleaning in preparation for moving the domain class generator to overflowdb.
First round: lot's of refactorings. The resulting generated code is unchanged (ignoring whitespace and some message changes).

It may have been cleaner to create separate PRs, but since this is just a bunch of small refactorings, I didn't want the extra maintenance burdon. It's probably best to review the changes commit by commit.