### PR TITLE
Deprecate `toParameter` and rename to `parameter`.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -63,9 +63,15 @@ trait ExpressionBase[NodeType <: nodes.Expression]
   )
 
   /**
+  Traverse to related parameter
+    */
+  @deprecated("October 2019")
+  def toParameter: MethodParameter = parameter
+
+  /**
     Traverse to related parameter
     */
-  def toParameter: MethodParameter = {
+  def parameter: MethodParameter = {
     new MethodParameter(
       raw
         .sack((sack: Integer, node: nodes.Expression) => node.value2(NodeKeys.ARGUMENT_INDEX))

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
@@ -49,7 +49,7 @@ class CallGraphTests extends WordSpec with Matchers {
 
   "should allow traversing from argument to formal parameter" in {
     CodeToCpgFixture().buildCpg(code) { cpg =>
-      cpg.argument.toParameter.name.toSet should not be empty
+      cpg.argument.parameter.name.toSet should not be empty
     }
   }
 


### PR DESCRIPTION
Following our naming conventions, the method `toParameter`, which actually walks from an expression (argument) to the corresponding formal parameter, should be called `parameter`. This PR deprecates `toParameter` and introduces `parameter` as a drop-in replacement.