### PR TITLE
size/count and is steps

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -3,6 +3,7 @@ package io.shiftleft.semanticcpg.language
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes._
+import java.lang.{Long => JLong}
 import java.util.{List => JList}
 
 import org.apache.tinkerpop.gremlin.process.traversal.Scope
@@ -300,4 +301,19 @@ class Steps[A](val raw: GremlinScala[A]) {
     * */
   def orderBy[B](fun: A => B): Steps[A] =
     new Steps[A](raw.order(By(fun)))
+
+  /** count number of elements */
+  def count: Steps[JLong] =
+    new Steps[JLong](raw.count)
+
+  /** alias for [[count]] step */
+  def size: Steps[JLong] = count
+
+  /** filter by a concrete value to compare against */
+  def is(value: AnyRef): Steps[A] =
+    new Steps[A](raw.is(value))
+
+  /** filter by a Predicate, e.g. [[P.gt(5)]] or [[P.eq(42)]] */
+  def is(predicate: P[A]): Steps[A] =
+    new Steps[A](raw.is(predicate))
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.semanticcpg.language
 
+import gremlin.scala.P
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.json4s.JString
@@ -68,6 +69,25 @@ class StepsTest extends WordSpec with Matchers {
 
       mainMethods.size shouldBe 1
       allMethods.size should be > 1
+    }
+  }
+
+  "count/size" in ExistingCpgFixture("splitmeup") { fixture =>
+    val methodCount: Long = fixture.cpg.method.count.head
+    methodCount should be > 30L
+  }
+
+  "filter on count/size" when {
+    "comparing against concrete value" in ExistingCpgFixture("splitmeup") { fixture =>
+      val methodsWithOneParam: Long =
+        fixture.cpg.method.filter(_.parameter.size.is(Long.box(1))).size.head
+      methodsWithOneParam should be > 5L
+    }
+
+    "comparing against predicate" in ExistingCpgFixture("splitmeup") { fixture =>
+      val methodsWithMoreThanOneParams: Long =
+        fixture.cpg.method.filter(_.parameter.size.is(P.gt(1))).size.head
+      methodsWithMoreThanOneParams should be > 20L
     }
   }
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -80,7 +80,7 @@ class StepsTest extends WordSpec with Matchers {
   "filter on count/size" when {
     "comparing against concrete value" in ExistingCpgFixture("splitmeup") { fixture =>
       val methodsWithOneParam: Long =
-        fixture.cpg.method.filter(_.parameter.size.is(Long.box(1))).size.head
+        fixture.cpg.method.filter(_.parameter.size.is(1)).size.head
       methodsWithOneParam should be > 5L
     }
 


### PR DESCRIPTION
Triggered https://github.com/ShiftLeftSecurity/codescience/issues/2995 it
became obvious that we're missing a few basic wrapper steps. These are easy
to add though.

`is(P)` is a bit of a leaky abstraction, but not too bad IMO.

n.b. independent of this we can still rename `filter` ->
`filterOnTrav` and `filterOnEnd` -> `filter`. Downside would be that we
have to teach customers. Upside is that we'll have to do that eventually
anyway, with the new collection-based traversal.