### PR TITLE
Preserve type-parametric information in the NAME of CALLs

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/bindingtablecompat/BindingTableCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/bindingtablecompat/BindingTableCompat.scala
@@ -34,14 +34,11 @@ class BindingTableCompat(cpg: Cpg) extends CpgPass(cpg) {
 
   private def createBinding(typeDecl: nodes.TypeDecl, diffGraph: DiffGraph)(method: nodes.Method): Unit = {
     // The csharp frontend creates method names which contain type parameters.
-    // This is unintended so we strip them here.
-    val indexOfTypeParameterStart = method.name.indexOf("<")
-    val mangledMethodName = if (indexOfTypeParameterStart != -1) {
-      method.name.substring(0, indexOfTypeParameterStart)
-    } else {
-      method.name
-    }
-    val newBinding = new NewBinding(mangledMethodName, method.signature)
+    // It is necessary to keep them because a class may define parametric and non-parametric
+    // functions with the same name, i.e., `void f() {} and void f<T>() {}' is valid.
+    // Also, different than Java, C# carries generic type information over to runtime.
+
+    val newBinding = new NewBinding(method.name, method.signature)
     diffGraph.addNode(newBinding)
     diffGraph.addEdgeFromOriginal(typeDecl, newBinding, EdgeTypes.BINDS)
     diffGraph.addEdgeToOriginal(newBinding, method, EdgeTypes.REF)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/callnamecompat/CallNameFixup.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/callnamecompat/CallNameFixup.scala
@@ -17,16 +17,15 @@ class CallNameFixup(cpg: Cpg) extends CpgPass(cpg) {
         val colonIndex = call.methodFullName.indexOf(":")
         if (colonIndex != -1) {
 
-          val namePart = call.methodFullName.substring(0, colonIndex)
+          var qualMethodName = call.methodFullName.substring(0, colonIndex)
 
-          val nameWithoutTypes = eraseTypeInformation(namePart)
+          // If the CALL name contains parametric type information, preserve it; otherwise, erase it.
+          qualMethodName = if (call.name.indexOf("<") != -1) qualMethodName else eraseTypeInformation(qualMethodName)
 
-          val nameParts = nameWithoutTypes.split("\\.").toList
+          val unqualMethodName = qualMethodName.split("\\.").toList.last
 
-          val nameFromFullName = nameParts.last
-
-          if (nameFromFullName != call.name) {
-            call.property(NodeKeyNames.NAME, nameFromFullName)
+          if (unqualMethodName != call.name) {
+            call.property(NodeKeyNames.NAME, unqualMethodName)
           }
         }
       }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -70,7 +70,8 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
         dstGraph.addEdgeInOriginal(call, method, EdgeTypes.CALL)
       case None =>
         logger.warn(
-          s"Unable to link CALL with METHOD_FULL_NAME ${call.methodFullName}, NAME ${call.name}, SIGNATURE ${call.signature}")
+          s"Unable to link CALL with METHOD_FULL_NAME ${call.methodFullName}, NAME ${call.name}, " +
+            s"SIGNATURE ${call.signature}, CODE ${call.code}")
     }
   }
 }


### PR DESCRIPTION
This is necessary for the adjusments being made in _csharp2cpg_ toward the recent CPG format changes incorporate for Javascript.