### PR TITLE
Add `LINE_NUMBER_END` and `COLUMN_NUMBER_END` to `METHOD`

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -14,7 +14,7 @@
         {"id" : 2, "name": "LINE_NUMBER", "comment": "Line where the code starts", "valueType" : "int", "cardinality" : "zeroOrOne"},
         {"id" : 11, "name": "COLUMN_NUMBER", "comment" : "Column where the code starts", "valueType" : "int", "cardinality" : "zeroOrOne" },
 	{"id" : 12, "name": "LINE_NUMBER_END", "comment" : "Line where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne"},
-	{"id" : 16, "name": "COLUMN_NUMBER_END", "comment" : "Column where the code ends", "valueType" : "string", "cardinality" : "zeroOrOne"},
+	{"id" : 16, "name": "COLUMN_NUMBER_END", "comment" : "Column where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne"},
 
         {"id" : 3, "name": "PARSER_TYPE_NAME", "comment": "Type name emitted by parser, only present for logical type UNKNOWN", "valueType" : "string", "cardinality" : "one"},
         {"id" : 4, "name": "ORDER", "comment": "General ordering property, such that the children of each AST-node are typically numbered from 1, ..., N (this is not enforced). The ordering has no technical meaning, but is used for pretty printing and OUGHT TO reflect order in the source code", "valueType" : "int", "cardinality" : "one"},

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -13,6 +13,8 @@
 
         {"id" : 2, "name": "LINE_NUMBER", "comment": "Line where the code starts", "valueType" : "int", "cardinality" : "zeroOrOne"},
         {"id" : 11, "name": "COLUMN_NUMBER", "comment" : "Column where the code starts", "valueType" : "int", "cardinality" : "zeroOrOne" },
+	{"id" : 12, "name": "LINE_NUMBER_END", "comment" : "Line where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne"},
+	{"id" : 16, "name": "COLUMN_NUMBER_END", "comment" : "Column where the code ends", "valueType" : "string", "cardinality" : "zeroOrOne"},
 
         {"id" : 3, "name": "PARSER_TYPE_NAME", "comment": "Type name emitted by parser, only present for logical type UNKNOWN", "valueType" : "string", "cardinality" : "one"},
         {"id" : 4, "name": "ORDER", "comment": "General ordering property, such that the children of each AST-node are typically numbered from 1, ..., N (this is not enforced). The ordering has no technical meaning, but is used for pretty printing and OUGHT TO reflect order in the source code", "valueType" : "int", "cardinality" : "one"},
@@ -78,7 +80,7 @@
 
         {"id" : 1, "name" : "METHOD",
          "keys": ["NAME", "FULL_NAME", "IS_EXTERNAL", "SIGNATURE", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME",
-		  "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
+		  "LINE_NUMBER", "COLUMN_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER_END", "ORDER"],
          "comment" : "A method/function/procedure",
          "is": ["DECLARATION", "CFG_NODE", "AST_NODE"],
          "outEdges" : [

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -57,6 +57,8 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
       "<global>",
       None,
       None,
+      None,
+      None,
       0,
       None
     )


### PR DESCRIPTION
A while back, we decided to remove `COLUMN_NUMBER_END` and `LINE_NUMBER_END`. It used to be present in all expressions, methods, and type declarations, and that cost us memory. Unfortunately, this means that a feature like `joern-code` (see https://github.com/ShiftLeftSecurity/joern/issues/85 and https://github.com/ShiftLeftSecurity/joern/issues/118) cannot be created.

As a compromise, this PR brings back `LINE_NUMBER_END` and `COLUMN_NUMBER_END` for methods at first, so that we can at least extract methods of interest.