### PR TITLE
Make query builder protected.

### DIFF
--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/query/DefaultCpgQueryExecutor.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/query/DefaultCpgQueryExecutor.scala
@@ -27,7 +27,7 @@ class DefaultCpgQueryExecutor(scriptEngineManager: ScriptEngineManager)(implicit
 
   private val uuidProvider = IO { UUID.randomUUID }
 
-  private def buildQuery(query: String) =
+  protected def buildQuery(query: String): String =
     s"""
       |import io.shiftleft.codepropertygraph.Cpg
       |import io.shiftleft.semanticcpg.language._


### PR DESCRIPTION
So we can reuse other parts of the class and customise the predef if necessary