### PR TITLE
override getId with correct id (rather then default value -1)

### DIFF
--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -540,6 +540,7 @@ $neighborAccesors
         $mixinTraits with ${nodeType.className}Base {
 
         override def layoutInformation: NodeLayoutInformation = ${nodeType.className}.layoutInformation
+        override def getId = ref.id
 
         /* all properties */
         override def valueMap: JMap[String, AnyRef] = $valueMapImpl


### PR DESCRIPTION
before:
```
val call = cpg.call.head

call: Call = Call(
  id -> 546L,
  ...

call.get
res2: CallDb = Call(
  id -> -1L,
  ...
```

now:
```
call.get
res2: CallDb = Call(
  id -> 546L,
  ...

```