### PR TITLE
add fast neighbor api

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" % "overflowdb-tinkerpop3" % "0.28",
+  "io.shiftleft" % "overflowdb-tinkerpop3" % "0.30",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.3.4.17",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" % "overflowdb-tinkerpop3" % "0.18",
+  "io.shiftleft" % "overflowdb-tinkerpop3" % "0.27-SNAPSHOT",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.3.4.17",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" % "overflowdb-tinkerpop3" % "0.27-SNAPSHOT",
+  "io.shiftleft" % "overflowdb-tinkerpop3" % "0.28",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.3.4.17",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -504,7 +504,7 @@ $neighboraccesors
           |}""".stripMargin
       }
       val neighbor_accesors = (outEdges.map(x=>neighboraccessorname(x, "OUT")) ++
-        outEdges.map(x=>neighboraccessorname(x, "IN")) ).zipWithIndex.map{case (s: String, n: Int) =>
+        inEdges.map(x=>neighboraccessorname(x, "IN")) ).zipWithIndex.map{case (s: String, n: Int) =>
           s"override def $s : JIterator[StoredNode] = createAdjacentNodeIteratorByOffSet($n).asInstanceOf[JIterator[StoredNode]]"
       }.mkString("\n")
 

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -157,7 +157,7 @@ class DomainClassCreator(schemaFile: String, basePackage: String) {
     writeFile(filename, edgeHeader, entries)
   }
 
-  def neighboraccessorname(et: String, direction: String) : String = {s"_${et}_${direction}"}
+  def neighboraccessorname(et: String, direction: String) : String = {"_" + camelCase(et + "_" + direction)}
 
 
   def writeNodesFile(outputDir: JFile): JFile = {

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -476,9 +476,9 @@ $neighborAccesors
       |  $abstractContainedNodeAccessors
       |}""".stripMargin
 
-      val neighborDelegators = (outEdges.map(et => neighboraccessorname(et, "OUT")) ++
-                                inEdges.map(et => neighboraccessorname(et, "IN"))).map(st =>
-        s"override def ${st}(): JIterator[StoredNode] = get().${st}()").mkString("\n")
+      val neighborDelegators = (outEdges.map(edgetypename => neighborAccessorName(edgetypename, "OUT")) ++
+                                inEdges.map(edgetypename => neighborAccessorName(edgetypename, "IN"))).map(nbaName =>
+        s"override def ${nbaName}(): JIterator[StoredNode] = get().${nbaName}()").mkString("\n")
 
       val nodeRefImpl = {
         val propertyDelegators = keys.map(_.name).map(camelCase).map { name =>


### PR DESCRIPTION
This adds a new API in order to allow dataflow trackers to traverse the graph more quickly.

This relies on https://github.com/ShiftLeftSecurity/overflowdb/pull/41

Until that is merged in some form, this won't build on jenkins.

However, we can now start the general discussion (do we want this API?), may change where to put it in the class hierarchy, and probably should bikeshed the name.

Current use is `someNode._CALL_OUT()` instead of `someNode.vertices(Direction.OUT, EdgeTypes.CALL)()`.