### PR TITLE
Dominator/CDG pass

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgAdapter.scala
@@ -1,0 +1,6 @@
+package io.shiftleft.semanticcpg.passes.cfgdominator
+
+trait CfgAdapter[Node] {
+  def successors(node: Node): TraversableOnce[Node]
+  def predecessors(node: Node): TraversableOnce[Node]
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
@@ -1,0 +1,114 @@
+package io.shiftleft.semanticcpg.passes.cfgdominator
+
+class CfgDominator[Node](adapter: CfgAdapter[Node]) {
+
+  /**
+    * Calculates the immediate dominators of all CFG nodes reachable from cfgEntry.
+    * Since the cfgEntry does not have an immediate dominator, it has no entry in the
+    * return map.
+    *
+    * The used algorithm is from: "A Simple, Fast Dominance Algorithm" from
+    * "Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy".
+    */
+  def calculate(cfgEntry: Node): Map[Node, Node] = {
+    val UNDEFINED = -1
+    val postOrderNumbering = createPostOrderNumbering(cfgEntry)
+    val indexOf = postOrderNumbering.withDefaultValue(UNDEFINED) // Index of each node into dominators array.
+    // We use withDefault because unreachable/dead
+    // code nodes are not numbered but may be touched
+    // as predecessors of reachable nodes.
+    val nodesInReversePostOrder = postOrderNumbering.toList // Does not contain entry.
+      .sortBy { case (node, index) => -index }
+      .map { case (node, index) => node }
+      .filter { _ != cfgEntry }
+    val dominators = Array.fill(indexOf.size)(UNDEFINED)
+
+    // Used in places where index might be UNDEFINED.
+    def saveDominators(index: Int): Int = {
+      if (index != UNDEFINED) {
+        dominators(index)
+      } else {
+        UNDEFINED
+      }
+    }
+
+    dominators(indexOf(cfgEntry)) = indexOf(cfgEntry)
+
+    var changed = true
+    while (changed) {
+      changed = false
+      nodesInReversePostOrder.foreach { node =>
+        val firstNotUndefinedPred = adapter
+          .predecessors(node)
+          .find { predecessor =>
+            saveDominators(indexOf(predecessor)) != UNDEFINED
+          }
+          .get
+
+        var newImmediateDominator = indexOf(firstNotUndefinedPred)
+        adapter.predecessors(node).foreach { predecessor =>
+          val predecessorIndex = indexOf(predecessor)
+          if (saveDominators(predecessorIndex) != UNDEFINED) {
+            newImmediateDominator = intersect(dominators, predecessorIndex, newImmediateDominator)
+          }
+        }
+
+        val nodeIndex = indexOf(node)
+        if (dominators(nodeIndex) != newImmediateDominator) {
+          dominators(nodeIndex) = newImmediateDominator
+          changed = true
+        }
+      }
+
+    }
+
+    val postOrderNumberingToNode = postOrderNumbering.map { case (node, index) => (index, node) }
+
+    postOrderNumbering.collect {
+      case (node, index) if node != cfgEntry =>
+        val immediateDominatorIndex = dominators(index)
+        (node, postOrderNumberingToNode(immediateDominatorIndex))
+    }
+  }
+
+  private def intersect(dominators: Array[Int], immediateDomIndex1: Int, immediateDomIndex2: Int): Int = {
+    var finger1 = immediateDomIndex1
+    var finger2 = immediateDomIndex2
+
+    while (finger1 != finger2) {
+      while (finger1 < finger2) {
+        finger1 = dominators(finger1)
+      }
+      while (finger2 < finger1) {
+        finger2 = dominators(finger2)
+      }
+    }
+    finger1
+  }
+
+  private def createPostOrderNumbering(cfgEntry: Node): Map[Node, Int] = {
+    var stack = (cfgEntry, adapter.successors(cfgEntry).toIterator) :: Nil
+    var visited = Set.empty[Node]
+    var numbering = Map.empty[Node, Int]
+    var nextNumber = 0
+
+    while (stack.nonEmpty) {
+      val (node, successorIt) = stack.head
+
+      visited += node
+
+      if (successorIt.hasNext) {
+        val successor = successorIt.next
+        if (!visited.contains(successor)) {
+          stack = (successor, adapter.successors(successor).toIterator) :: stack
+        }
+      } else {
+        stack = stack.tail
+        numbering += (node -> nextNumber)
+        nextNumber += 1
+      }
+    }
+
+    numbering
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorFrontier.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorFrontier.scala
@@ -1,0 +1,40 @@
+package io.shiftleft.semanticcpg.passes.cfgdominator
+
+import scala.collection.mutable
+
+class CfgDominatorFrontier[Node](cfgAdapter: CfgAdapter[Node], domTreeAdapter: DomTreeAdapter[Node]) {
+
+  /**
+    * Calculates a the dominator frontier for a set of CFG nodes.
+    * The returned multimap associates the frontier nodes to each CFG node.
+    *
+    * The used algorithm is from: "A Simple, Fast Dominance Algorithm" from
+    * "Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy".
+    */
+  def calculate(allCfgNodes: Seq[Node]): mutable.MultiMap[Node, Node] = {
+    val domFrontier = new mutable.HashMap[Node, mutable.Set[Node]] with mutable.MultiMap[Node, Node]
+
+    allCfgNodes.foreach { joinCandiate =>
+      val predecessors = cfgAdapter.predecessors(joinCandiate).toSeq
+
+      if (predecessors.size > 1) {
+        val joinNode = joinCandiate
+
+        domTreeAdapter.immediateDominator(joinNode) match {
+          case Some(immediateJoinNodeDom) =>
+            predecessors.foreach { predecessor =>
+              var currentPred = Option(predecessor)
+
+              while (currentPred.isDefined && currentPred.get != immediateJoinNodeDom) {
+                domFrontier.addBinding(currentPred.get, joinNode)
+                currentPred = domTreeAdapter.immediateDominator(currentPred.get)
+              }
+            }
+          case _ =>
+        }
+      }
+    }
+
+    domFrontier
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
@@ -1,0 +1,61 @@
+package io.shiftleft.semanticcpg.passes.cfgdominator
+
+import gremlin.scala._
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.passes.{CpgPass, DiffGraph, ParallelIteratorExecutor}
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.utils.ExpandTo
+
+/**
+  * This pass has no prerequisites.
+  */
+class CfgDominatorPass(cpg: Cpg) extends CpgPass(cpg) {
+
+  override def run(): Iterator[DiffGraph] = {
+    val methodsIterator = cpg.method.toIterator
+    new ParallelIteratorExecutor(methodsIterator).map(perMethod)
+  }
+
+  private def perMethod(method: Vertex): DiffGraph = {
+    val cfgAdapter = new CpgCfgAdapter()
+    val dominatorCalculator = new CfgDominator(cfgAdapter)
+
+    val reverseCfgAdapter = new ReverseCpgCfgAdapter()
+    val postDominatorCalculator = new CfgDominator(reverseCfgAdapter)
+
+    val dstGraph = new DiffGraph()
+
+    val cfgNodeToImmediateDominator = dominatorCalculator.calculate(method)
+    addDomTreeEdges(dstGraph, cfgNodeToImmediateDominator)
+
+    val cfgNodeToPostImmediateDominator =
+      postDominatorCalculator.calculate(ExpandTo.methodToFormalReturn(method))
+    addPostDomTreeEdges(dstGraph, cfgNodeToPostImmediateDominator)
+
+    dstGraph
+  }
+
+  private def addDomTreeEdges(dstGraph: DiffGraph, cfgNodeToImmediateDominator: Map[Vertex, Vertex]): Unit = {
+    // TODO do not iterate over potential hash map to ensure same interation order for
+    // edge creation.
+    cfgNodeToImmediateDominator.foreach {
+      case (node, immediateDominator) =>
+        dstGraph.addEdgeInOriginal(immediateDominator.asInstanceOf[StoredNode],
+                                   node.asInstanceOf[StoredNode],
+                                   EdgeTypes.DOMINATE)
+    }
+  }
+
+  private def addPostDomTreeEdges(dstGraph: DiffGraph, cfgNodeToPostImmediateDominator: Map[Vertex, Vertex]): Unit = {
+    // TODO do not iterate over potential hash map to ensure same interation order for
+    // edge creation.
+    cfgNodeToPostImmediateDominator.foreach {
+      case (node, immediatePostDominator) =>
+        dstGraph.addEdgeInOriginal(immediatePostDominator.asInstanceOf[StoredNode],
+                                   node.asInstanceOf[StoredNode],
+                                   EdgeTypes.POST_DOMINATE)
+    }
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CpgCfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CpgCfgAdapter.scala
@@ -1,0 +1,17 @@
+package io.shiftleft.semanticcpg.passes.cfgdominator
+
+import gremlin.scala.Vertex
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import org.apache.tinkerpop.gremlin.structure.Direction
+
+import scala.collection.JavaConverters._
+
+class CpgCfgAdapter extends CfgAdapter[Vertex] {
+  override def successors(node: Vertex): TraversableOnce[Vertex] = {
+    node.vertices(Direction.OUT, EdgeTypes.CFG).asScala
+  }
+
+  override def predecessors(node: Vertex): TraversableOnce[Vertex] = {
+    node.vertices(Direction.IN, EdgeTypes.CFG).asScala
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/DomTreeAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/DomTreeAdapter.scala
@@ -1,0 +1,13 @@
+package io.shiftleft.semanticcpg.passes.cfgdominator
+
+trait DomTreeAdapter[Node] {
+
+  /**
+    * Returns the immediate dominator of a cfgNode. The returned value
+    * can be None if cfgNode was the cfg entry node while calculating
+    * the dominator relation or if cfgNode is dead code. In the post
+    * dominator case "dead code" means code which does lead to the
+    * normal method exit. An example would be a thrown excpetion.
+    */
+  def immediateDominator(cfgNode: Node): Option[Node]
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/ReverseCpgCfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/ReverseCpgCfgAdapter.scala
@@ -1,0 +1,17 @@
+package io.shiftleft.semanticcpg.passes.cfgdominator
+
+import gremlin.scala.Vertex
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import org.apache.tinkerpop.gremlin.structure.Direction
+
+import scala.collection.JavaConverters._
+
+class ReverseCpgCfgAdapter extends CfgAdapter[Vertex] {
+  override def successors(node: Vertex): TraversableOnce[Vertex] = {
+    node.vertices(Direction.IN, EdgeTypes.CFG).asScala
+  }
+
+  override def predecessors(node: Vertex): TraversableOnce[Vertex] = {
+    node.vertices(Direction.OUT, EdgeTypes.CFG).asScala
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
@@ -1,0 +1,57 @@
+package io.shiftleft.semanticcpg.passes.codepencegraph
+
+import gremlin.scala._
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
+import org.apache.logging.log4j.LogManager
+import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominatorFrontier, ReverseCpgCfgAdapter}
+import org.apache.tinkerpop.gremlin.structure.Direction
+import io.shiftleft.semanticcpg.language._
+
+import scala.collection.JavaConverters._
+
+/**
+  * This pass has ContainsEdgePass and CfgDominatorPass as prerequisites.
+  */
+class CdgPass(cpg: Cpg) extends CpgPass(cpg) {
+  import CdgPass.logger
+
+  override def run(): Iterator[DiffGraph] = {
+    val dstGraph = new DiffGraph
+
+    val dominanceFrontier =
+      new CfgDominatorFrontier(new ReverseCpgCfgAdapter(), new CpgPostDomTreeAdapter())
+
+    cpg.method.l.foreach { method =>
+      val cfgNodes = method.vertices(Direction.OUT, EdgeTypes.CONTAINS).asScala.toList
+      val postDomFrontiers = dominanceFrontier.calculate(method :: cfgNodes)
+
+      postDomFrontiers.foreach {
+        case (node, frontier) =>
+          frontier.foreach { postDomFrontierNode =>
+            postDomFrontierNode match {
+              case _: nodes.Literal | _: nodes.Identifier | _: nodes.Call | _: nodes.MethodRef | _: nodes.Unknown =>
+                dstGraph.addEdgeInOriginal(postDomFrontierNode.asInstanceOf[nodes.StoredNode],
+                                           node.asInstanceOf[nodes.StoredNode],
+                                           EdgeTypes.CDG)
+              case _ =>
+                val method = postDomFrontierNode.vertices(Direction.IN, EdgeTypes.CONTAINS).next
+                val nodeLabel = postDomFrontierNode.label
+                logger.warn(
+                  s"Found CDG edge starting at $nodeLabel node. This is most likely caused by an invalid CFG." +
+                    s" Method: ${method.valueOption(NodeKeys.FULL_NAME)}" +
+                    s" number of outgoing CFG edges from $nodeLabel node: ${postDomFrontierNode.edges(Direction.OUT, EdgeTypes.CFG).asScala.size}")
+
+            }
+          }
+      }
+    }
+
+    Iterator(dstGraph)
+  }
+}
+
+object CdgPass {
+  private val logger = LogManager.getLogger(classOf[CdgPass])
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CpgPostDomTreeAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CpgPostDomTreeAdapter.scala
@@ -1,0 +1,18 @@
+package io.shiftleft.semanticcpg.passes.codepencegraph
+
+import gremlin.scala.Vertex
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.semanticcpg.passes.cfgdominator.DomTreeAdapter
+import org.apache.tinkerpop.gremlin.structure.Direction
+
+class CpgPostDomTreeAdapter extends DomTreeAdapter[Vertex] {
+
+  override def immediateDominator(cfgNode: Vertex): Option[Vertex] = {
+    val iterator = cfgNode.vertices(Direction.IN, EdgeTypes.POST_DOMINATE)
+    if (iterator.hasNext) {
+      Some(iterator.next)
+    } else {
+      None
+    }
+  }
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
@@ -1,0 +1,88 @@
+package io.shiftleft.semanticcpg.passes
+
+import gremlin.scala._
+import io.shiftleft.OverflowDbTestInstance
+import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominator, CfgDominatorFrontier, DomTreeAdapter, CfgAdapter}
+import org.apache.tinkerpop.gremlin.structure.Direction
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class CfgDominatorFrontierTests extends WordSpec with Matchers {
+
+  private class TestCfgAdapter extends CfgAdapter[Vertex] {
+    override def successors(node: Vertex): TraversableOnce[Vertex] = {
+      node.vertices(Direction.OUT, "CFG").asScala
+    }
+    override def predecessors(node: Vertex): TraversableOnce[Vertex] = {
+      node.vertices(Direction.IN, "CFG").asScala
+    }
+  }
+
+  private class TestDomTreeAdapter(immediateDominators: Map[Vertex, Vertex]) extends DomTreeAdapter[Vertex] {
+    override def immediateDominator(cfgNode: Vertex): Option[Vertex] = {
+      immediateDominators.get(cfgNode)
+    }
+  }
+
+  "Cfg dominance frontier test" in {
+    implicit val graph: ScalaGraph = OverflowDbTestInstance.create
+
+    val v0 = graph + "UNKNOWN"
+    val v1 = graph + "UNKNOWN"
+    val v2 = graph + "UNKNOWN"
+    val v3 = graph + "UNKNOWN"
+    val v4 = graph + "UNKNOWN"
+    val v5 = graph + "UNKNOWN"
+    val v6 = graph + "UNKNOWN"
+
+    v0 --- "CFG" --> v1
+    v1 --- "CFG" --> v2
+    v2 --- "CFG" --> v3
+    v2 --- "CFG" --> v5
+    v3 --- "CFG" --> v4
+    v4 --- "CFG" --> v2
+    v4 --- "CFG" --> v5
+    v5 --- "CFG" --> v6
+
+    val cfgAdapter = new TestCfgAdapter
+    val cfgDominatorCalculator = new CfgDominator(cfgAdapter)
+    val immediateDominators = cfgDominatorCalculator.calculate(v0)
+
+    val domTreeAdapter = new TestDomTreeAdapter(immediateDominators)
+    val cfgDominatorFrontier = new CfgDominatorFrontier(cfgAdapter, domTreeAdapter)
+    val dominanceFrontier = cfgDominatorFrontier.calculate(graph.V.l())
+
+    dominanceFrontier.get(v0) shouldBe None
+    dominanceFrontier.get(v1) shouldBe None
+    dominanceFrontier.get(v2) shouldBe Some(Set(v2))
+    dominanceFrontier.get(v3) shouldBe Some(Set(v2, v5))
+    dominanceFrontier.get(v4) shouldBe Some(Set(v2, v5))
+    dominanceFrontier.get(v5) shouldBe None
+    dominanceFrontier.get(v6) shouldBe None
+  }
+
+  "Cfg domiance frontier with dead code test" in {
+    implicit val graph: ScalaGraph = OverflowDbTestInstance.create
+
+    val v0 = graph + "UNKNOWN"
+    val v1 = graph + "UNKNOWN" // This node simulates dead code as it is not reachable from the entry v0.
+    val v2 = graph + "UNKNOWN"
+
+    v0 --- "CFG" --> v2
+    v1 --- "CFG" --> v2
+
+    val cfgAdapter = new TestCfgAdapter
+    val cfgDominatorCalculator = new CfgDominator(cfgAdapter)
+    val immediateDominators = cfgDominatorCalculator.calculate(v0)
+
+    val domTreeAdapter = new TestDomTreeAdapter(immediateDominators)
+    val cfgDominatorFrontier = new CfgDominatorFrontier(cfgAdapter, domTreeAdapter)
+    val dominanceFrontier = cfgDominatorFrontier.calculate(graph.V.l())
+
+    dominanceFrontier.get(v0) shouldBe None
+    dominanceFrontier.get(v1) shouldBe Some(Set(v2))
+    dominanceFrontier.get(v2) shouldBe None
+  }
+
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorPassTests.scala
@@ -1,0 +1,80 @@
+package io.shiftleft.semanticcpg.passes
+
+import gremlin.scala._
+import io.shiftleft.OverflowDbTestInstance
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
+import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
+import org.apache.tinkerpop.gremlin.structure.Direction
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class CfgDominatorPassTests extends WordSpec with Matchers {
+  "Have correct DOMINATE/POST_DOMINATE edges after CfgDominatorPass run." in {
+    implicit val cpg: Cpg = new Cpg(OverflowDbTestInstance.create)
+    implicit val graph: ScalaGraph = cpg.graph
+
+    val v0 = graph + NodeTypes.METHOD
+    val v1 = graph + NodeTypes.UNKNOWN
+    val v2 = graph + NodeTypes.UNKNOWN
+    val v3 = graph + NodeTypes.UNKNOWN
+    val v4 = graph + NodeTypes.UNKNOWN
+    val v5 = graph + NodeTypes.UNKNOWN
+    val v6 = graph + NodeTypes.METHOD_RETURN
+
+    v0 --- EdgeTypes.AST --> v6
+
+    v0 --- EdgeTypes.CFG --> v1
+    v1 --- EdgeTypes.CFG --> v2
+    v2 --- EdgeTypes.CFG --> v3
+    v2 --- EdgeTypes.CFG --> v5
+    v3 --- EdgeTypes.CFG --> v4
+    v4 --- EdgeTypes.CFG --> v2
+    v4 --- EdgeTypes.CFG --> v5
+    v5 --- EdgeTypes.CFG --> v6
+
+    val dominatorTreePass = new CfgDominatorPass(cpg)
+    dominatorTreePass.createAndApply()
+
+    val v0Dominates = v0.vertices(Direction.OUT, EdgeTypes.DOMINATE).asScala.toList
+    v0Dominates.size shouldBe 1
+    v0Dominates.toSet shouldBe Set(v1)
+    val v1Dominates = v1.vertices(Direction.OUT, EdgeTypes.DOMINATE).asScala.toList
+    v1Dominates.size shouldBe 1
+    v1Dominates.toSet shouldBe Set(v2)
+    val v2Dominates = v2.vertices(Direction.OUT, EdgeTypes.DOMINATE).asScala.toList
+    v2Dominates.size shouldBe 2
+    v2Dominates.toSet shouldBe Set(v3, v5)
+    val v3Dominates = v3.vertices(Direction.OUT, EdgeTypes.DOMINATE).asScala.toList
+    v3Dominates.size shouldBe 1
+    v3Dominates.toSet shouldBe Set(v4)
+    val v4Dominates = v4.vertices(Direction.OUT, EdgeTypes.DOMINATE).asScala.toList
+    v4Dominates.size shouldBe 0
+    val v5Dominates = v5.vertices(Direction.OUT, EdgeTypes.DOMINATE).asScala.toList
+    v5Dominates.size shouldBe 1
+    v5Dominates.toSet shouldBe Set(v6)
+    val v6Dominates = v6.vertices(Direction.OUT, EdgeTypes.DOMINATE).asScala.toList
+    v6Dominates.size shouldBe 0
+
+    val v6PostDominates = v6.vertices(Direction.OUT, EdgeTypes.POST_DOMINATE).asScala.toList
+    v6PostDominates.size shouldBe 1
+    v6PostDominates.toSet shouldBe Set(v5)
+    val v5PostDominates = v5.vertices(Direction.OUT, EdgeTypes.POST_DOMINATE).asScala.toList
+    v5PostDominates.size shouldBe 2
+    v5PostDominates.toSet shouldBe Set(v2, v4)
+    val v4PostDominates = v4.vertices(Direction.OUT, EdgeTypes.POST_DOMINATE).asScala.toList
+    v4PostDominates.size shouldBe 1
+    v4PostDominates.toSet shouldBe Set(v3)
+    val v3PostDominates = v3.vertices(Direction.OUT, EdgeTypes.POST_DOMINATE).asScala.toList
+    v3PostDominates.size shouldBe 0
+    val v2PostDominates = v2.vertices(Direction.OUT, EdgeTypes.POST_DOMINATE).asScala.toList
+    v2PostDominates.size shouldBe 1
+    v2PostDominates.toSet shouldBe Set(v1)
+    val v1PostDominates = v1.vertices(Direction.OUT, EdgeTypes.POST_DOMINATE).asScala.toList
+    v1PostDominates.size shouldBe 1
+    v1PostDominates.toSet shouldBe Set(v0)
+    val v0PostDominates = v0.vertices(Direction.OUT, EdgeTypes.POST_DOMINATE).asScala.toList
+    v0PostDominates.size shouldBe 0
+  }
+}


### PR DESCRIPTION
The domanitor and CDG passes were for some reason in `semanticcpg-ext`, although these are passes required for a PDG - which is a structure present in the original 2014 code property graph. Moving the code over.