### PR TITLE
Switch StorageBackend based on product type.

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -57,7 +57,8 @@ trait BridgeBase {
     parser.parse(args, Config()).get
   }
 
-  protected def runAmmonite(config: Config): Unit = {
+  protected def runAmmonite(config: Config,
+                            slProduct: SLProduct = OcularProduct): Unit = {
     val additionalImportCode: List[String] =
       config.additionalImports.flatMap { importScript =>
         val file = importScript.toIO
@@ -79,7 +80,7 @@ trait BridgeBase {
           .Main(
             predefCode = predefPlus(additionalImportCode ++ replConfig ++ shutdownHooks),
             welcomeBanner = Some("Welcome to ShiftLeft Ocular/Joern"),
-            storageBackend = new StorageBackend,
+            storageBackend = new StorageBackend(slProduct),
             remoteLogging = false,
             colors = config.colors.getOrElse(Colors.Default)
           )

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -57,8 +57,7 @@ trait BridgeBase {
     parser.parse(args, Config()).get
   }
 
-  protected def runAmmonite(config: Config,
-                            slProduct: SLProduct = OcularProduct): Unit = {
+  protected def runAmmonite(config: Config, slProduct: SLProduct = OcularProduct): Unit = {
     val additionalImportCode: List[String] =
       config.additionalImports.flatMap { importScript =>
         val file = importScript.toIO

--- a/console/src/main/scala/io/shiftleft/console/SLProduct.scala
+++ b/console/src/main/scala/io/shiftleft/console/SLProduct.scala
@@ -1,0 +1,5 @@
+package io.shiftleft.console
+
+sealed trait SLProduct { def name: String }
+case object OcularProduct extends SLProduct { val name: String = "ocular" }
+case object JoernProduct extends SLProduct { val name: String = "joern" }

--- a/console/src/main/scala/io/shiftleft/console/StorageBackend.scala
+++ b/console/src/main/scala/io/shiftleft/console/StorageBackend.scala
@@ -2,16 +2,18 @@ package io.shiftleft.console
 
 import ammonite.runtime.Storage
 import ammonite.util.Tag
+import os.Path
 
 /**
   * like the default ammonite folder storage (which gives us e.g. command history), but without the CodePredef
   * error when using multiple ocular installations (see https://github.com/ShiftLeftSecurity/product/issues/2082)
   */
-class StorageBackend extends Storage.Folder(StorageBackend.consoleHome) {
+class StorageBackend(slProduct: SLProduct) extends Storage.Folder(StorageBackend.consoleHome(slProduct)) {
   override def compileCacheSave(path: String, tag: Tag, data: Storage.CompileCache): Unit = ()
   override def compileCacheLoad(path: String, tag: Tag): Option[Storage.CompileCache] = None
 }
 
 object StorageBackend {
-  def consoleHome = os.Path(System.getProperty("user.home")) / ".shiftleft" / "ocular"
+  def consoleHome(slProduct: SLProduct): Path =
+    os.Path(System.getProperty("user.home")) / ".shiftleft" / slProduct.name
 }


### PR DESCRIPTION
This PR will allow us to switch between using `~/.shiftleft/ocular` and `~/.shiftleft/joern` depending on the tool invoked by the user.