### PR TITLE
Fix source location for github.com/fabiolb/fabio.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -91,6 +91,8 @@ object LocationCreator {
           local.lineNumber,
           local.start.method.head
         )
+      case source: nodes.Source =>
+        apply(source.node)
       case vertex: Vertex =>
         emptyLocation(vertex.label, Some(vertex.asInstanceOf[nodes.Node]))
     }


### PR DESCRIPTION
C.f. <https://github.com/ShiftLeftSecurity/product/issues/3288>.

Previously the reported locations for findings were empty, now we
actually have filename, line number and method name correctly set (in
Ocular at least).

---

We're going from this:

```
ocular> cpg.finding.l
res2: List[Finding] = List(
  Finding(
    id -> 197513L,
    name -> "sensitive-to-log",
    category -> "a3-sensitive-data-exposure",
    title -> "Sensitive Data Leak: Sensitive data is leaked via `token` to log ",
    ...
    parameter -> "token",
    methodName -> "",
    lineNo -> "0",
    filename -> "",
    ...
  ),
  Finding(
    id -> 197512L,
    name -> "sensitive-to-log",
    category -> "a3-sensitive-data-exposure",
    title -> "Sensitive Data Leak: Sensitive data is leaked via `token` to log ",
    ...
    vulnDescr -> "Sensitive Data Leak",
    parameter -> "token",
    methodName -> "",
    lineNo -> "0",
    filename -> "",
  )
)
```

to this:

```
ocular> cpg.finding.l
res3: List[Finding] = List(
  Finding(
    id -> 197755L,
    name -> "sensitive-to-log",
    category -> "a3-sensitive-data-exposure",
    title -> "Sensitive Data Leak: Sensitive data is leaked via `token` to log in `vaultClient.Get`",
    ...
    parameter -> "token",
    methodName -> "*github.com/fabiolb/fabio/cert.vaultClient.Get:tuple2()",
    lineNo -> "85",
    filename -> "/home/olof/src/go/src/github.com/fabiolb/fabio/cert/vault_client.go",
    ...
  ),
  Finding(
    id -> 197754L,
    name -> "sensitive-to-log",
    category -> "a3-sensitive-data-exposure",
    title -> "Sensitive Data Leak: Sensitive data is leaked via `token` to log in `vaultClient.Get`",
    ...
    parameter -> "token",
    methodName -> "*github.com/fabiolb/fabio/cert.vaultClient.Get:tuple2()",
    lineNo -> "41",
    filename -> "/home/olof/src/go/src/github.com/fabiolb/fabio/cert/vault_client.go",
    ...
  )
)
```

C.f. also
<https://github.com/fabiolb/fabio/blob/master/cert/vault_client.go#L85> as
source for the first finding and
<https://github.com/fabiolb/fabio/blob/master/cert/vault_client.go#L41> for the
second one.

---

However, since `Source` isn't even in the same category as the other node
types, this feels a bit hacky.