### PR TITLE
Turn off syntax highlighting by default

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -37,9 +37,17 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
   def location: NewLocation =
     new NewLocation(raw.map(x => x.location))
 
-  def dump: String = CodeDumper.dump(this, true)
+  /**
+    * For methods, dump the method code. For expressions,
+    * dump the method code along with an arrow pointing
+    * to the expression.
+    * */
+  def dump: String = CodeDumper.dump(this, false)
 
-  def dumpRaw: String = CodeDumper.dump(this, false)
+  /**
+    * Dump with colored (syntax highlighted output)
+    * */
+  def dumpc: String = CodeDumper.dump(this, false)
 
   /* follow the incoming edges of the given type as long as possible */
   protected def walkIn(edgeType: String): GremlinScala[Vertex] =

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -37,13 +37,13 @@ class CodeDumperTests extends WordSpec with Matchers {
     }
 
     "should allow dumping via .dump" in {
-      val code = cpg.method.name("my_func").dumpRaw
+      val code = cpg.method.name("my_func").dump
       code should startWith(CodeDumper.arrow.toString)
     }
 
     "should allow dumping callIn" in {
       implicit val resolver: ICallResolver = NoResolve
-      val code = cpg.method.name("foo").callIn.dumpRaw
+      val code = cpg.method.name("foo").callIn.dump
       code should startWith("int")
     }
 


### PR DESCRIPTION
The ammonite shell is having trouble with the ansi escape sequences generated by `source-highlight`, and this seems to require quite a bit of work to fix (see https://github.com/ShiftLeftSecurity/codepropertygraph/issues/441). Until this is fixed, let's have `.dump` at least return non-highlighted code. Once it works, we change this default behavior.