### PR TITLE
Use `cpg` in DiffGraphApplier.applyDiff, as opposed to `graph`.

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -77,7 +77,7 @@ abstract class CpgPass(cpg: Cpg) {
     try {
       logStart()
       run().map { dstGraph =>
-        val appliedDiffGraph = new DiffGraphApplier().applyDiff(dstGraph, cpg.graph)
+        val appliedDiffGraph = new DiffGraphApplier().applyDiff(dstGraph, cpg)
         new DiffGraphProtoSerializer().serialize(appliedDiffGraph)
       }
     } finally {
@@ -91,7 +91,7 @@ abstract class CpgPass(cpg: Cpg) {
   def createAndApply(): Unit = {
     logStart()
     try {
-      run().foreach(new DiffGraphApplier().applyDiff(_, cpg.graph))
+      run().foreach(new DiffGraphApplier().applyDiff(_, cpg))
     } finally {
       logEnd()
     }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphApplier.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphApplier.scala
@@ -3,6 +3,7 @@ package io.shiftleft.passes
 import java.util
 
 import gremlin.scala.ScalaGraph
+import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
@@ -18,7 +19,8 @@ class DiffGraphApplier {
   /**
     * Applies diff to existing (loaded) OdbGraph
     **/
-  def applyDiff(diffGraph: DiffGraph, graph: ScalaGraph): AppliedDiffGraph = {
+  def applyDiff(diffGraph: DiffGraph, cpg: Cpg): AppliedDiffGraph = {
+    val graph = cpg.graph
     addNodes(diffGraph, graph)
     addEdges(diffGraph, graph)
     addNodeProperties(diffGraph, graph)


### PR DESCRIPTION
`DiffGraphApplier` is now a public API, and it should work on CPGs,
not Gremlin-Scala graphs, as that is an implementation detail.