### PR TITLE
CodeDump: move arrow onto the right side

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ publish / skip := true
 
 // parsed by project/Utils.scala
 
-val fuzzyc2cpgVersion = "1.1.4"
+val fuzzyc2cpgVersion = "1.1.8"
 
 lazy val codepropertygraph = Projects.codepropertygraph
 lazy val protoBindings = Projects.protoBindings

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CDataFlowTests.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CDataFlowTests.scala
@@ -9,8 +9,7 @@ class CDataFlowTests extends CpgDataFlowTests {
     cpgFactory.buildCpg(
       """
         |
-        | void flows1(FILE *fd, int mode)
-        | {
+        | void flows1(FILE *fd, int mode) {
         |     char buff[40];
         |
         |     int sz = 0;

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -13,7 +13,7 @@ import scala.util.Try
 object CodeDumper {
 
   private val logger = LogManager.getLogger(CodeDumper)
-  val arrow: CharSequence = "/* ===> */ "
+  val arrow: CharSequence = "/* <=== */ "
 
   /**
     * Evaluate the `step` and determine associated locations.
@@ -80,7 +80,7 @@ object CodeDumper {
       .map {
         case (line, lineNo) =>
           if (lineToHighlight.isDefined && lineNo == lineToHighlight.get - startLine) {
-            arrow + " " + line
+            line + " " + arrow
           } else {
             line
           }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -10,7 +10,8 @@ class CodeDumperTests extends WordSpec with Matchers {
 
   val code = """
                 | // A comment
-                |int my_func(int param1) {
+                |int my_func(int param1)
+                |{
                 |   int x = foo(param1);
                 |}""".stripMargin
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -9,6 +9,7 @@ import io.shiftleft.semanticcpg.language._
 class CodeDumperTests extends WordSpec with Matchers {
 
   val code = """
+                | // A comment
                 |int my_func(int param1) {
                 |   int x = foo(param1);
                 |}""".stripMargin
@@ -23,7 +24,7 @@ class CodeDumperTests extends WordSpec with Matchers {
     "should be able to dump complete function" in {
       val query = cpg.method.name("my_func")
       val code = CodeDumper.dump(query, false).mkString("\n")
-      code should startWith(CodeDumper.arrow.toString)
+      code should startWith("int my_func")
       code should include("foo(param1)")
       code should endWith("}")
     }
@@ -32,7 +33,7 @@ class CodeDumperTests extends WordSpec with Matchers {
       val query = cpg.call.name("foo")
       val code = CodeDumper.dump(query, false).mkString("\n")
       code should startWith("int")
-      code should include regex (Pattern.quote(CodeDumper.arrow.toString) + ".*" + "int x = foo" + ".*")
+      code should include regex (".*" + "int x = foo" + ".*" + Pattern.quote(CodeDumper.arrow.toString) + ".*")
       code should endWith("}")
     }
 
@@ -42,7 +43,7 @@ class CodeDumperTests extends WordSpec with Matchers {
 
     "should allow dumping via .dump" in {
       val code = cpg.method.name("my_func").dumpRaw.mkString("\n")
-      code should startWith(CodeDumper.arrow.toString)
+      code should startWith("int my_func")
     }
 
     "should allow dumping callIn" in {


### PR DESCRIPTION
* Moving arrow onto the right-hand side so that code formatting isn't broken.
* Update fuzzyc version to latest for line-number patch.