### PR TITLE
Introduce `where` as replacement for `filterOnEnd`

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -237,8 +237,12 @@ class Steps[A](val raw: GremlinScala[A]) {
   /**
     Same as filter, but operates with a lambda (will only work with local databases)
     */
-  def filterOnEnd(predicate: A => Boolean): Steps[A] =
+  def where(predicate: A => Boolean): Steps[A] =
     new Steps[A](raw.filterOnEnd(predicate))
+
+  @deprecated("", "Nov. 2019")
+  def filterOnEnd(predicate: A => Boolean): Steps[A] =
+    where(predicate)
 
   /**
     * The or step is a filter with multiple or related filter traversals.

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -23,7 +23,7 @@ class StepsTest extends WordSpec with Matchers {
       val mainMethods: List[nodes.Method] =
         fixture.cpg.method
           .name(".*")
-          .filterOnEnd(_.fullName.matches(".*main.*"))
+          .where(_.fullName.matches(".*main.*"))
           .toList
 
       mainMethods.size shouldBe 1
@@ -63,7 +63,7 @@ class StepsTest extends WordSpec with Matchers {
         fixture.cpg.method
           .name(".*")
           .aggregate(allMethods)
-          .filterOnEnd(_.fullName.matches(".*main.*"))
+          .where(_.fullName.matches(".*main.*"))
           .toList
 
       mainMethods.size shouldBe 1

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CAstTests.scala
@@ -52,7 +52,7 @@ class CAstTests extends WordSpec with Matchers {
         .name("moo")
         .callIn
         .argument(1)
-        .filterOnEnd(
+        .where(
           arg =>
             arg.start.ast
               .isCallTo("<operator>.(addition|multiplication)")

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
@@ -56,8 +56,8 @@ class CMethodTests extends WordSpec with Matchers {
     }
 
     "should allow filtering by number of parameters" in {
-      cpg.method.filterOnEnd(_.parameter.size == 2).name.l shouldBe List("main")
-      cpg.method.filterOnEnd(_.parameter.size == 1).name.l shouldBe List()
+      cpg.method.where(_.parameter.size == 2).name.l shouldBe List("main")
+      cpg.method.where(_.parameter.size == 1).name.l shouldBe List()
     }
 
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTests.scala
@@ -37,7 +37,7 @@ class TypeDeclTests extends WordSpec with Matchers {
     }
 
     "should allow traversing from type to enclosing file" in {
-      cpg.typeDecl.file.filterOnEnd(_.name.endsWith(".c")).l should not be empty
+      cpg.typeDecl.file.where(_.name.endsWith(".c")).l should not be empty
     }
 
   }


### PR DESCRIPTION
Found a non-intrusive solution to https://github.com/ShiftLeftSecurity/codescience/issues/2995: renamed `filterOnEnd` to `where`. I left `filterOnEnd` as an alias for now and deprecated it.
