### PR TITLE
locally download protoc to ensure there's no conflict...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 target/
 codepropertygraph/project/
 /codepropertygraph/src/main/resources/cpg.json
-/protoc-*.zip
 private-key.pem
 travis_wait_*
 **/*.pyc
+/protoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,9 @@ before_install:
   -out private-key.pem -d; gpg --import --batch private-key.pem; fi
 env:
   global:
-  - PROTOC_PKG=protoc-3.10.0-linux-x86_64.zip
-  - PROTOC_RELEASE=https://github.com/google/protobuf/releases/download/v3.10.0/$PROTOC_PKG
-  - PROTOC_TARGET=${HOME}/protoc
-  - PATH="${PROTOC_TARGET}/bin:${PATH}"
   - secure: O33fw6sV6z2laegGMQ3qLPA0Eb+w9cHTXIC81q3Nw9G6nJLYGMAelexF0tx7h7zrfdz0HLDW6ZVqAWf44taqACzBu0JCPgBA/RCSlNxUKlINHNp/lapG26b4m2eNHt4KyfZ7QFcxRjRg6Y7z2XpKiNvUOxEWSh7cDxZcTY8fE9S33SDbefaBpIJsXj3tIxqBunu2ItTitE0p0B0pLfCtlC2YT9EG2FAaBxppYFmG0/TKw/tIAQAKdgiGmVCTk/ux/wEFjCqcrbqXfgRsRHe7o4TrRjEo4gFsj/mN5VLuQDH7sioMHfMI73rJAg5A7E1eFVz3iktKR4znFQxdW5JNoiHc3D6a8TA/o9IkHWOpNDHZgDvJecw5pCYS7odNNwoCa/U0THiyFonMEJEE6R+LZs0UPz1QpHc8VN+KEI+vOVdLT06w0mpUEpr1t3Q1hL4QZMg/Se2u9wmBnyBfOlOUW6h/j5N/E5hZG0lRKCSfmHtL5bdxCLC8C0xEjEz4oWf9ZdeA2JvgB6PLL+ipQ3yJ+XlNFPhIXrrb5Ea/ZPv/4BgGZ28tHGJfVeDUnGG0OPCmiwHYgIsgulPERz17MFRD7J3DTd3WnhryV0KXF/56soOUBuufJHEz/q6HxvNWWz4g1t3REPE2lAzhrmRN68CN9mJJ+AsQqXIwZQ3jL1k1hW4=
   - secure: WELN1ch6XMSPo96MvX26i0NziRh/4libPilj2JGUUXnPl7CXFBBTUDZDWR54+2eT35CaTboSIFFis5WywDB4eC6T6LaoM22GUXGdvmZVxlBrYkk3SQygqye7Cru6zjgWJt3Y0nC9eoT7Wsh9GeUPyJYJGjeW8ODNMTpwnuTEyfVBa/HfjwQdc0e6IDtZu0GzRbstt7k4/X6dQsUZQBnLfM39fOTk4QTHo4VMNgieavHFdg/EGTeDHz5UNuMN9Ep0HXFiyuM4+mS9z2UUT7h0NyJ352t/1GioJe3ry5pvSZnjKjpD07HKnBt3iL/7YB9POaWeb6NFysrQQByTZNrb4pKsXB3A9BjTSjc8oZRbamuxHd7ICjZMXukSKkxwqQtOl9lM5dTSSvsdkljlGCCxqbziP016xzx9RUiNHnYIiQFmjIExyMpo5QFs6NxjxAwsLrjnJiMFERmQmLLN5ubizzKPyVCYuEpyuBjPNhFANX083vax7uHp+PBGyP5Fd8HFpciD9tqo24E3kXsIV94p1P0l8Xqbf9jwfU9xKqGWU8A/1GZZmDtuh+HvvmNPe8L9JIqJthLbz+IjtX5a+PJQQbnlmSPBjEhZcqNCOQ/d4ljWiCYA8/ExcwbR9WH9XRmgGxY10gFDM75j1LjmZalGu/FmvQYPH53txWnZRw/IAJg=
 install:
-- rm -rf $HOME/protoc
-- wget $PROTOC_RELEASE
-- unzip $PROTOC_PKG -d $PROTOC_TARGET
-- protoc --version
 - python --version
 stages:
 - name: test

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.4")
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.1.14")

--- a/proto-bindings/build.sbt
+++ b/proto-bindings/build.sbt
@@ -3,10 +3,12 @@ name := "codepropertygraph-protos"
 lazy val generateProtobuf = taskKey[File]("generate cpg.proto")
 
 enablePlugins(ProtobufPlugin)
+val protocLocalDir = "protoc"
+val protocBinaryPath = s"$protocLocalDir/bin/protoc"
+ProtobufConfig / protobufProtoc := protocBinaryPath
 ProtobufConfig / version := "3.10.0"
-
 sourceDirectories in ProtobufConfig += (protobufExternalIncludePath in ProtobufConfig).value
-ProtobufConfig / protobufGenerate := (ProtobufConfig / protobufGenerate).dependsOn(copyLatestCpgProto).value
+ProtobufConfig / protobufGenerate := (ProtobufConfig/protobufGenerate).dependsOn(copyLatestCpgProto).dependsOn(installProtoc).value
 
 lazy val copyLatestCpgProto = taskKey[Unit]("copy latest cpg.proto to externalIncludePath")
 copyLatestCpgProto := {
@@ -49,8 +51,6 @@ installProtoc := {
   import sys.process._
   import better.files.FileExtensions
   val protocVersion = (ProtobufConfig/version).value
-  val protocLocalDir = "protoc"
-  val protocBinaryPath = s"$protocLocalDir/bin/protoc"
   val protocBinary = new File(protocBinaryPath)
   val isAlreadyInstalled = protocBinary.exists && s"$protocBinaryPath --version".!!.contains(protocVersion)
 


### PR DESCRIPTION
... with the system-wide installed version

Before this, we needed to ensure the correct version of protoc was
installed. After a system upgrade, the build would regularly break.

* only downloads if it's not yet downloaded in the right version
* detects the platform in a native way, only tested for linux yet

Related: 
* https://github.com/ShiftLeftSecurity/codepropertygraph/pull/475
* https://github.com/ShiftLeftSecurity/codescience/pull/3063