### PR TITLE
towards fixing the cpg-csharp bindings

### DIFF
--- a/build-dotnet-bindings.sh
+++ b/build-dotnet-bindings.sh
@@ -27,7 +27,7 @@ fi
 echo "generating csharp protoc bindings for cpg.proto"
 rm -rf target/csharp
 mkdir -p target/csharp/io/shiftleft/proto
-cp codepropertygraph/target/resource_managed/main/cpg.proto target/csharp
+cp codepropertygraph/target/cpg.proto target/csharp
 cp proto-bindings/cpg-proto-bindings.csproj target/csharp
 cd target/csharp
 protoc --csharp_out=io/shiftleft/proto cpg.proto


### PR DESCRIPTION
* check return codes when invoking external commands
* fix path to cpg.proto

re https://github.com/ShiftLeftSecurity/codescience/issues/2988

I'm not sure where the proto bindings are built (I didn't find anything on jenkins or travis), but in case that's still attempted, it should just work again. Otherwise we'll need to see where we want that to happen (probably travis).