### PR TITLE
when rendering nodes on console, also print the element labels

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ Global / useGpg := false
 ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 ThisBuild/compile/javacOptions ++= Seq("-g") //debug symbols
 
+Global/onChangedBuildSource := ReloadOnSourceChanges
 onLoad in Global := {
   assert(GitLFSUtils.isGitLFSEnabled(), "You need to install git-lfs and run 'git lfs pull'")
   (onLoad in Global).value

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
@@ -50,6 +50,8 @@ class CpgOverlayIntegrationTest extends WordSpec with Matchers {
       override def label = NodeTypes.UNKNOWN
       override def properties = Map(NodeKeyNames.CODE -> propValue)
       override def accept[T](visitor: NodeVisitor[T]): T = ???
+      override def getId: java.lang.Long = ???
+      override def productElementLabel(n: Int): String = ???
     }
     new CpgPass(cpg) {
 

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -67,7 +67,22 @@ trait BridgeBase {
       case None =>
         val replConfig = List(
           "repl.prompt() = \"" + promptStr() + "\"",
-          "repl.pprinter() = repl.pprinter().copy(defaultHeight = 99999)",
+          """|val originalPrinter = repl.pprinter()
+             |repl.pprinter.update(originalPrinter.copy(
+             |  defaultHeight = 99999,
+             |  additionalHandlers = {
+             |    case node: nodes.Node =>
+             |      import pprint.Tree
+             |      Tree.Apply(
+             |        node.productPrefix,
+             |        Iterator.range(0, node.productArity).map { n =>
+             |          Tree.Infix(
+             |            Tree.Literal(node.productElementLabel(n)),
+             |            "->",
+             |            originalPrinter.treeify(node.productElement(n)))
+             |      })
+             |  }
+             |))""".stripMargin,
           "banner()"
         )
         ammonite

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NewNodeStepsTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NewNodeStepsTests.scala
@@ -102,5 +102,7 @@ object NewNodeNodeStepsTest {
     override def containedNodesByLocalName: Map[String, List[Node]] =
       Map(testContainedLabel -> containedNodes)
     override def accept[T](visitor: NodeVisitor[T]): T = ???
+    override def getId: java.lang.Long = ???
+    override def productElementLabel(n: Int): String = ???
   }
 }


### PR DESCRIPTION
* add labels for product elements which will help with pretty printing
* configure pprint to make use of the productElementLabels

before:
![image](https://user-images.githubusercontent.com/506752/67140254-5de80580-f2b5-11e9-9a8a-3791c81c5fe3.png)

after: 
![image](https://user-images.githubusercontent.com/506752/67140263-6f311200-f2b5-11e9-96ab-739c5e32e8a1.png)
