### PR TITLE
More NodeTypeStarter tests

### DIFF
--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SampleDocuTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/SampleDocuTest.scala
@@ -9,7 +9,7 @@ class SampleDocuTest extends WordSpec with Matchers {
        int main(int argc, char **argv) { }
     """
 
-  CodeToCpgFixture().buildCpg(code) { cpg =>
+  CodeToCpgFixture(code) { cpg =>
     "should return `main` as the only method" in {
       cpg.method.name.toSet shouldBe Set("main")
     }


### PR DESCRIPTION
- introduced tests for starting at literals, calls, and arguments.
- Simplified SampleDocuTest