### PR TITLE
Introduce utility methods `isCallTo` and `containsCallTo`

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -20,6 +20,11 @@ trait AstNodeBase[NodeType <: nodes.AstNode] { this: NodeSteps[NodeType] =>
     * */
   def ast: AstNode = new AstNode(raw.emit.repeat(_.out(EdgeTypes.AST)).cast[nodes.AstNode])
 
+  def containsCallTo(regex: String): Call =
+    new Call(new AstNode(raw.cast[nodes.AstNode]).filter(_.ast.isCall.name(regex)).raw.cast[nodes.Call])
+
+  def isCallTo(regex: String): Call = isCall.name(regex)
+
   /**
     * Nodes of the AST rooted in this node, minus the node itself
     * */

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
@@ -34,7 +34,7 @@ class CAstTests extends WordSpec with Matchers {
         .name("bar")
         .callIn
         .argument(1)
-        .filter(_.ast.isCall.name("<operator>.(addition|multiplication)"))
+        .containsCallTo("<operator>.(addition|multiplication)")
         .code
         .l shouldBe List("x + 10")
     }
@@ -48,7 +48,7 @@ class CAstTests extends WordSpec with Matchers {
         .name("moo")
         .callIn
         .argument(1)
-        .filter(_.ast.isCall.name("<operator>.(addition|multiplication)"))
+        .containsCallTo("<operator>.(addition|multiplication)")
         .code
         .l shouldBe List("boo(1+2)")
 
@@ -58,8 +58,8 @@ class CAstTests extends WordSpec with Matchers {
         .argument(1)
         .filterOnEnd(
           arg =>
-            arg.start.ast.isCall
-              .name("<operator>.(addition|multiplication)")
+            arg.start.ast
+              .isCallTo("<operator>.(addition|multiplication)")
               .filterNot(_.inAstMinusLeaf(arg).isCall)
               .l
               .nonEmpty)


### PR DESCRIPTION
Two utility methods to make AST traversals shorter.