### PR TITLE
Add `nodeType` to `SINK` nodes for consistency.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/securityprofile.json
+++ b/codepropertygraph/src/main/resources/schemas/securityprofile.json
@@ -74,6 +74,7 @@
             {"localName" : "nodeType", "nodeType" : "TYPE", "cardinality" : "one"}
         ]},	{"id" : 203, "name" : "SINK", "comment" : "", "keys" : ["SINK_TYPE"], "comment" : "", "outEdges" : [], "containedNodes" : [
             {"localName" : "node", "nodeType" : "TRACKING_POINT", "cardinality" : "one"},
+	    {"localName" : "nodeType", "nodeType" : "TYPE", "cardinality" : "one"},
             {"localName" : "method", "nodeType" : "METHOD", "cardinality" : "one" },
             {"localName" : "methodTags", "nodeType" : "TAG", "cardinality" : "list"},
             {"localName" : "callingMethod", "nodeType" : "METHOD", "cardinality" : "zeroOrOne"},


### PR DESCRIPTION
`SOURCE` nodes have a `nodeType`, while `SINK` nodes do not. To be consistent - and because sp2tsdb requires this field - in this PR, this field is added.