### PR TITLE
Add missing test for AST traversals

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -38,20 +38,31 @@ trait AstNodeBase[NodeType <: nodes.AstNode] { this: NodeSteps[NodeType] =>
   /**
     * Nodes of the AST obtained by expanding AST edges backwards until the method root is reached
     * */
-  def inAst: AstNode =
-    new AstNode(
-      raw.emit
-        .until(_.hasLabel(NodeTypes.METHOD))
-        .repeat(_.in(EdgeTypes.AST))
-        .cast[nodes.AstNode])
+  def inAst: AstNode = inAst(null)
 
   /**
     * Nodes of the AST obtained by expanding AST edges backwards until the method root is reached, minus this node
     * */
-  def inAstMinusLeaf: AstNode =
+  def inAstMinusLeaf: AstNode = inAstMinusLeaf(null)
+
+  /**
+    * Nodes of the AST obtained by expanding AST edges backwards until `root` or the method root is reached
+    * */
+  def inAst(root: nodes.AstNode): AstNode =
+    new AstNode(
+      raw.emit
+        .until(_.or(_.hasLabel(NodeTypes.METHOD), _.filterOnEnd(n => root != null && root == n)))
+        .repeat(_.in(EdgeTypes.AST))
+        .cast[nodes.AstNode])
+
+  /**
+    * Nodes of the AST obtained by expanding AST edges backwards until `root` or the method root is reached,
+    * minus this node
+    * */
+  def inAstMinusLeaf(root: nodes.AstNode): AstNode =
     new AstNode(
       raw
-        .until(_.hasLabel(NodeTypes.METHOD))
+        .until(_.or(_.hasLabel(NodeTypes.METHOD), _.filterOnEnd(n => root != null && root == n)))
         .repeat(_.in(EdgeTypes.AST))
         .emit
         .cast[nodes.AstNode])
@@ -127,4 +138,5 @@ trait AstNodeBase[NodeType <: nodes.AstNode] { this: NodeSteps[NodeType] =>
   def isMethodRef: MethodRef = new MethodRef(
     raw.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef]
   )
+
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
@@ -26,6 +26,16 @@ class CAstTests extends WordSpec with Matchers {
     }
   }
 
+  "should allow finding addition in argument to bar" in {
+    CodeToCpgFixture().buildCpg(code) { cpg =>
+      implicit val resolver : ICallResolver = NoResolve
+      cpg.method.name("bar")
+        .callIn.argument(1)
+        .filter(_.ast.isCall.name("<operator>.(addition|multiplication)"))
+        .code.l shouldBe List ("x + 10")
+    }
+  }
+
   "should identify three control structures" in {
     CodeToCpgFixture().buildCpg(code) { cpg =>
       cpg.method

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
@@ -28,11 +28,14 @@ class CAstTests extends WordSpec with Matchers {
 
   "should allow finding addition in argument to bar" in {
     CodeToCpgFixture().buildCpg(code) { cpg =>
-      implicit val resolver : ICallResolver = NoResolve
-      cpg.method.name("bar")
-        .callIn.argument(1)
+      implicit val resolver: ICallResolver = NoResolve
+      cpg.method
+        .name("bar")
+        .callIn
+        .argument(1)
         .filter(_.ast.isCall.name("<operator>.(addition|multiplication)"))
-        .code.l shouldBe List ("x + 10")
+        .code
+        .l shouldBe List("x + 10")
     }
   }
 


### PR DESCRIPTION
In the AST traversal tests, we were one test shy where we ensure that we can find multiplication and additions in call arguments. Added the test.