### PR TITLE
Nits for semanticcpg passes package

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/callnamecompat/CallNameFixup.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/callnamecompat/CallNameFixup.scala
@@ -6,9 +6,9 @@ import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
 
 /**
-  * Compitibilty pass which fixes mismatches between method full name and method name
+  * Compatibility pass which fixes mismatches between method full name and method name
   * properties.
-  * TODO remove once this is fixed.
+  * TODO remove when not needed anymore.
   */
 class CallNameFixup(cpg: Cpg) extends CpgPass(cpg) {
   override def run(): Iterator[DiffGraph] = {
@@ -19,7 +19,7 @@ class CallNameFixup(cpg: Cpg) extends CpgPass(cpg) {
 
           val namePart = call.methodFullName.substring(0, colonIndex)
 
-          val nameWithoutTypes = earseTypeInformation(namePart)
+          val nameWithoutTypes = eraseTypeInformation(namePart)
 
           val nameParts = nameWithoutTypes.split("\\.").toList
 
@@ -35,7 +35,7 @@ class CallNameFixup(cpg: Cpg) extends CpgPass(cpg) {
     Iterator.empty
   }
 
-  private def earseTypeInformation(name: String): String = {
+  private def eraseTypeInformation(name: String): String = {
 
     val dstStringBuilder = StringBuilder.newBuilder
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/methodinstcompat/MethodInstCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/methodinstcompat/MethodInstCompat.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConverters._
 
 /**
   * This pass ensures compatibility with CPGs in old format containing METHOD_INST nodes.
-  * TODO remove when not need anymore.
+  * TODO remove when not needed anymore.
   */
 class MethodInstCompat(cpg: Cpg) extends CpgPass(cpg) {
   private val methodInstFullNameToMethodFullName = mutable.Map.empty[String, String]
@@ -25,34 +25,29 @@ class MethodInstCompat(cpg: Cpg) extends CpgPass(cpg) {
       init()
 
       cpg.call.toIterator.foreach { call =>
-        call.methodInstFullName match {
-          case Some(methodInstFullName) =>
-            methodInstFullNameToMethodFullName.get(methodInstFullName) match {
-              case Some(methodFullName) =>
-                call.setProperty(NodeKeys.METHOD_FULL_NAME, methodFullName)
-              case None =>
-                MethodInstCompat.logger.warn(
-                  s"Unable to find method full name by " +
-                    s"method instance full name $methodInstFullName for CALL ${call.code}.")
-            }
-          case None =>
-            None
+        call.methodInstFullName.foreach { methodInstFullName =>
+          methodInstFullNameToMethodFullName.get(methodInstFullName) match {
+            case Some(methodFullName) =>
+              call.setProperty(NodeKeys.METHOD_FULL_NAME, methodFullName)
+            case None =>
+              MethodInstCompat.logger.warn(
+                s"Unable to find method full name by " +
+                  s"method instance full name $methodInstFullName for CALL ${call.code}.")
+          }
         }
 
       }
 
       cpg.methodRef.toIterator.foreach { methodRef =>
-        methodRef.methodInstFullName match {
-          case Some(methodInstFullName) =>
-            methodInstFullNameToMethodFullName.get(methodInstFullName) match {
-              case Some(methodFullName) =>
-                methodRef.setProperty(NodeKeys.METHOD_FULL_NAME, methodFullName)
-              case None =>
-                MethodInstCompat.logger.warn(
-                  s"Unable to find method full name by " +
-                    s"method instance full name $methodInstFullName for METHDO_REF ${methodRef.code}.")
-            }
-          case None =>
+        methodRef.methodInstFullName.foreach { methodInstFullName =>
+          methodInstFullNameToMethodFullName.get(methodInstFullName) match {
+            case Some(methodFullName) =>
+              methodRef.setProperty(NodeKeys.METHOD_FULL_NAME, methodFullName)
+            case None =>
+              MethodInstCompat.logger.warn(
+                s"Unable to find method full name by " +
+                  s"method instance full name $methodInstFullName for METHDO_REF ${methodRef.code}.")
+          }
         }
       }
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/containsedges/ContainsEdgePass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/containsedges/ContainsEdgePass.scala
@@ -13,24 +13,7 @@ import io.shiftleft.semanticcpg.utils.ExpandTo
   * language frontends which do not provide method stubs and type decl stubs.
   */
 class ContainsEdgePass(cpg: Cpg) extends CpgPass(cpg) {
-
-  private val sourceTypes = List(
-    NodeTypes.METHOD,
-    NodeTypes.TYPE_DECL,
-    NodeTypes.FILE
-  )
-
-  private val destinationTypes = List(
-    NodeTypes.BLOCK,
-    NodeTypes.IDENTIFIER,
-    NodeTypes.RETURN,
-    NodeTypes.METHOD,
-    NodeTypes.TYPE_DECL,
-    NodeTypes.CALL,
-    NodeTypes.LITERAL,
-    NodeTypes.METHOD_REF,
-    NodeTypes.UNKNOWN
-  )
+  import ContainsEdgePass.{destinationTypes, sourceTypes}
 
   override def run(): Iterator[DiffGraph] = {
     val sourceVerticesTraversal = cpg.graph.V.hasLabel(sourceTypes.head, sourceTypes.tail: _*)
@@ -56,4 +39,26 @@ class ContainsEdgePass(cpg: Cpg) extends CpgPass(cpg) {
 
     dstGraph
   }
+}
+
+object ContainsEdgePass {
+
+  private val destinationTypes = List(
+    NodeTypes.BLOCK,
+    NodeTypes.IDENTIFIER,
+    NodeTypes.RETURN,
+    NodeTypes.METHOD,
+    NodeTypes.TYPE_DECL,
+    NodeTypes.CALL,
+    NodeTypes.LITERAL,
+    NodeTypes.METHOD_REF,
+    NodeTypes.UNKNOWN
+  )
+
+  private val sourceTypes = List(
+    NodeTypes.METHOD,
+    NodeTypes.TYPE_DECL,
+    NodeTypes.FILE
+  )
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc
 
-import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewMethodReturn}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, NodeTypes, nodes}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -7,7 +7,7 @@ import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.Implicits._
 import org.apache.tinkerpop.gremlin.structure.Direction
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.{LogManager, Logger}
 
 import scala.collection.JavaConverters._
 
@@ -76,5 +76,5 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
 }
 
 object CallLinker {
-  private val logger = LoggerFactory.getLogger(getClass)
+  private val logger: Logger = LogManager.getLogger(getClass)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language.Steps
 import io.shiftleft.Implicits.JavaIteratorDeco
-import java.lang.{Long => JLong}
 
 import io.shiftleft.codepropertygraph.Cpg
 import org.apache.tinkerpop.gremlin.structure.Direction

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/memberaccesslinker/MemberAccessLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/memberaccesslinker/MemberAccessLinker.scala
@@ -15,8 +15,9 @@ import scala.collection.JavaConverters._
   */
 class MemberAccessLinker(cpg: Cpg) extends CpgPass(cpg) {
   import MemberAccessLinker.logger
-  private var loggedDeprecationWarning: Boolean = _
-  private var loggedForTypeMemberCombination: Set[(nodes.Type, String)] = _
+
+  private[this] var loggedDeprecationWarning: Boolean = _
+  private[this] var loggedForTypeMemberCombination: Set[(nodes.Type, String)] = _
 
   override def run(): Iterator[DiffGraph] = {
     loggedDeprecationWarning = false

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methodexternaldecorator/MethodExternalDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methodexternaldecorator/MethodExternalDecoratorPass.scala
@@ -1,7 +1,5 @@
 package io.shiftleft.semanticcpg.passes.methodexternaldecorator
 
-import java.lang
-
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.TypeDecl
@@ -12,19 +10,6 @@ import org.apache.tinkerpop.gremlin.structure.Direction
 
 import scala.collection.JavaConverters._
 
-object MethodExternalDecoratorPass {
-  private var loggedDeprecatedWarning = false
-  private val logger: Logger =
-    LogManager.getLogger(classOf[MethodExternalDecoratorPass])
-
-  def log(message: String): Unit = {
-    if (!loggedDeprecatedWarning) {
-      logger.warn(message)
-      loggedDeprecatedWarning = true
-    }
-  }
-}
-
 /**
   * Sets the isExternal flag for Method in case it is not set already.
   * It is set to its parent type decl isExternal, defaulting to false otherwise.
@@ -34,6 +19,8 @@ object MethodExternalDecoratorPass {
 class MethodExternalDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
 
   import MethodExternalDecoratorPass._
+
+  private[this] var loggedDeprecatedWarning = false
 
   private def isValidExternalFlag(isExternal: java.lang.Boolean): Boolean =
     isExternal != null
@@ -87,4 +74,17 @@ class MethodExternalDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
 
     Iterator(dstGraph)
   }
+
+  @inline
+  private def log(message: String): Unit = {
+    if (!loggedDeprecatedWarning) {
+      logger.warn(message)
+      loggedDeprecatedWarning = true
+    }
+  }
+
+}
+
+object MethodExternalDecoratorPass {
+  private val logger: Logger = LogManager.getLogger(classOf[MethodExternalDecoratorPass])
 }


### PR DESCRIPTION
Just trying to improve the consistency of the code:
- reducing global mutable state by moving variables from companion
objects to classes (and making it private)
- having companion objects at the end of the file (usually their
contents is less important, we do it most of the time, but always)
- minor typos
- less verbose pattern matching