### PR TITLE
Introduce `CodeDumper`

### DIFF
--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -6,6 +6,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons"  % "commons-lang3"    % "3.8",
   "org.json4s" %% "json4s-native" % "3.6.7",
   "com.massisframework" % "j-text-utils" % "0.3.4",
+  "com.github.pathikrit" %% "better-files"  % "3.8.0",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test
 )

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -52,7 +52,7 @@ object CodeDumper {
   /**
     * For a given `filename`, `startLine`, and `endLine`, return the corresponding code
     * by reading it from the file. If `lineToHighlight` is defined, then a line containing
-    * and arrow (as a source code comment) is included right before that line.
+    * an arrow (as a source code comment) is included right before that line.
     * */
   def code(filename: String, startLine: Integer, endLine: Integer, lineToHighlight: Option[Integer] = None): String = {
     val lines = Try(File(filename).lines.toList).getOrElse {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -1,0 +1,76 @@
+package io.shiftleft.semanticcpg.codedumper
+
+import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.NodeSteps
+import better.files._
+import org.apache.logging.log4j.LogManager
+
+import scala.util.Try
+
+object CodeDumper {
+
+  private val logger = LogManager.getLogger(CodeDumper)
+  val arrow: CharSequence = "// ===>\n"
+
+  /**
+    * Evaluate the `step` and determine associated locations.
+    * Dump code at those locations
+    * */
+  def dump[NodeType <: nodes.StoredNode](step: NodeSteps[NodeType]): String =
+    step.location.l.map(dump).mkString("\n")
+
+  /**
+    * Dump string representation of code at given `location`.
+    * */
+  def dump(location: nodes.NewLocation): String = {
+    val filename = location.filename
+
+    if (location.node.isEmpty) {
+      logger.warn("Empty `location.node` encountered")
+      return ""
+    }
+
+    val node = location.node.get
+    val method = node match {
+      case n: nodes.Method     => Some(n)
+      case n: nodes.Expression => Some(n.method)
+      case _                   => None
+    }
+
+    val lineToHighlight = location.lineNumber
+    method
+      .filter { m =>
+        m.lineNumber.isDefined && m.lineNumberEnd.isDefined
+      }
+      .map { m =>
+        code(filename, m.lineNumber.get, m.lineNumberEnd.get, lineToHighlight)
+      }
+      .getOrElse("")
+  }
+
+  /**
+    * For a given `filename`, `startLine`, and `endLine`, return the corresponding code
+    * by reading it from the file. If `lineToHighlight` is defined, then a line containing
+    * and arrow (as a source code comment) is included right before that line.
+    * */
+  def code(filename: String, startLine: Integer, endLine: Integer, lineToHighlight: Option[Integer] = None): String = {
+    val lines = Try(File(filename).lines.toList).getOrElse {
+      logger.warn("error reading from: " + filename);
+      List()
+    }
+    lines
+      .slice(startLine - 1, endLine)
+      .zipWithIndex
+      .map {
+        case (line, lineNo) =>
+          if (lineToHighlight.isDefined && lineNo == lineToHighlight.get - startLine) {
+            arrow + " " + line
+          } else {
+            line
+          }
+      }
+      .mkString("\n")
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -40,11 +40,9 @@ object CodeDumper {
 
     val lineToHighlight = location.lineNumber
     method
-      .filter { m =>
-        m.lineNumber.isDefined && m.lineNumberEnd.isDefined
-      }
-      .map { m =>
-        code(filename, m.lineNumber.get, m.lineNumberEnd.get, lineToHighlight)
+      .collect {
+        case m: nodes.Method if m.lineNumber.isDefined && m.lineNumberEnd.isDefined =>
+          code(filename, m.lineNumber.get, m.lineNumberEnd.get, lineToHighlight)
       }
       .getOrElse("")
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.language
 
 import gremlin.scala.{GremlinScala, P, Vertex}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import io.shiftleft.semanticcpg.language.types.structure.File
 
 /**
@@ -35,6 +36,8 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
     * */
   def location: NewLocation =
     new NewLocation(raw.map(x => x.location))
+
+  def dump: String = CodeDumper.dump(this)
 
   /* follow the incoming edges of the given type as long as possible */
   protected def walkIn(edgeType: String): GremlinScala[Vertex] =

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -36,6 +36,11 @@ class CodeDumperTests extends WordSpec with Matchers {
       CodeDumper.code("foo", 1, 2) shouldBe ""
     }
 
+    "should allow dumping via .dump" in {
+      val code = cpg.method.name("my_func").dump
+      code should startWith(CodeDumper.arrow.toString)
+    }
+
   }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -1,0 +1,41 @@
+package io.shiftleft.semanticcpg.codedumper
+
+import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
+import org.scalatest.{Matchers, WordSpec}
+import io.shiftleft.semanticcpg.language._
+
+class CodeDumperTests extends WordSpec with Matchers {
+
+  val code = """
+                |int my_func(int param1) {
+                |   int x = foo(param1);
+                |}""".stripMargin
+
+  CodeToCpgFixture(code) { cpg =>
+    "should return empty string for empty traversal" in {
+      CodeDumper.dump(cpg.method.name("notinthere")) shouldBe ""
+    }
+
+    "should be able to dump complete function" in {
+      val query = cpg.method.name("my_func")
+      val code = CodeDumper.dump(query)
+      code should startWith(CodeDumper.arrow.toString)
+      code.contains("foo(param1)") shouldBe true
+      code should endWith("}")
+    }
+
+    "should dump method with arrow for expression (a call)" in {
+      val query = cpg.call.name("foo")
+      val code = CodeDumper.dump(query)
+      code should startWith("int")
+      code.matches(".*" + CodeDumper.arrow + ".*" + "int x = foo" + ".*")
+      code should endWith("}")
+    }
+
+    "methodCode should return nothing on invalid filename" in {
+      CodeDumper.code("foo", 1, 2) shouldBe ""
+    }
+
+  }
+
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -20,7 +20,7 @@ class CodeDumperTests extends WordSpec with Matchers {
       val query = cpg.method.name("my_func")
       val code = CodeDumper.dump(query)
       code should startWith(CodeDumper.arrow.toString)
-      code.contains("foo(param1)") shouldBe true
+      code should include("foo(param1)")
       code should endWith("}")
     }
 
@@ -28,7 +28,7 @@ class CodeDumperTests extends WordSpec with Matchers {
       val query = cpg.call.name("foo")
       val code = CodeDumper.dump(query)
       code should startWith("int")
-      code.matches(".*" + CodeDumper.arrow + ".*" + "int x = foo" + ".*")
+      code should include regex (CodeDumper.arrow + ".*" + "int x = foo" + ".*")
       code should endWith("}")
     }
 


### PR DESCRIPTION
This PR introduces a `.dump` step defined on all NodeSteps. This serves as a replacement for the old shell utility `joern-code`. It enables to quickly browse the code associated with findings. By integrating this capability into the query language, it becomes available both in Ocular and Joern without further integration work.

This fixes https://github.com/ShiftLeftSecurity/joern/issues/85