### PR TITLE
Minor fixes for query language

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
@@ -1,0 +1,18 @@
+package io.shiftleft.semanticcpg.language.nodemethods
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.{Node, StoredNode}
+import io.shiftleft.semanticcpg.language.LocationCreator
+
+class NodeMethods(node: Node) {
+
+  def location: nodes.NewLocation = {
+    node match {
+      case storedNode: StoredNode =>
+        LocationCreator(storedNode)
+      case _ =>
+        LocationCreator.emptyLocation("", None)
+
+    }
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes.{Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
-import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, WithinMethodMethods}
+import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, NodeMethods, WithinMethodMethods}
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
@@ -22,6 +22,8 @@ package object language {
 
   // Implicit conversions from generated node types. We use these to add methods
   // to generated node types.
+
+  implicit def toExtendedNode(node: Node): NodeMethods = new NodeMethods(node)
 
   implicit def withMethodMethodsQp(node: nodes.WithinMethod): WithinMethodMethods =
     new WithinMethodMethods(node)
@@ -186,23 +188,5 @@ package object language {
 
   implicit def toCallForCallGraph(steps: Steps[nodes.Call]): Call =
     new Call(steps.raw)
-
-  // Locations
-
-  implicit def toExtendedNode(node: Node): ExtendedNode =
-    new ExtendedNode(node)
-
-  case class ExtendedNode(node: Node) {
-
-    def location: nodes.NewLocation = {
-      node match {
-        case storedNode: StoredNode =>
-          LocationCreator(storedNode)
-        case _ =>
-          LocationCreator.emptyLocation("", None)
-
-      }
-    }
-  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
@@ -26,12 +26,6 @@ class ControlStructure(raw: GremlinScala[nodes.ControlStructure])
   def condition: Expression =
     new Expression(raw.out(EdgeTypes.CONDITION).cast[nodes.Expression])
 
-  /**
-    * Only those control structures where condition matched `regex`
-    * */
-  def condition(regex: String): ControlStructure =
-    new ControlStructure(this.filterOnEnd(_.code.matches(regex)).raw)
-
   def whenTrue: AstNode = new AstNode(
     raw.out.has(NodeKeys.ORDER, secondChildIndex).cast[nodes.AstNode]
   )

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -60,9 +60,14 @@ class Method(override val raw: GremlinScala[nodes.Method])
   }
 
   /**
+    * All control structures of this method
+    * */
+  def controlStructure: ControlStructure = ast.isControlStructure
+
+  /**
     * Shorthand to traverse to control structures where condition matches `regex`
     * */
-  def condition(regex: String): ControlStructure = ast.isControlStructure.condition(regex)
+  def controlStructure(regex: String): ControlStructure = ast.isControlStructure.code(regex)
 
   /**
     * Outgoing call sites

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
@@ -82,7 +82,7 @@ class CAstTests extends WordSpec with Matchers {
     }
 
     "should identify conditions" in {
-      cpg.method.name("foo").ast.isControlStructure.condition.code.l shouldBe List("x > 10", "y > x")
+      cpg.method.name("foo").controlStructure.condition.code.l shouldBe List("x > 10", "y > x")
     }
 
     "should allow parserTypeName filtering and then ast" in {
@@ -100,7 +100,7 @@ class CAstTests extends WordSpec with Matchers {
       query1Size shouldBe query2Size
     }
 
-    "should allow filtering on conditions" in {
+    "should allow filtering on control structures" in {
       cpg.method
         .name("foo")
         .controlStructure(".*x > 10.*")

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
@@ -103,13 +103,13 @@ class CAstTests extends WordSpec with Matchers {
     "should allow filtering on conditions" in {
       cpg.method
         .name("foo")
-        .condition(".*x > 10.*")
+        .controlStructure(".*x > 10.*")
         .l
         .size shouldBe 1
 
       cpg.method
         .name("foo")
-        .condition(".*x > 10.*")
+        .controlStructure(".*x > 10.*")
         .whenTrue
         .ast
         .isReturnNode
@@ -118,7 +118,7 @@ class CAstTests extends WordSpec with Matchers {
 
       cpg.method
         .name("foo")
-        .condition(".*x > 10.*")
+        .controlStructure(".*x > 10.*")
         .whenFalse
         .ast
         .isCall


### PR DESCRIPTION
* Moved `ExtendedNode` to `NodeMethods` to be consistent with the way we add methods to AST and CFG nodes
* Add missing step to retrieve all control structures of a method
* Rename wrongly named `condition(regex)` step to `controlStructure(regex)`
* Update tests accordingly.