### PR TITLE
Lift CpgQueryExecutor into the console project.

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -2,14 +2,71 @@ name := "console"
 
 enablePlugins(JavaAppPackaging)
 
+dependsOn(Projects.codepropertygraph)
+
+scalacOptions ++= Seq(
+  "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
+  "-encoding", "utf-8",                // Specify character encoding used by source files.
+  "-explaintypes",                     // Explain type errors in more detail.
+  "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
+  "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+  "-language:experimental.macros",     // Allow macro definition (besides implementation and application)
+  "-language:higherKinds",             // Allow higher-kinded types
+  "-language:implicitConversions",     // Allow definition of implicit functions called views
+  "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
+  "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+  "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+  "-Xfuture",                          // Turn on future language features.
+  "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+  "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+  "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+  "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
+  "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
+  "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
+  "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
+  "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+  "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
+  "-Xlint:option-implicit",            // Option.apply used implicit view.
+  "-Xlint:package-object-classes",     // Class or object defined in package object.
+  "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
+  "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
+  "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
+  "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+  "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+  "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+  "-Ypartial-unification",             // Enable partial unification in type constructor inference
+  "-Ywarn-dead-code",                  // Warn when dead code is identified.
+  "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+  "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
+  "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
+  "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+  "-Ywarn-numeric-widen",              // Warn when numerics are widened.
+  "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+  "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+  "-Ywarn-unused:locals",              // Warn if a local definition is unused.
+  "-Ywarn-unused:params",              // Warn if a value parameter is unused.
+  "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+  "-Ywarn-unused:privates",            // Warn if a private member is unused.
+  // "-Ywarn-value-discard"               // Warn when non-Unit expression results are unused.
+)
+
+val ScoptVersion = "3.7.1"
+val BetterFilesVersion = "3.8.0"
+val CatsVersion = "2.0.0"
+val CirceVersion = "0.12.2"
+val AmmoniteVersion = "1.7.1"
+val ScalatestVersion = "3.0.8"
+
 libraryDependencies ++= Seq(
-  "com.massisframework"  %  "j-text-utils"  % "0.3.4",
-  "com.github.scopt"     %% "scopt"         % "3.7.1",
-  "com.github.pathikrit" %% "better-files"  % "3.8.0",
-  "org.apache.commons"   % "commons-lang3"  % "3.8",
-  "io.circe"             %% "circe-generic" % "0.12.1",
-  "io.circe"             %% "circe-parser"  % "0.12.1",
-  "com.lihaoyi"          %% "ammonite"      % "1.7.1" cross CrossVersion.full,
-  "org.scalatest"        %% "scalatest"     % "3.0.8",
-  "org.scalatest"        %% "scalatest"     % "3.0.8" % Test,
+  "com.github.scopt"     %% "scopt"         % ScoptVersion,
+  "com.github.pathikrit" %% "better-files"  % BetterFilesVersion,
+  "org.typelevel"        %% "cats-core"     % CatsVersion,
+  "org.typelevel"        %% "cats-effect"   % CatsVersion,
+  "io.circe"             %% "circe-generic" % CirceVersion,
+  "io.circe"             %% "circe-parser"  % CirceVersion,
+  "com.lihaoyi"          %% "ammonite"      % AmmoniteVersion cross CrossVersion.full,
+
+  "org.scalatest"        %% "scalatest"     % ScalatestVersion % Test,
 )

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -43,7 +43,7 @@ trait BridgeBase {
         .text("import additional additional script(s): will execute and keep console open")
 
       opt[Unit]("nocolors")
-        .action((x, c) => c.copy(colors = Some(Colors.BlackWhite)))
+        .action((_, c) => c.copy(colors = Some(Colors.BlackWhite)))
         .text("turn off colors")
 
       opt[String]("command")

--- a/console/src/main/scala/io/shiftleft/console/query/CpgQueryExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/query/CpgQueryExecutor.scala
@@ -1,12 +1,11 @@
-package io.shiftleft.cpgserver.query
-
-import java.util.UUID
+package io.shiftleft.console.query
 
 import cats.data.OptionT
 import cats.effect.IO
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.cpgserver.model.CpgOperationResult
+
+import java.util.UUID
 
 /**
   * This trait provides an abstraction over the execution of queries on a CPG.

--- a/console/src/main/scala/io/shiftleft/console/query/CpgResult.scala
+++ b/console/src/main/scala/io/shiftleft/console/query/CpgResult.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.cpgserver.model
+package io.shiftleft.console.query
 
 sealed trait CpgOperationResult[+T]
 

--- a/console/src/main/scala/io/shiftleft/console/query/DefaultCpgQueryExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/query/DefaultCpgQueryExecutor.scala
@@ -1,4 +1,10 @@
-package io.shiftleft.cpgserver.query
+package io.shiftleft.console.query
+
+import cats.data.OptionT
+import cats.effect.{Blocker, ContextShift, IO}
+import javax.script.ScriptEngineManager
+
+import io.shiftleft.codepropertygraph.Cpg
 
 import java.util.UUID
 import java.util.concurrent.{ConcurrentHashMap, Executors}
@@ -6,13 +12,6 @@ import java.util.concurrent.{ConcurrentHashMap, Executors}
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.Map
 import scala.concurrent.ExecutionContext
-
-import cats.data.OptionT
-import cats.effect.{Blocker, ContextShift, IO}
-import javax.script.ScriptEngineManager
-
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.cpgserver.model.{CpgOperationFailure, CpgOperationResult, CpgOperationSuccess}
 
 class DefaultCpgQueryExecutor(scriptEngineManager: ScriptEngineManager)(implicit val cs: ContextShift[IO])
     extends CpgQueryExecutor[String] {

--- a/console/src/test/scala/io/shiftleft/console/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ScriptManagerTest.scala
@@ -1,8 +1,9 @@
 package io.shiftleft.console
 
 import better.files.File
-import io.shiftleft.console.ScriptManager.ScriptDescription
 import org.scalatest.{Inside, Matchers, WordSpec}
+
+import io.shiftleft.console.ScriptManager.ScriptDescription
 
 class ScriptManagerTest extends WordSpec with Matchers with Inside {
 
@@ -31,10 +32,8 @@ class ScriptManagerTest extends WordSpec with Matchers with Inside {
       val sut = new TestScriptManager
       inside(sut.scripts()) {
         case ScriptDescription("list-funcs", _) :: _ =>
-          val actualT: String = sut.runScriptT("list-funcs")
-          actualT shouldBe expected
-          val actual = sut.runScript("list-funcs")
-          actual shouldBe expected
+          sut.runScriptT[String]("list-funcs") shouldBe expected
+          sut.runScript("list-funcs") shouldBe expected
       }
 
     }

--- a/console/src/test/scala/io/shiftleft/console/query/DefaultCpgQueryExecutorSpec.scala
+++ b/console/src/test/scala/io/shiftleft/console/query/DefaultCpgQueryExecutorSpec.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.cpgserver.query
+package io.shiftleft.console.query
 
 import java.io.Reader
 import java.util.UUID
@@ -6,17 +6,15 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.postfixOps
-
 import cats.data.OptionT
 import cats.effect.{ContextShift, IO}
 import javax.script._
+import org.scalatest.{Matchers, WordSpec}
 import org.scalatest.concurrent.Eventually
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.cpgserver.BaseSpec
-import io.shiftleft.cpgserver.model.{CpgOperationFailure, CpgOperationResult, CpgOperationSuccess}
 
-class DefaultCpgQueryExecutorSpec extends BaseSpec with Eventually {
+class DefaultCpgQueryExecutorSpec extends WordSpec with Matchers with Eventually {
 
   private val queryResult = "a result"
   private val queryException = new RuntimeException("Oh noes!")

--- a/cpgserver/build.sbt
+++ b/cpgserver/build.sbt
@@ -3,6 +3,7 @@ name := "CPG server"
 
 dependsOn(Projects.codepropertygraph)
 dependsOn(Projects.semanticcpg)
+dependsOn(Projects.console)
 
 scalacOptions ++= Seq(
   "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
@@ -53,7 +54,7 @@ scalacOptions ++= Seq(
 )
 
 val Http4sVersion = "0.20.11"
-val CirceVersion = "0.12.1"
+val CirceVersion = "0.12.2"
 val PureconfigVersion = "0.12.1"
 val WebjarLocatorVersion = "0.37"
 val SwaggerVersion = "3.23.8"

--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerMain.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/CpgServerMain.scala
@@ -6,9 +6,9 @@ import javax.script.ScriptEngineManager
 import org.http4s.implicits._
 import org.http4s.server.blaze.BlazeServerBuilder
 
+import io.shiftleft.console.query.DefaultCpgQueryExecutor
 import io.shiftleft.cpgserver.config.ServerConfiguration
 import io.shiftleft.cpgserver.cpg.DummyCpgProvider
-import io.shiftleft.cpgserver.query.DefaultCpgQueryExecutor
 import io.shiftleft.cpgserver.route.{CpgRoute, HttpErrorHandler, SwaggerRoute}
 
 object CpgServerMain extends IOApp {

--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/cpg/CpgProvider.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/cpg/CpgProvider.scala
@@ -1,12 +1,11 @@
 package io.shiftleft.cpgserver.cpg
 
 import java.util.UUID
-
 import cats.data.OptionT
 import cats.effect.IO
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.cpgserver.model.CpgOperationResult
+import io.shiftleft.console.query.CpgOperationResult
 
 trait CpgProvider {
 

--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/cpg/DummyCpgProvider.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/cpg/DummyCpgProvider.scala
@@ -6,13 +6,12 @@ import java.util.concurrent.{ConcurrentHashMap, Executors}
 import scala.collection.JavaConverters._
 import scala.collection.concurrent.Map
 import scala.concurrent.ExecutionContext
-
 import cats.data.OptionT
 import cats.effect.{Blocker, ContextShift, IO}
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewMethod
-import io.shiftleft.cpgserver.model.{CpgOperationFailure, CpgOperationResult, CpgOperationSuccess}
+import io.shiftleft.console.query.{CpgOperationFailure, CpgOperationResult, CpgOperationSuccess}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
 

--- a/cpgserver/src/main/scala/io/shiftleft/cpgserver/route/CpgRoute.scala
+++ b/cpgserver/src/main/scala/io/shiftleft/cpgserver/route/CpgRoute.scala
@@ -2,7 +2,6 @@ package io.shiftleft.cpgserver.route
 
 import java.nio.file.{Files, Paths}
 import java.util.UUID
-
 import cats.effect.IO
 import cats.implicits.catsStdInstancesForList
 import cats.syntax.foldable._
@@ -14,9 +13,8 @@ import org.http4s.dsl.io._
 import org.http4s.{EntityDecoder, HttpRoutes, MessageBodyFailure, Response}
 import org.slf4j.LoggerFactory
 
+import io.shiftleft.console.query.{CpgOperationFailure, CpgOperationSuccess, CpgQueryExecutor}
 import io.shiftleft.cpgserver.cpg.CpgProvider
-import io.shiftleft.cpgserver.model.{CpgOperationFailure, CpgOperationSuccess}
-import io.shiftleft.cpgserver.query.CpgQueryExecutor
 
 final class CpgRoute[T: Encoder](cpgProvider: CpgProvider, cpgQueryExecutor: CpgQueryExecutor[T])(
     implicit httpErrorHandler: HttpErrorHandler) {

--- a/cpgserver/src/test/scala/io/shiftleft/cpgserver/cpg/DummyCpgProviderSpec.scala
+++ b/cpgserver/src/test/scala/io/shiftleft/cpgserver/cpg/DummyCpgProviderSpec.scala
@@ -3,14 +3,14 @@ package io.shiftleft.cpgserver.cpg
 import java.util.UUID
 
 import scala.concurrent.ExecutionContext
-
 import cats.data.OptionT
 import cats.effect.{ContextShift, IO}
 import org.scalatest.concurrent.Eventually
 
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.console.query.CpgOperationResult
 import io.shiftleft.cpgserver.BaseSpec
-import io.shiftleft.cpgserver.model.CpgOperationResult
+
 import scala.concurrent.duration._
 import scala.language.postfixOps
 

--- a/cpgserver/src/test/scala/io/shiftleft/cpgserver/route/CpgRouteSpec.scala
+++ b/cpgserver/src/test/scala/io/shiftleft/cpgserver/route/CpgRouteSpec.scala
@@ -2,15 +2,14 @@ package io.shiftleft.cpgserver.route
 
 import java.nio.file.Files
 import java.util.UUID
-
 import cats.data.{Kleisli, OptionT}
 import cats.effect.IO
 import org.http4s.implicits._
 import org.http4s._
+
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.console.query.{CpgOperationFailure, CpgOperationResult, CpgOperationSuccess, CpgQueryExecutor}
 import io.shiftleft.cpgserver.cpg.CpgProvider
-import io.shiftleft.cpgserver.model.{CpgOperationFailure, CpgOperationResult, CpgOperationSuccess}
-import io.shiftleft.cpgserver.query.CpgQueryExecutor
 import io.shiftleft.cpgserver.route.CpgRoute.{ApiError, CpgOperationResponse, CreateCpgQueryResponse, CreateCpgResponse}
 
 class CpgRouteSpec extends Http4sSpec {


### PR DESCRIPTION
This **does not** integrate the `CpgQueryExecutor` into the script manager, it simply moves the executor over to the `console` project.