### PR TITLE
Utility methods to get around `.start`

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -300,4 +300,7 @@ class Steps[A](val raw: GremlinScala[A]) {
     * */
   def orderBy[B](fun: A => B): Steps[A] =
     new Steps[A](raw.order(By(fun)))
+
+  def size: Int = l.size
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,0 +1,15 @@
+package io.shiftleft.semanticcpg.language.nodemethods
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.structure.{Local, MethodParameter}
+
+class MethodMethods(val node: nodes.Method) extends AnyVal {
+
+  def parameter: MethodParameter = node.start.parameter
+
+  def methodReturn: nodes.MethodReturn = node.start.methodReturn.head
+
+  def local: Local = node.start.local
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes.{Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
-import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, NodeMethods, WithinMethodMethods}
+import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, MethodMethods, NodeMethods, WithinMethodMethods}
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
@@ -30,6 +30,9 @@ package object language {
 
   implicit def astNodeMethodsQp(node: nodes.AstNode): AstNodeMethods =
     new AstNodeMethods(node)
+
+  implicit def toMethodMethods(node: nodes.Method): MethodMethods =
+    new MethodMethods(node)
 
   // Implicit conversions from Step[NodeType, Label] to corresponding Step classes.
   // If you introduce a new Step-type, that is, one that inherits from `Steps[NodeType,Labels]`,

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
@@ -55,6 +55,11 @@ class CMethodTests extends WordSpec with Matchers {
       cpg.method.name("main").file.name.l should not be empty
     }
 
+    "should allow filtering by number of parameters" in {
+      cpg.method.filterOnEnd(_.parameter.size == 2).name.l shouldBe List("main")
+      cpg.method.filterOnEnd(_.parameter.size == 1).name.l shouldBe List()
+    }
+
   }
 
 }


### PR DESCRIPTION
This adds methods to `nodes.Method` via implicit conversion. This makes the queries I want to present in an upcoming blog post a lot more elegant.

As discussed on slack, while the new query language implementation will make this kind of glue code obsolete, I will be introducing it in the next months so that the language already takes shape, even if the implementation still changes.