### PR TITLE
Comments + dead code removal

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -52,35 +52,6 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
           new ContainsEdgePass(cpg),
           new NamespaceCreator(cpg),
         )
-      case Languages.CSHARP =>
-        List(
-          new MethodInstCompat(cpg),
-          new CallNameFixup(cpg),
-          new ReceiverEdgePass(cpg),
-          new MethodDecoratorPass(cpg),
-          new CapturingLinker(cpg),
-          new Linker(cpg),
-          new BindingTableCompat(cpg),
-          new CallLinker(cpg),
-          new MemberAccessLinker(cpg),
-          new MethodExternalDecoratorPass(cpg),
-          new ContainsEdgePass(cpg),
-          new NamespaceCreator(cpg),
-        )
-      case _ =>
-        List(
-          new MethodInstCompat(cpg),
-          new ReceiverEdgePass(cpg),
-          new MethodDecoratorPass(cpg),
-          new CapturingLinker(cpg),
-          new Linker(cpg),
-          new BindingTableCompat(cpg),
-          new CallLinker(cpg),
-          new MemberAccessLinker(cpg),
-          new MethodExternalDecoratorPass(cpg),
-          new ContainsEdgePass(cpg),
-          new NamespaceCreator(cpg),
-        )
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -29,7 +29,7 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
     init()
 
     // TODO bring in Receiver type. Just working on name and comparing to full name
-    // will only work for C because there name always equals full name.
+    // will only work for C because in C, name always equals full name.
     methodToParameterCount.foreach {
       case (NameAndSignature(name, signature), parameterCount) =>
         methodFullNameToNode.get(name) match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
@@ -8,6 +8,9 @@ import io.shiftleft.semanticcpg.language._
 
 /**
   * This pass has no other pass as prerequisite.
+  * For each `TYPE` node that does not have a corresponding `TYPE_DECL`
+  * node, this pass creates a `TYPE_DECL` node. The `TYPE_DECL` is
+  * considered external.
   */
 class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -32,6 +32,8 @@ class Linker(cpg: Cpg) extends CpgPass(cpg) {
 
     linkAstChildToParent(dstGraph)
 
+    // Create REF edges from TYPE nodes to TYPE_DECL nodes.
+
     linkToSingle(
       srcLabels = List(NodeTypes.TYPE),
       dstNodeLabel = NodeTypes.TYPE_DECL,
@@ -40,6 +42,9 @@ class Linker(cpg: Cpg) extends CpgPass(cpg) {
       dstFullNameKey = nodes.Type.Keys.TypeDeclFullName,
       dstGraph
     )
+
+    // Create EVAL_TYPE edges from nodes of various types
+    // to TYPE nodes.
 
     linkToSingle(
       srcLabels = List(
@@ -61,6 +66,9 @@ class Linker(cpg: Cpg) extends CpgPass(cpg) {
       dstGraph
     )
 
+    // Create REF edges from METHOD_REFs to
+    // METHOD nodes.
+
     linkToSingle(
       srcLabels = List(NodeTypes.METHOD_REF),
       dstNodeLabel = NodeTypes.METHOD,
@@ -69,6 +77,9 @@ class Linker(cpg: Cpg) extends CpgPass(cpg) {
       dstFullNameKey = nodes.MethodRef.Keys.MethodFullName,
       dstGraph
     )
+
+    // Create INHERITS_FROM nodes from TYPE_DECL
+    // nodes to TYPE nodes.
 
     linkToMultiple(
       srcLabels = List(NodeTypes.TYPE_DECL),
@@ -85,6 +96,9 @@ class Linker(cpg: Cpg) extends CpgPass(cpg) {
       dstFullNameKey = nodes.TypeDecl.Keys.InheritsFromTypeFullName,
       dstGraph
     )
+
+    // Create ALIAS_OF edges from TYPE_DECL nodes to
+    // TYPE nodes.
 
     linkToMultiple(
       srcLabels = List(NodeTypes.TYPE_DECL),


### PR DESCRIPTION
While writing documentation, I needed to verify correctness by reading the code. I ended up removing some dead code and adding some comments to make it easier to understand the code.

- EnhancedBaseCreator is only used in the OSS version and listing more languages than required may lead us to miss that `EnhancedBaseCreatorEx` actually hosts the relevant code for languages unsupported by the OSS version
- The `Linker` performs different linking operations, and I've commented for each what they do
- Fixed two IDE warnings in `linkSingle` and added a comment that describes what it does
