### PR TITLE
Decoration language for array access

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val cpgserver = Projects.cpgserver
 lazy val cpgvalidator = Projects.cpgvalidator
 lazy val cpg2overflowdb = Projects.cpg2overflowdb
 lazy val console = Projects.console
+lazy val queries = Projects.queries
 
 ThisBuild/scalacOptions ++= Seq("-deprecation", "-feature", "-language:implicitConversions")
 ThisBuild/compile/javacOptions ++= Seq("-g") //debug symbols

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -9,4 +9,5 @@ object Projects {
   lazy val cpgvalidator = project.in(file("cpgvalidator"))
   lazy val cpg2overflowdb = project.in(file("cpg2overflowdb"))
   lazy val console = project.in(file("console"))
+  lazy val queries = project.in(file("queries"))
 }

--- a/queries/build.sbt
+++ b/queries/build.sbt
@@ -1,0 +1,9 @@
+name := "queries"
+
+dependsOn(Projects.semanticcpg % "compile -> compile; test -> test",
+          Projects.dataflowengine % "compile -> compile; test -> test")
+
+libraryDependencies ++= Seq(
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test
+)

--- a/queries/src/test/scala/io/shiftleft/queries/CopyOperations.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/CopyOperations.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.queries
 
-import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
 import org.scalatest.{Matchers, WordSpec}

--- a/queries/src/test/scala/io/shiftleft/queries/CopyOperations.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/CopyOperations.scala
@@ -21,18 +21,6 @@ class CopyOperations extends WordSpec with Matchers {
       cpg.assignment.target.arrayAccess.subscripts.map(_.code.toSet).l shouldBe List(Set("i", "j", "offset"))
     }
 
-    /**
-      * Determine assignments where target (argument(1)) contains a computed member
-      * access. For that access, determine the destination buffer and all indices
-      * */
-    def indexBufferAssigns(cpg: Cpg) =
-      cpg.assignment.target.arrayAccess
-        .map { array =>
-          val indices = array.subscripts.code.toSet
-          val buf = array.call.argument(1)
-          (buf, indices)
-        }
-
     "find indexed buffer assignment targets in loops where index is incremented" in {
 
       /**

--- a/queries/src/test/scala/io/shiftleft/queries/CopyOperations.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/CopyOperations.scala
@@ -1,9 +1,9 @@
-package io.shiftleft.semanticcpg.samplequeries
+package io.shiftleft.queries
 
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
 import org.scalatest.{Matchers, WordSpec}
-import io.shiftleft.semanticcpg.language._
 
 class CopyOperations extends WordSpec with Matchers {
 
@@ -26,9 +26,7 @@ class CopyOperations extends WordSpec with Matchers {
       * access. For that access, determine the destination buffer and all indices
       * */
     def indexBufferAssigns(cpg: Cpg) =
-      cpg
-        .call(".*assign.*")
-        .argument(1)
+      cpg.assign.target
         .ast
         .isCall
         .name(".*op.*computedMemberAccess.*")

--- a/queries/src/test/scala/io/shiftleft/queries/FunctionComplexityMetrics.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/FunctionComplexityMetrics.scala
@@ -1,8 +1,8 @@
-package io.shiftleft.semanticcpg.samplequeries
+package io.shiftleft.queries
 
+import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
 import org.scalatest.{Matchers, WordSpec}
-import io.shiftleft.semanticcpg.language._
 
 class FunctionComplexityMetrics extends WordSpec with Matchers {
 

--- a/queries/src/test/scala/io/shiftleft/queries/MallocMemcpyTests.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/MallocMemcpyTests.scala
@@ -1,9 +1,8 @@
-package io.shiftleft.dataflowengine.samplequeries
+package io.shiftleft.queries
 
-import io.shiftleft.dataflowengine.language.DataFlowCodeToCpgFixture
-import org.scalatest.{Matchers, WordSpec}
+import io.shiftleft.dataflowengine.language.{DataFlowCodeToCpgFixture, _}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.dataflowengine.language._
+import org.scalatest.{Matchers, WordSpec}
 
 class MallocMemcpyTests extends WordSpec with Matchers {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccess.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccess.scala
@@ -1,13 +1,12 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import gremlin.scala.GremlinScala
-import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.types.expressions.Identifier
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 import io.shiftleft.semanticcpg.language.Steps
 import io.shiftleft.semanticcpg.language._
 
-class ArrayAccess(raw: GremlinScala[ArrayAccessNode]) extends Steps[ArrayAccessNode](raw) {
+class ArrayAccess(raw: GremlinScala[nodes.ArrayAccess]) extends Steps[nodes.ArrayAccess](raw) {
 
   def array: Expression = map(_.array)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccess.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccess.scala
@@ -1,0 +1,16 @@
+package io.shiftleft.semanticcpg.language.operatorextension
+
+import gremlin.scala.GremlinScala
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language.types.expressions.Identifier
+import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
+import io.shiftleft.semanticcpg.language.Steps
+import io.shiftleft.semanticcpg.language._
+
+class ArrayAccess(raw: GremlinScala[ArrayAccessNode]) extends Steps[ArrayAccessNode](raw) {
+
+  def array: Expression = map(_.array)
+
+  def subscripts: Steps[Identifier] = map(_.subscripts)
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessNode.scala
@@ -1,0 +1,15 @@
+package io.shiftleft.semanticcpg.language.operatorextension
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language.types.expressions.Identifier
+import io.shiftleft.semanticcpg.language._
+
+class ArrayAccessNode(node: nodes.Call) {
+
+  def call: nodes.Call = node
+
+  def array: nodes.Expression = node.argument(1)
+
+  def subscripts: Identifier = node.argument(2).ast.isIdentifier
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignTarget.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignTarget.scala
@@ -1,0 +1,16 @@
+package io.shiftleft.semanticcpg.language.operatorextension
+
+import gremlin.scala.GremlinScala
+import io.shiftleft.semanticcpg.language.NodeSteps
+import io.shiftleft.codepropertygraph.generated.nodes
+
+class AssignTarget(override val raw: GremlinScala[nodes.Expression]) extends NodeSteps[nodes.Expression](raw) {
+
+  def arrayAccess: ArrayAccess = new ArrayAccess(
+    new AssignTarget(raw).ast.isCall
+      .nameExact("<operator>.computedMemberAccess")
+      .raw
+      .map(new ArrayAccessNode(_))
+  )
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignTarget.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignTarget.scala
@@ -2,15 +2,15 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import gremlin.scala.GremlinScala
 import io.shiftleft.semanticcpg.language.NodeSteps
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.{nodes => basenodes}
 
-class AssignTarget(override val raw: GremlinScala[nodes.Expression]) extends NodeSteps[nodes.Expression](raw) {
+class AssignTarget(override val raw: GremlinScala[basenodes.Expression]) extends NodeSteps[basenodes.Expression](raw) {
 
   def arrayAccess: ArrayAccess = new ArrayAccess(
     new AssignTarget(raw).ast.isCall
       .nameExact("<operator>.computedMemberAccess")
       .raw
-      .map(new ArrayAccessNode(_))
+      .map(new nodes.ArrayAccess(_))
   )
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Assignment.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Assignment.scala
@@ -1,15 +1,14 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import gremlin.scala.GremlinScala
-import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language.Steps
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
+import io.shiftleft.codepropertygraph.generated.{nodes => basenodes}
+import io.shiftleft.semanticcpg.language.NodeSteps
 
 /**
   * A wrapper for assignment calls that offers syntactic sugar
   * */
-class Assignment(override val raw: GremlinScala[nodes.Call]) extends Steps[nodes.Call](raw) {
+class Assignment(override val raw: GremlinScala[basenodes.Call]) extends NodeSteps[basenodes.Call](raw) {
 
-  def target: Expression = new Assignment(raw).argument(1)
+  def target: AssignTarget = new AssignTarget(new Assignment(raw).argument(1).raw)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Assignment.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Assignment.scala
@@ -1,0 +1,15 @@
+package io.shiftleft.semanticcpg.language.operatorextension
+
+import gremlin.scala.GremlinScala
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language.Steps
+import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
+
+/**
+  * A wrapper for assignment calls that offers syntactic sugar
+  * */
+class Assignment(override val raw: GremlinScala[nodes.Call]) extends Steps[nodes.Call](raw) {
+
+  def target: Expression = new Assignment(raw).argument(1)
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -5,6 +5,6 @@ import io.shiftleft.semanticcpg.language._
 
 class NodeTypeStarters(cpg: Cpg) {
 
-  def assign: Assignment = new Assignment(cpg.call.name("<operator>.assignment.*").raw)
+  def assignment: Assignment = new Assignment(cpg.call.name("<operator>.assignment.*").raw)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -1,0 +1,10 @@
+package io.shiftleft.semanticcpg.language.operatorextension
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
+
+class NodeTypeStarters(cpg: Cpg) {
+
+  def assign: Assignment = new Assignment(cpg.call.name("<operator>.assignment.*").raw)
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/ArrayAccess.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/ArrayAccess.scala
@@ -1,10 +1,10 @@
-package io.shiftleft.semanticcpg.language.operatorextension
+package io.shiftleft.semanticcpg.language.operatorextension.nodes
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language.types.expressions.Identifier
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.expressions.Identifier
 
-class ArrayAccessNode(node: nodes.Call) {
+class ArrayAccess(node: nodes.Call) {
 
   def call: nodes.Call = node
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -203,6 +203,16 @@ package object language {
   implicit def toCallForCallGraph(steps: Steps[nodes.Call]): Call =
     new Call(steps.raw)
 
+  // / Call graph extension
+
+  // Operator extension
+
+  import io.shiftleft.semanticcpg.language.operatorextension.{NodeTypeStarters => OpNodeTypeStarters}
+  implicit def toNodeTypeStartersOps(cpg: Cpg): OpNodeTypeStarters =
+    new OpNodeTypeStarters(cpg)
+
+  // /Operator extension
+
   implicit def toNodeStepsTag[NodeType <: nodes.StoredNode](original: Steps[NodeType]): NodeSteps[NodeType] =
     new NodeSteps[NodeType](original.raw)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -12,7 +12,8 @@ import io.shiftleft.semanticcpg.language.nodemethods.{
   NodeMethods,
   WithinMethodMethods
 }
-import io.shiftleft.semanticcpg.language.operatorextension.{ArrayAccess, ArrayAccessNode}
+import io.shiftleft.semanticcpg.language.operatorextension.ArrayAccess
+import io.shiftleft.semanticcpg.language.operatorextension.nodes.ArrayAccess
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
@@ -213,10 +214,13 @@ package object language {
   implicit def toNodeTypeStartersOps(cpg: Cpg): OpNodeTypeStarters =
     new OpNodeTypeStarters(cpg)
 
-  implicit def arrayAccessToCall(node: ArrayAccessNode): nodes.Call = node.call
+  implicit def arrayAccessToCall(
+      node: operatorextension.nodes.ArrayAccess): io.shiftleft.semanticcpg.language.nodemethods.CallMethods =
+    node.call
 
-  implicit def arrayAccessToCallStep(step: Steps[ArrayAccessNode]): Call =
-    new Call(step.raw.map(_.call))
+  implicit def arrayAccessToCallStep(
+      step: operatorextension.ArrayAccess): io.shiftleft.semanticcpg.language.types.expressions.Call =
+    new io.shiftleft.semanticcpg.language.types.expressions.Call(step.raw.map(_.call))
 
   // /Operator extension
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -12,6 +12,7 @@ import io.shiftleft.semanticcpg.language.nodemethods.{
   NodeMethods,
   WithinMethodMethods
 }
+import io.shiftleft.semanticcpg.language.operatorextension.{ArrayAccess, ArrayAccessNode}
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
@@ -208,8 +209,14 @@ package object language {
   // Operator extension
 
   import io.shiftleft.semanticcpg.language.operatorextension.{NodeTypeStarters => OpNodeTypeStarters}
+
   implicit def toNodeTypeStartersOps(cpg: Cpg): OpNodeTypeStarters =
     new OpNodeTypeStarters(cpg)
+
+  implicit def arrayAccessToCall(node: ArrayAccessNode): nodes.Call = node.call
+
+  implicit def arrayAccessToCallStep(step: Steps[ArrayAccessNode]): Call =
+    new Call(step.raw.map(_.call))
 
   // /Operator extension
 


### PR DESCRIPTION
* Move all sample queries to `queries` project because it's unclear which extension module to place these queries in once we use several extensions in a query
* Introduce a decoration language for query access as an extension in `semanticpg`
