### PR TITLE
Allow retrieving of node ids

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -150,6 +150,11 @@ class Steps[NodeType](val raw: GremlinScala[NodeType]) {
     new Steps[NodeType](raw.dedup())
 
   /**
+    * Traverse to ids of underlying objects
+    * */
+  def id: Steps[AnyRef] = new Steps(raw.id)
+
+  /**
     Step that selects only the node with the given id.
     */
   def id(key: AnyRef)(implicit isElement: NodeType <:< Element): Steps[NodeType] =

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -103,6 +103,10 @@ class StepsTest extends WordSpec with Matchers {
     i should be > 0
   }
 
+  "allow retrieving ids" in ExistingCpgFixture("splitmeup") { fixture =>
+    fixture.cpg.method.id.l should not be empty
+  }
+
   "toJson" when ExistingCpgFixture("splitmeup") { fixture =>
     "operating on StoredNode" in {
       val json = fixture.cpg.namespace.nameExact("io.shiftleft.testcode.splitmeup").toJson


### PR DESCRIPTION
We previously had steps to filter based on id, but not to retrieve ids. This was only possible via `raw`. Added `id` retrieval step to be consistent with the rest of the language.