### PR TITLE
Cleanup of tests for inclusion on website

### DIFF
--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
@@ -16,47 +16,36 @@ class CallGraphTests extends WordSpec with Matchers {
        }
     """
 
-  "should find that add is called by main" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+  CodeToCpgFixture(code) { cpg =>
+    "should find that add is called by main" in {
       cpg.method.name("add").caller.name.toSet shouldBe Set("main")
     }
-  }
 
-  "should find that main calls add and others" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find that main calls add and others" in {
       cpg.method.name("main").callee.name.toSet shouldBe Set("add", "printf", "<operator>.addition")
     }
-  }
 
-  "should find three outgoing calls for main" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find three outgoing calls for main" in {
       cpg.method.name("main").callOut.code.toSet shouldBe
         Set("1+2", "add((1+2), 3)", "printf(\"%d\\n\", add((1+2), 3))")
     }
-  }
 
-  "should find one callsite for add" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find one callsite for add" in {
       cpg.method.name("add").callIn.code.toSet shouldBe Set("add((1+2), 3)")
     }
-  }
 
-  "should find that argument '1+2' is passed to parameter 'x'" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find that argument '1+2' is passed to parameter 'x'" in {
       cpg.parameter.name("x").argument().code.toSet shouldBe Set("1+2")
     }
-  }
 
-  "should allow traversing from argument to formal parameter" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow traversing from argument to formal parameter" in {
       cpg.argument.parameter.name.toSet should not be empty
     }
-  }
 
-  "should allow traversing from argument to call" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow traversing from argument to call" in {
       cpg.method.name("printf").callIn.argument.call.name.toSet shouldBe Set("printf")
     }
+
   }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/LocationTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/LocationTests.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.semanticcpg.language
 
 import org.scalatest.{Matchers, WordSpec}
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
 
 class LocationTests extends WordSpec with Matchers {
@@ -11,8 +10,9 @@ class LocationTests extends WordSpec with Matchers {
       int x = foo(param1);
    }"""
 
-  "should return location for method" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+  CodeToCpgFixture(code) { cpg =>
+    "should return location for method" in {
+
       val locations = cpg.method.name("my_func").location.l
       locations.size shouldBe 1
 
@@ -25,10 +25,9 @@ class LocationTests extends WordSpec with Matchers {
       loc.nodeLabel shouldBe "METHOD"
 
     }
-  }
 
-  "should return location for parameter" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should return location for parameter" in {
+
       val locations = cpg.parameter.name("param1").location.l
       locations.size shouldBe 1
 
@@ -39,11 +38,11 @@ class LocationTests extends WordSpec with Matchers {
       loc.lineNumber shouldBe Some(2)
       loc.filename should endWith(".c")
       loc.nodeLabel shouldBe "METHOD_PARAMETER_IN"
-    }
-  }
 
-  "should return location for return parameter" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    }
+
+    "should return location for return parameter" in {
+
       val locations = cpg.method.name("my_func").methodReturn.location.l
       locations.size shouldBe 1
 
@@ -54,11 +53,11 @@ class LocationTests extends WordSpec with Matchers {
       loc.lineNumber shouldBe Some(2)
       loc.filename should endWith(".c")
       loc.nodeLabel shouldBe "METHOD_RETURN"
-    }
-  }
 
-  "should return location for call" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    }
+
+    "should return location for call" in {
+
       val locations = cpg.call.name("foo").location.l
       locations.size shouldBe 1
 
@@ -69,11 +68,10 @@ class LocationTests extends WordSpec with Matchers {
       loc.lineNumber shouldBe Some(3)
       loc.filename should endWith(".c")
       loc.nodeLabel shouldBe "CALL"
-    }
-  }
 
-  "should return location for identifier" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    }
+
+    "should return location for identifier" in {
       val locations = cpg.identifier.name("x").location.l
       locations.size shouldBe 1
 
@@ -84,7 +82,9 @@ class LocationTests extends WordSpec with Matchers {
       loc.lineNumber shouldBe Some(3)
       loc.filename should endWith(".c")
       loc.nodeLabel shouldBe "IDENTIFIER"
+
     }
+
   }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NodeTypeStartersTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NodeTypeStartersTests.scala
@@ -4,14 +4,22 @@ import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
 import org.scalatest.{Matchers, WordSpec}
 
+/**
+  * The following tests show in detail how queries can be started. For
+  * all node types, for which it seems reasonable, all nodes of that type
+  * can be used as a starting point, e.g., `cpg.method` starts at all methods
+  * while `cpg.local` starts at all locals.
+  * */
 class NodeTypeStartersTests extends WordSpec with Matchers {
 
   val code = """
-       int main(int argc, char **argv) { }
+       /* A C comment */
+       // A C++ comment
+       int main(int argc, char **argv) { int mylocal; }
        struct foo { int x; };
     """
 
-  CodeToCpgFixture().buildCpg(code) { cpg =>
+  CodeToCpgFixture(code) { cpg =>
     "should allow retrieving files" in {
       cpg.file.name.l.head should endWith(".c")
     }
@@ -20,8 +28,16 @@ class NodeTypeStartersTests extends WordSpec with Matchers {
       cpg.method.name.l shouldBe List("main")
     }
 
+    "should allow retrieving comments" in {
+      cpg.comment.code.toSet shouldBe Set("/* A C comment */", "// A C++ comment\n")
+    }
+
     "should allow retrieving parameters" in {
       cpg.parameter.name.toSet shouldBe Set("argc", "argv")
+    }
+
+    "should allow retrieving locals" in {
+      cpg.local.name.l shouldBe List("mylocal")
     }
 
     "should allow retrieving type declarations" in {
@@ -67,7 +83,9 @@ class NodeTypeStartersTests extends WordSpec with Matchers {
         NodeTypes.FILE,
         NodeTypes.METHOD_RETURN,
         NodeTypes.TYPE,
-        NodeTypes.BLOCK
+        NodeTypes.BLOCK,
+        NodeTypes.COMMENT,
+        NodeTypes.LOCAL
       )
     }
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
@@ -21,14 +21,12 @@ class CAstTests extends WordSpec with Matchers {
       | }
     """.stripMargin
 
-  "should identify four blocks" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+  CodeToCpgFixture(code) { cpg =>
+    "should identify four blocks" in {
       cpg.method.name("foo").ast.isBlock.l.size shouldBe 4
     }
-  }
 
-  "should allow finding addition in argument to bar" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow finding addition in argument to bar" in {
       implicit val resolver: ICallResolver = NoResolve
       cpg.method
         .name("bar")
@@ -38,10 +36,8 @@ class CAstTests extends WordSpec with Matchers {
         .code
         .l shouldBe List("x + 10")
     }
-  }
 
-  "should allow finding that addition is not a direct argument of moo" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow finding that addition is not a direct argument of moo" in {
       implicit val resolver: ICallResolver = NoResolve
 
       cpg.method
@@ -66,10 +62,8 @@ class CAstTests extends WordSpec with Matchers {
         .code
         .l shouldBe List()
     }
-  }
 
-  "should identify three control structures" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should identify three control structures" in {
       cpg.method
         .name("foo")
         .ast
@@ -86,16 +80,12 @@ class CAstTests extends WordSpec with Matchers {
         .l
         .size shouldBe 1
     }
-  }
 
-  "should identify conditions" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should identify conditions" in {
       cpg.method.name("foo").ast.isControlStructure.condition.code.l shouldBe List("x > 10", "y > x")
     }
-  }
 
-  "should allow parserTypeName filtering and then ast" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow parserTypeName filtering and then ast" in {
       val query1Size = cpg.method.name("foo").ast.isControlStructure.ast.l.size
       query1Size should be > 0
 
@@ -109,10 +99,8 @@ class CAstTests extends WordSpec with Matchers {
         .size
       query1Size shouldBe query2Size
     }
-  }
 
-  "should allow filtering on conditions" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow filtering on conditions" in {
       cpg.method
         .name("foo")
         .condition(".*x > 10.*")
@@ -138,6 +126,7 @@ class CAstTests extends WordSpec with Matchers {
         .code
         .l shouldBe List("printf(\"reached\")")
     }
+
   }
 
   val bufInLoopCode =
@@ -151,8 +140,9 @@ class CAstTests extends WordSpec with Matchers {
       |}
     """.stripMargin
 
-  "should find index `i` used for buf" in {
-    CodeToCpgFixture().buildCpg(bufInLoopCode) { cpg =>
+  CodeToCpgFixture().buildCpg(bufInLoopCode) { cpg =>
+    "should find index `i` used for buf" in {
+
       cpg.call
         .name("<operator>.computedMemberAccess")
         .argument
@@ -160,10 +150,9 @@ class CAstTests extends WordSpec with Matchers {
         .code
         .l shouldBe List("i")
     }
-  }
 
-  "should find that i is assigned as part of loop header" in {
-    CodeToCpgFixture().buildCpg(bufInLoopCode) { cpg =>
+    "should find that i is assigned as part of loop header" in {
+
       cpg.call
         .name("<operator>.computedMemberAccess")
         .argument
@@ -172,11 +161,10 @@ class CAstTests extends WordSpec with Matchers {
         .isControlStructure
         .code
         .l shouldBe List("for (int i = 0; i < bar; i++)")
-    }
-  }
 
-  "should correctly identify condition of for loop" in {
-    CodeToCpgFixture().buildCpg(bufInLoopCode) { cpg =>
+    }
+
+    "should correctly identify condition of for loop" in {
       cpg.call
         .name("<operator>.computedMemberAccess")
         .argument
@@ -187,6 +175,7 @@ class CAstTests extends WordSpec with Matchers {
         .code
         .l shouldBe List("i < bar")
     }
+
   }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
@@ -13,39 +13,35 @@ class CMethodTests extends WordSpec with Matchers {
        int main(int argc, char **argv) { }
     """
 
-  "should return correct function/method name" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+  CodeToCpgFixture(code) { cpg =>
+    "should return correct function/method name" in {
       cpg.method.name.toSet shouldBe Set("main")
     }
-  }
 
-  "should have correct type signature" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should have correct type signature" in {
       cpg.method.signature.toSet shouldBe Set("int(int,char * *)")
     }
 
-  "should return correct number of parameters" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should return correct number of parameters" in {
       cpg.parameter.name.toSet shouldBe Set("argc", "argv")
       cpg.method.name("main").parameter.name.toSet shouldBe Set("argc", "argv")
     }
 
-  "should return correct parameter types" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should return correct parameter types" in {
       cpg.parameter.name("argc").evalType.l shouldBe List("int")
       cpg.parameter.name("argv").evalType.l shouldBe List("char * *")
     }
 
-  "should return correct return type" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should return correct return type" in {
       cpg.methodReturn.evalType.l shouldBe List("int")
       cpg.method.name("main").methodReturn.evalType.l shouldBe List("int")
       cpg.parameter.name("argc").method.methodReturn.evalType.l shouldBe List("int")
     }
 
-  "should return a filename for method 'main'" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should return a filename for method 'main'" in {
       cpg.method.name("main").file.name.l should not be empty
     }
+
+  }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/LocalsTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/LocalsTests.scala
@@ -33,26 +33,24 @@ class LocalsTests extends WordSpec with Matchers {
                     |    }
                  """.stripMargin
 
-  "should allow to query for all locals" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+  CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow to query for all locals" in {
       cpg.local.name.toSet shouldBe Set("a", "b", "c", "z", "x", "q", "p")
     }
 
-  "should allow to query for all locals in method `free_list`" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow to query for all locals in method `free_list`" in {
       cpg.method.name("free_list").local.name.toSet shouldBe Set("q", "p")
     }
 
-  "should prove correct (name, type) pairs for locals" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should prove correct (name, type) pairs for locals" in {
       cpg.method.name("free_list").local.map(l => (l.name, l.typeFullName)).toSet shouldBe
         Set(("q", "struct node *"), ("p", "struct node *"))
     }
 
-  "should allow finding filenames by local regex" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow finding filenames by local regex" in {
       val filename = cpg.local.name("a*").file.name.headOption()
       filename should not be empty
       filename.head.endsWith(".c") shouldBe true
     }
+  }
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/StructureTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/StructureTests.scala
@@ -11,29 +11,27 @@ class StructureTests extends WordSpec with Matchers {
                    | int main() {}
                  """.stripMargin
 
-  "should return one source file" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+  CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should return one source file" in {
       cpg.file.name.l.count(_.endsWith(".c")) shouldBe 1
     }
-  }
 
-  "should allow traversing from file to namespace blocks" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow traversing from file to namespace blocks" in {
       cpg.file.namespaceBlock.name.toSet shouldBe Set("<global>")
     }
 
-  "should allow traversing to namespaces" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow traversing to namespaces" in {
       cpg.file.namespace.name("<global>").l.size shouldBe 1
     }
 
-  "should allow traversing to type declarations" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow traversing to type declarations" in {
       cpg.file.typeDecl.name.toSet shouldBe Set("foo")
     }
 
-  "should allow traversing to methods in namespaces" in
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow traversing to methods in namespaces" in {
       cpg.file.namespace.method.name.toSet shouldBe Set("main")
     }
+
+  }
+
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTests.scala
@@ -15,42 +15,31 @@ class TypeDeclTests extends WordSpec with Matchers {
                    |
     """.stripMargin
 
-  "should find types `foo`, `char`, `int`, and `void`" in
-    CodeToCpgFixture().buildCpg(code) {
-      { cpg =>
-        cpg.typeDecl.name.toSet shouldBe Set("foo", "char", "int", "void")
-      }
+  CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find types `foo`, `char`, `int`, and `void`" in {
+      cpg.typeDecl.name.toSet shouldBe Set("foo", "char", "int", "void")
     }
 
-  "should find only one internal type (`foo`)" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find only one internal type (`foo`)" in {
       cpg.typeDecl.internal.name.toSet shouldBe Set("foo")
     }
-  }
 
-  "should find three external types (`char`, `int`, `void`)" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find three external types (`char`, `int`, `void`)" in {
       cpg.typeDecl.external.name.toSet shouldBe Set("char", "int", "void")
     }
-  }
 
-  "should find two members for `foo`: `x` and `y`" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find two members for `foo`: `x` and `y`" in {
       cpg.typeDecl.name("foo").member.name.toSet shouldBe Set("x", "y")
     }
-  }
 
-  "should find one method in type `foo`" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should find one method in type `foo`" in {
       cpg.typeDecl.name("foo").method.name.toSet shouldBe Set("method")
     }
 
-  }
-
-  "should allow traversing from type to enclosing file" in {
-    CodeToCpgFixture().buildCpg(code) { cpg =>
+    "should allow traversing from type to enclosing file" in {
       cpg.typeDecl.file.filterOnEnd(_.name.endsWith(".c")).l should not be empty
     }
+
   }
 
 }


### PR DESCRIPTION
I would like to include some of our tests as-is on the website to help document the query language. In this PR, I therefore clean up the tests to make them shorter.