### PR TITLE
Cleanup NodeTypeStarters and add spec

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -12,6 +12,11 @@ import io.shiftleft.semanticcpg.language.types.structure.File
 class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) extends Steps[NodeType](raw) {
 
   /**
+    * Traverse to node labels
+    * */
+  def label: Steps[String] = new Steps(raw.label)
+
+  /**
     * Traverse to source file
     * */
   def file: File =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -125,9 +125,18 @@ class NodeTypeStarters(cpg: Cpg) {
     new MethodRef(scalaGraph.V.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
 
   /**
+  Begin traversal at node with id.
+    */
+  def id[NodeType <: nodes.StoredNode](anId: Any): NodeSteps[NodeType] = id(Seq(anId))
+
+  /**
   Begin traversal at set of nodes - specified by their ids
     */
-  def atVerticesWithId[NodeType <: nodes.StoredNode](ids: Seq[Any]): NodeSteps[NodeType] =
-    if (ids.size == 0) new NodeSteps[NodeType](scalaGraph.V(-1).cast[NodeType])
+  def id[NodeType <: nodes.StoredNode](ids: Seq[Any]): NodeSteps[NodeType] =
+    if (ids.isEmpty) new NodeSteps[NodeType](scalaGraph.V(-1).cast[NodeType])
     else new NodeSteps[NodeType](scalaGraph.V(ids: _*).cast[NodeType])
+
+  @deprecated("October 2019", "")
+  def atVerticesWithId[NodeType <: nodes.StoredNode](ids: Seq[Any]): NodeSteps[NodeType] = id(ids)
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -65,7 +65,7 @@ trait ExpressionBase[NodeType <: nodes.Expression]
   /**
   Traverse to related parameter
     */
-  @deprecated("October 2019")
+  @deprecated("October 2019", "")
   def toParameter: MethodParameter = parameter
 
   /**

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NodeTypeStartersTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NodeTypeStartersTests.scala
@@ -1,0 +1,76 @@
+package io.shiftleft.semanticcpg.language
+
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
+import org.scalatest.{Matchers, WordSpec}
+
+class NodeTypeStartersTests extends WordSpec with Matchers {
+
+  val code = """
+       int main(int argc, char **argv) { }
+       struct foo { int x; };
+    """
+
+  CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow retrieving files" in {
+      cpg.file.name.l.head should endWith(".c")
+    }
+
+    "should allow retrieving methods" in {
+      cpg.method.name.l shouldBe List("main")
+    }
+
+    "should allow retrieving parameters" in {
+      cpg.parameter.name.toSet shouldBe Set("argc", "argv")
+    }
+
+    "should allow retrieving type declarations" in {
+      cpg.typeDecl.name.toSet shouldBe Set("foo", "int", "void", "char * *")
+    }
+
+    "should allow retrieving members" in {
+      cpg.member.name.l shouldBe List("x")
+    }
+
+    "should allow retrieving (used) types" in {
+      cpg.types.name.toSet shouldBe Set("int", "void", "char * *")
+    }
+
+    "should allow retrieving namespaces" in {
+      cpg.namespace.name.l shouldBe List("<global>")
+    }
+
+    "should allow retrieving namespace blocks" in {
+      cpg.namespaceBlock.name.toSet shouldBe Set("<global>")
+    }
+
+    "should allow retrieving of method returns" in {
+      cpg.methodReturn.code.l shouldBe List("RET")
+    }
+
+    "should allow retrieving of meta data" in {
+      cpg.metaData.language.l shouldBe List("C")
+    }
+
+    "should allow retrieving all nodes" in {
+      val allNodesLabels = cpg.all.label.toSet
+
+      allNodesLabels shouldBe Set(
+        NodeTypes.NAMESPACE_BLOCK,
+        NodeTypes.MEMBER,
+        NodeTypes.TYPE_DECL,
+        NodeTypes.METHOD_PARAMETER_IN,
+        NodeTypes.METHOD_PARAMETER_OUT,
+        NodeTypes.NAMESPACE,
+        NodeTypes.META_DATA,
+        NodeTypes.METHOD,
+        NodeTypes.FILE,
+        NodeTypes.METHOD_RETURN,
+        NodeTypes.TYPE,
+        NodeTypes.BLOCK
+      )
+    }
+
+  }
+
+}


### PR DESCRIPTION
I am currently writing documentation on the query language and I'm taking this as an opportunity to add spec via tests and cleanup where required. In this PR, I clean up node type starters.
- atVerticesWithId is deprecated and replaced by `id`
- id accepts both a sequence of ids and a single id
- added `label` step to retrieve node label without using `raw`