### PR TITLE
Syntax highlighting for `dump`.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -101,7 +101,7 @@ object CodeDumper {
       highlightedCode
     } catch {
       case exception: Exception =>
-        logger.info("syntax highlighting now working. Is `source-highlight-esc.sh` installed?")
+        logger.info("syntax highlighting now working. Is `source-highlight` installed?")
         logger.info(exception)
         ""
     } finally {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.semanticcpg.codedumper
 
-import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.{Languages, nodes}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.NodeSteps
 import better.files._
+import io.shiftleft.codepropertygraph.Cpg
 import org.apache.logging.log4j.LogManager
 
+import sys.process._
 import scala.util.Try
 
 object CodeDumper {
@@ -17,13 +19,15 @@ object CodeDumper {
     * Evaluate the `step` and determine associated locations.
     * Dump code at those locations
     * */
-  def dump[NodeType <: nodes.StoredNode](step: NodeSteps[NodeType]): String =
-    step.location.l.map(dump).mkString("\n")
+  def dump[NodeType <: nodes.StoredNode](step: NodeSteps[NodeType], highlight: Boolean = true): String = {
+    val cpg = new Cpg(step.graph)
+    step.location.l.map(dump(_, highlight, cpg)).mkString("\n")
+  }
 
   /**
     * Dump string representation of code at given `location`.
     * */
-  def dump(location: nodes.NewLocation): String = {
+  private def dump(location: nodes.NewLocation, highlight: Boolean, cpg: Cpg): String = {
     val filename = location.filename
 
     if (location.node.isEmpty) {
@@ -32,6 +36,13 @@ object CodeDumper {
     }
 
     val node = location.node.get
+    val language = cpg.metaData.language.headOption()
+    if (language.isEmpty || !Set(Languages.C).contains(language.get)) {
+      println(language)
+      logger.info("dump not supported for this language or language not set in CPG")
+      return ""
+    }
+
     val method = node match {
       case n: nodes.Method     => Some(n)
       case n: nodes.Expression => Some(n.method)
@@ -42,7 +53,12 @@ object CodeDumper {
     method
       .collect {
         case m: nodes.Method if m.lineNumber.isDefined && m.lineNumberEnd.isDefined =>
-          code(filename, m.lineNumber.get, m.lineNumberEnd.get, lineToHighlight)
+          val rawCode = code(filename, m.lineNumber.get, m.lineNumberEnd.get, lineToHighlight)
+          if (highlight) {
+            externalHighlighter(rawCode, language)
+          } else {
+            rawCode
+          }
       }
       .getOrElse("")
   }
@@ -69,6 +85,29 @@ object CodeDumper {
           }
       }
       .mkString("\n")
+  }
+
+  private def externalHighlighter(code: String, language: Option[String]): String = {
+
+    val langFlag = language match {
+      case Some(Languages.C) => "-sC"
+      case _                 => throw new RuntimeException("Attempting to call highlighter on unsupported language")
+    }
+
+    val f = File.newTemporaryFile("dump")
+    f.writeText(code)
+    val ret = try {
+      val highlightedCode: String = Process(Seq("source-highlight-esc.sh", f.path.toString, langFlag)).!!
+      highlightedCode
+    } catch {
+      case exception: Exception =>
+        logger.info("syntax highlighting now working. Is `source-highlight-esc.sh` installed?")
+        logger.info(exception)
+        ""
+    } finally {
+      f.delete()
+    }
+    ret
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -37,7 +37,9 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
   def location: NewLocation =
     new NewLocation(raw.map(x => x.location))
 
-  def dump: String = CodeDumper.dump(this)
+  def dump: String = CodeDumper.dump(this, true)
+
+  def dumpRaw: String = CodeDumper.dump(this, false)
 
   /* follow the incoming edges of the given type as long as possible */
   protected def walkIn(edgeType: String): GremlinScala[Vertex] =

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -13,12 +13,12 @@ class CodeDumperTests extends WordSpec with Matchers {
 
   CodeToCpgFixture(code) { cpg =>
     "should return empty string for empty traversal" in {
-      CodeDumper.dump(cpg.method.name("notinthere")) shouldBe ""
+      CodeDumper.dump(cpg.method.name("notinthere"), false) shouldBe ""
     }
 
     "should be able to dump complete function" in {
       val query = cpg.method.name("my_func")
-      val code = CodeDumper.dump(query)
+      val code = CodeDumper.dump(query, false)
       code should startWith(CodeDumper.arrow.toString)
       code should include("foo(param1)")
       code should endWith("}")
@@ -26,7 +26,7 @@ class CodeDumperTests extends WordSpec with Matchers {
 
     "should dump method with arrow for expression (a call)" in {
       val query = cpg.call.name("foo")
-      val code = CodeDumper.dump(query)
+      val code = CodeDumper.dump(query, false)
       code should startWith("int")
       code should include regex (CodeDumper.arrow + ".*" + "int x = foo" + ".*")
       code should endWith("}")
@@ -37,7 +37,7 @@ class CodeDumperTests extends WordSpec with Matchers {
     }
 
     "should allow dumping via .dump" in {
-      val code = cpg.method.name("my_func").dump
+      val code = cpg.method.name("my_func").dumpRaw
       code should startWith(CodeDumper.arrow.toString)
     }
 


### PR DESCRIPTION
* Add syntax-highlighting using `source-highlight`
* Add checks to ensure that - for the time being - `dump` returns empty strings for all languages except C
