### PR TITLE
Refactor: move tagging primitives.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewTagNodePair.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewTagNodePair.scala
@@ -1,0 +1,27 @@
+package io.shiftleft.semanticcpg.language
+
+import gremlin.scala.GremlinScala
+import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
+import io.shiftleft.passes.DiffGraph
+
+class NewTagNodePair[NodeType <: Node](raw: GremlinScala[nodes.NewTagNodePair]) {
+
+  def store()(implicit diffGraph: DiffGraph): Unit = {
+    raw.toList.foreach { tagNodePair =>
+      val tag = tagNodePair.tag
+      val tagValue = tagNodePair.node
+      diffGraph.addNode(tag.asInstanceOf[NewNode])
+      tagValue match {
+        case tagValue: StoredNode =>
+          diffGraph.addEdgeFromOriginal(tagValue.asInstanceOf[StoredNode],
+                                        tag.asInstanceOf[NewNode],
+                                        EdgeTypes.TAGGED_BY)
+        case tagValue: NewNode =>
+          diffGraph.addEdge(tagValue, tag.asInstanceOf[NewNode], EdgeTypes.TAGGED_BY, Nil)
+      }
+    }
+
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -60,4 +60,29 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
   def toMaps(): Steps[Map[String, Any]] =
     new Steps[Map[String, Any]](raw.map(_.toMap))
 
+  /**
+    * Execute traversal and create new (tag,node) pair.
+    * */
+  def newTagNodePair(tagName: String, tagValue: String = ""): NewTagNodePair[NodeType] = {
+    new NewTagNodePair[NodeType](
+      raw.map { node =>
+        nodes.NewTagNodePair(nodes.NewTag(tagName, tagValue), node)
+      }
+    )
+  }
+
+  /**
+  Execute traversal and map each node to the list of its associated tags.
+    */
+  def tagList: List[List[nodes.TagBase]] =
+    raw.map { taggedNode =>
+      taggedNode.tagList
+    }.l
+
+  /**
+  Traverse to tags of nodes in enhanced graph
+    */
+  def tag: Tag =
+    new Tag(raw.out(EdgeTypes.TAGGED_BY).cast[nodes.Tag])
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -147,4 +147,10 @@ class NodeTypeStarters(cpg: Cpg) {
   @deprecated("", "October 2019")
   def atVerticesWithId[NodeType <: nodes.StoredNode](ids: Seq[Any]): NodeSteps[NodeType] = id(ids)
 
+  /**
+  Traverse to all tags
+    */
+  def tag: Tag =
+    new Tag(scalaGraph.V.hasLabel(NodeTypes.TAG).cast[nodes.Tag])
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
@@ -1,0 +1,79 @@
+package io.shiftleft.semanticcpg.language
+
+import gremlin.scala._
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.semanticcpg.language.types.expressions.{Call, Identifier, Literal}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.{NameAccessors, ValueAccessors}
+import io.shiftleft.semanticcpg.language.types.structure._
+import io.shiftleft.semanticcpg.language.{NodeSteps => OriginalNodeSteps}
+
+class Tag(override val raw: GremlinScala[nodes.Tag])
+    extends OriginalNodeSteps[nodes.Tag](raw)
+    with NameAccessors[nodes.Tag]
+    with ValueAccessors[nodes.Tag] {
+
+  def method: Method =
+    new Method(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.METHOD)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.Method])
+
+  def methodReturn: MethodReturn =
+    new MethodReturn(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.METHOD_RETURN)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.MethodReturn])
+
+  def parameter: MethodParameter =
+    new MethodParameter(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.MethodParameterIn])
+
+  def parameterOut: MethodParameterOut =
+    new MethodParameterOut(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.METHOD_PARAMETER_OUT)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.MethodParameterOut])
+
+  def call: Call =
+    new Call(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.CALL)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.Call])
+
+  def identifier: Identifier =
+    new Identifier(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.IDENTIFIER)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.Identifier])
+
+  def literal: Literal =
+    new Literal(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.LITERAL)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.Literal])
+
+  def local: Local =
+    new Local(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.LOCAL)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.Local])
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tags.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tags.scala
@@ -1,0 +1,7 @@
+package io.shiftleft.semanticcpg.language
+
+import gremlin.scala.GremlinScala
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language.{NodeSteps => OriginalNodeSteps}
+
+class Tags(override val raw: GremlinScala[nodes.Tags]) extends OriginalNodeSteps[nodes.Tags](raw) {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
@@ -1,8 +1,9 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.{Node, StoredNode}
-import io.shiftleft.semanticcpg.language.LocationCreator
+import io.shiftleft.semanticcpg.language._
+import gremlin.scala._
 
 class NodeMethods(node: Node) {
 
@@ -15,4 +16,21 @@ class NodeMethods(node: Node) {
 
     }
   }
+
+  def tagList: List[nodes.TagBase] =
+    node match {
+      case storedNode: StoredNode =>
+        storedNode.start.raw
+          .out(EdgeTypes.TAGGED_BY)
+          .toList //TODO MP: use project step
+          .map { tagNode =>
+            nodes
+              .NewTag(tagNode.value2(NodeKeys.NAME), tagNode.value2(NodeKeys.VALUE))
+              .asInstanceOf[nodes.TagBase]
+          }
+          .distinct
+      case _ =>
+        Nil
+    }
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg
 
-import gremlin.scala.{GremlinScala, __}
+import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.{Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.nodemethods.{
@@ -202,5 +202,11 @@ package object language {
 
   implicit def toCallForCallGraph(steps: Steps[nodes.Call]): Call =
     new Call(steps.raw)
+
+  implicit def toNodeStepsTag[NodeType <: nodes.StoredNode](original: Steps[NodeType]): NodeSteps[NodeType] =
+    new NodeSteps[NodeType](original.raw)
+
+  implicit def toTagTag(steps: Steps[nodes.Tag]): Tag =
+    new Tag(steps.raw)
 
 }


### PR DESCRIPTION
As part of `semanticcpg-ext` dissolving: 
* Location was moved to `semanticcpg` earlier already but we forgot to move tagging primitives
* Importing `io.shiftleft.semanticcpgext.language` is now rarely needed
* A bit of cleanup
