### PR TITLE
add scala version to artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ inThisBuild(
     resolvers ++= Seq(Resolver.mavenLocal, "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"),
     packageDoc / publishArtifact := true,
     packageSrc / publishArtifact := true,
-    crossPaths := false, // do not append scala version to the generated artifacts
     scmInfo := Some(ScmInfo(url("https://github.com/ShiftLeftSecurity/codepropertygraph"),
                             "scm:git@github.com:ShiftLeftSecurity/codepropertygraph.git")),
     homepage := Some(url("https://github.com/ShiftLeftSecurity/codepropertygraph/")),

--- a/codepropertygraph/codegen/src/main/python/generateJava.py
+++ b/codepropertygraph/codegen/src/main/python/generateJava.py
@@ -3,10 +3,9 @@
 import json, os
 
 # equivalent of `sourceManaged.in(Compile).value` in build.sbt
-OUTPUT_DIR = '../../../../target/src_managed/main/io/shiftleft/codepropertygraph/generated'
+OUTPUT_DIR = '../../../../target/generateJava/' # codepropertygraph/target
 
 def generateJava(cpgDescr):
-
     try:
         os.makedirs(OUTPUT_DIR)
     except FileExistsError:

--- a/codepropertygraph/codegen/src/main/python/generateProtobuf.py
+++ b/codepropertygraph/codegen/src/main/python/generateProtobuf.py
@@ -2,7 +2,7 @@
 
 import json, os
 
-OUTPUT_DIR = '../../../../target/resource_managed/main/'
+OUTPUT_DIR = '../../../../target/' # codepropertygraph/target
 
 def generateProtobuf(cpgDescr):
     protoStr = open('../resources/templates/cpg.proto.tpl').read()

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -685,7 +685,7 @@ class DomainClassCreator(schemaFile: String, basePackage: String) {
     targetFile.createIfNotExists(createParents = true)
 
     println(s"writing results to $targetFile")
-    outputFile.moveTo(targetFile, overwrite = true).toJava
+    outputFile.moveTo(targetFile)(File.CopyOptions(overwrite = true)).toJava
   }
 
   def calculateNodeToInEdges(nodeTypes: List[NodeType]): mutable.MultiMap[String, String] = {

--- a/project/meta-build.sbt
+++ b/project/meta-build.sbt
@@ -1,4 +1,4 @@
 libraryDependencies ++= Seq(
-  "com.github.pathikrit" %% "better-files" % "3.1.0",
+  "com.github.pathikrit" %% "better-files" % "3.8.0",
   "com.typesafe.play" %% "play-json" % "2.6.8"
 )

--- a/samples/pass/build.sbt
+++ b/samples/pass/build.sbt
@@ -1,12 +1,12 @@
 name := "samplepass"
 organization := "io.shiftleft"
 
-val cpgVersion = "0.9.225"
+val cpgVersion = "0.11.1"
 
 libraryDependencies ++= Seq(
 
-  "io.shiftleft" % "codepropertygraph" % cpgVersion,
-  "io.shiftleft" % "enhancements"  % cpgVersion,
+  "io.shiftleft" %% "codepropertygraph" % cpgVersion,
+  "io.shiftleft" %% "enhancements"  % cpgVersion,
 
   "org.scalatest" %% "scalatest" % "3.0.3" % Test
 )


### PR DESCRIPTION
normally, all scala artifacts have the scala major version in their
artifact path. not sure why we don't (yet), but adding it now will
save us some hassle when upgrading to 2.13.
the new artifact name will be `codepropertygraph_2.12`, for which all
scala build tools have a short version, e.g sbt's
`"io.shiftleft" %% "codepropertygraph" % cpgVersion`