### PR TITLE
`dump` must return `List[String]` to work with browse

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -13,15 +13,15 @@ import scala.util.Try
 object CodeDumper {
 
   private val logger = LogManager.getLogger(CodeDumper)
-  val arrow: CharSequence = "// ===>\n"
+  val arrow: CharSequence = "// ===> "
 
   /**
     * Evaluate the `step` and determine associated locations.
     * Dump code at those locations
     * */
-  def dump[NodeType <: nodes.StoredNode](step: NodeSteps[NodeType], highlight: Boolean = true): String = {
+  def dump[NodeType <: nodes.StoredNode](step: NodeSteps[NodeType], highlight: Boolean = true): List[String] = {
     val cpg = new Cpg(step.graph)
-    step.location.l.map(dump(_, highlight, cpg)).mkString("\n")
+    step.location.l.map(dump(_, highlight, cpg))
   }
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -42,12 +42,12 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
     * dump the method code along with an arrow pointing
     * to the expression.
     * */
-  def dump: String = CodeDumper.dump(this, false)
+  def dump: List[String] = CodeDumper.dump(this, false)
 
   /**
     * Dump with colored (syntax highlighted output)
     * */
-  def dumpc: String = CodeDumper.dump(this, false)
+  def dumpc: List[String] = CodeDumper.dump(this, false)
 
   /* follow the incoming edges of the given type as long as possible */
   protected def walkIn(edgeType: String): GremlinScala[Vertex] =

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -13,12 +13,12 @@ class CodeDumperTests extends WordSpec with Matchers {
 
   CodeToCpgFixture(code) { cpg =>
     "should return empty string for empty traversal" in {
-      CodeDumper.dump(cpg.method.name("notinthere"), false) shouldBe ""
+      CodeDumper.dump(cpg.method.name("notinthere"), false).mkString("\n") shouldBe ""
     }
 
     "should be able to dump complete function" in {
       val query = cpg.method.name("my_func")
-      val code = CodeDumper.dump(query, false)
+      val code = CodeDumper.dump(query, false).mkString("\n")
       code should startWith(CodeDumper.arrow.toString)
       code should include("foo(param1)")
       code should endWith("}")
@@ -26,7 +26,7 @@ class CodeDumperTests extends WordSpec with Matchers {
 
     "should dump method with arrow for expression (a call)" in {
       val query = cpg.call.name("foo")
-      val code = CodeDumper.dump(query, false)
+      val code = CodeDumper.dump(query, false).mkString("\n")
       code should startWith("int")
       code should include regex (CodeDumper.arrow + ".*" + "int x = foo" + ".*")
       code should endWith("}")
@@ -37,13 +37,13 @@ class CodeDumperTests extends WordSpec with Matchers {
     }
 
     "should allow dumping via .dump" in {
-      val code = cpg.method.name("my_func").dump
+      val code = cpg.method.name("my_func").dump.mkString("\n")
       code should startWith(CodeDumper.arrow.toString)
     }
 
     "should allow dumping callIn" in {
       implicit val resolver: ICallResolver = NoResolve
-      val code = cpg.method.name("foo").callIn.dump
+      val code = cpg.method.name("foo").callIn.dump.mkString("\n")
       code should startWith("int")
     }
 


### PR DESCRIPTION
While testing `dump` on the shell, it became clear that - to work with the pager (`browse`) - we need to return a list of strings. This also makes more sense: one string of code is returned per result. What also became clear is that an arrow on a line by itself, followed by a newline, doesn't look good. The arrow is now on the same line as the expression.