### PR TITLE
Have `callIn` return `Call`, not `Steps[nodes.Call]`.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -55,8 +55,8 @@ class Method(override val raw: GremlinScala[nodes.Method]) extends Steps[nodes.M
   /**
     * Incoming call sites
     * */
-  def callIn(implicit callResolver: ICallResolver): Steps[nodes.Call] = {
-    new Steps[nodes.Call](
+  def callIn(implicit callResolver: ICallResolver): Call = {
+    new Call(
       sideEffect(callResolver.resolveDynamicMethodCallSites).raw
         .in(EdgeTypes.CALL)
         .cast[nodes.Call])

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -41,6 +41,12 @@ class CodeDumperTests extends WordSpec with Matchers {
       code should startWith(CodeDumper.arrow.toString)
     }
 
+    "should allow dumping callIn" in {
+      implicit val resolver: ICallResolver = NoResolve
+      val code = cpg.method.name("foo").callIn.dumpRaw
+      code should startWith("int")
+    }
+
   }
 
 }


### PR DESCRIPTION
This is necessary because `.dump` is defined on `NodeSteps`, and
although implicit conversions are in place, we end up with
ambiguity that does not allow us to resolve that `Steps[nodes.Call]`
is `Call`.