### PR TITLE
Update script manager to read scripts from within project by default

### DIFF
--- a/console/src/test/resources/scripts/list-funcs.sc
+++ b/console/src/test/resources/scripts/list-funcs.sc
@@ -1,0 +1,1 @@
+cpg.method.name.l

--- a/console/src/test/resources/scripts/scripts.json
+++ b/console/src/test/resources/scripts/scripts.json
@@ -1,0 +1,8 @@
+{
+  "scripts": [
+    {
+      "name": "list-funcs",
+      "description": "Lists all functions."
+    }
+  ]
+}

--- a/resources/testcode/scripts/list-funcs/description.json
+++ b/resources/testcode/scripts/list-funcs/description.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b7ef0a19c841f1d68370a24698bb244262dd48277ebaf3d76caa40182b1d81e
-size 67

--- a/resources/testcode/scripts/list-funcs/list-funcs.scala
+++ b/resources/testcode/scripts/list-funcs/list-funcs.scala
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:498d148dd6cc7a201e6b949cc49e1569a3aaafd1c5110ec4eb1805b6bdecfb7d
-size 18


### PR DESCRIPTION
- Enables IDE support for libraries imported by the script.
- Does *not* compile the scripts. This doesn't seem to be possible as the scala compiler expects the script code to be placed within a class/trait etc.