### PR TITLE
Add missing tags to IoFlow nodes

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/securityprofile.json
+++ b/codepropertygraph/src/main/resources/schemas/securityprofile.json
@@ -108,6 +108,8 @@
       {"localName": "dataTags", "nodeType" : "TAG", "cardinality" : "list"},
       {"localName": "sourceDescriptorTags", "nodeType" : "TAG", "cardinality" : "list"},
       {"localName": "sinkDescriptorTags", "nodeType" : "TAG", "cardinality" : "list"},
+      {"localName": "sourceTags", "nodeType" : "TAG", "cardinality" : "list"},
+      {"localName": "dstTags", "nodeType" : "TAG", "cardinality": "list"},
       {"localName" : "source", "nodeType" : "SOURCE", "cardinality" : "one"},
       {"localName" : "sink", "nodeType" : "SINK", "cardinality" : "one"},
       {"localName" : "transforms", "nodeType" : "TRANSFORM", "cardinality" : "list"},


### PR DESCRIPTION
I have finished a `codescience` PR that unifies the two SPs and ensures that the findings in the overlay SP are the same as in the old proto SP. This is a small change I need in `codepropertygraph` that required to make this work.