### PR TITLE
Improvements for operator extension + truncation example

### DIFF
--- a/queries/src/test/scala/io/shiftleft/queries/TruncationsTests.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/TruncationsTests.scala
@@ -20,7 +20,7 @@ class TruncationsTests extends WordSpec with Matchers {
     """
 
   DataFlowCodeToCpgFixture(code) { cpg =>
-    cpg.call("strlen").inAssignment.target.expr.evalType("(g?)int").method.name.l shouldBe ("vulnerable")
+    cpg.call("strlen").inAssignment.target.expr.evalType("(g?)int").method.name.l shouldBe List("vulnerable")
   }
 
 }

--- a/queries/src/test/scala/io/shiftleft/queries/TruncationsTests.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/TruncationsTests.scala
@@ -1,0 +1,26 @@
+package io.shiftleft.queries
+
+import io.shiftleft.dataflowengine.language.DataFlowCodeToCpgFixture
+import org.scalatest.{Matchers, WordSpec}
+import io.shiftleft.semanticcpg.language._
+
+class TruncationsTests extends WordSpec with Matchers {
+
+  val code: String =
+    """
+      int vulnerable(char *str) {
+        int len;
+        len = strlen(str);
+      }
+
+      int non_vulnerable(char *str) {
+        size_t len;
+        len = strlen(str);
+      }
+    """
+
+  DataFlowCodeToCpgFixture(code) { cpg =>
+    cpg.call("strlen").inAssignment.target.expr.evalType("(g?)int").method.name.l shouldBe ("vulnerable")
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignSource.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignSource.scala
@@ -1,0 +1,11 @@
+package io.shiftleft.semanticcpg.language.operatorextension
+
+import gremlin.scala.GremlinScala
+import io.shiftleft.codepropertygraph.generated.nodes.Expression
+import io.shiftleft.semanticcpg.language.Steps
+
+class AssignSource(override val raw: GremlinScala[nodes.AssignSource]) extends Steps[nodes.AssignSource](raw) {
+
+  def expr: Steps[Expression] = map(_.expr)
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTrav.scala
@@ -11,6 +11,8 @@ class AssignmentTrav(override val raw: GremlinScala[nodes.Assignment]) extends S
 
   def target: Target = new Target(map(_.target).map(new nodes.Target(_)).raw)
 
+  def source: AssignSource = new AssignSource(map(_.source).map(new nodes.AssignSource(_)).raw)
+
   def call: Steps[Call] = map(_.call)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTrav.scala
@@ -8,6 +8,10 @@ import io.shiftleft.semanticcpg.language._
 
 class OpAstNodeTrav[NodeType <: basenodes.AstNode](raw: GremlinScala[NodeType]) {
 
+  def inAssignment = new AssignmentTrav(astNode.flatMap(new OpAstNode(_).inAssignment).raw)
+
+  private def astNode = new AstNode(raw.cast[basenodes.AstNode])
+
   def assignments: AssignmentTrav =
     new AssignmentTrav(
       new AstNode(raw.cast[basenodes.AstNode])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/AssignSource.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/AssignSource.scala
@@ -2,4 +2,4 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodes
 
 import io.shiftleft.codepropertygraph.generated.{nodes => basenodes}
 
-class AssignSource(val expr: basenodes.Expression) extends AnyRef {}
+class AssignSource(val expr: basenodes.Expression) {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/AssignSource.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/AssignSource.scala
@@ -1,0 +1,5 @@
+package io.shiftleft.semanticcpg.language.operatorextension.nodes
+
+import io.shiftleft.codepropertygraph.generated.{nodes => basenodes}
+
+class AssignSource(val expr: basenodes.Expression) extends AnyRef {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/Assignment.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/Assignment.scala
@@ -1,10 +1,12 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodes
 
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language.nodemethods.CallMethods
 
 class Assignment(val call: nodes.Call) extends AnyRef {
 
   def target: nodes.Expression = new CallMethods(call).argument(1)
 
+  def source: Expression = new CallMethods(call).argument(2)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/OpAstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodes/OpAstNode.scala
@@ -6,6 +6,11 @@ import io.shiftleft.semanticcpg.language._
 
 class OpAstNode(val node: nodes.AstNode) extends AnyRef {
 
+  def inAssignment: AssignmentTrav =
+    new AssignmentTrav(
+      node.start.inAstMinusLeaf.isCall.name(NodeTypeStarters.assignmentPattern).map(new Assignment(_)).raw
+    )
+
   def assignments: AssignmentTrav =
     new AssignmentTrav(rawTravForPattern(NodeTypeStarters.assignmentPattern).map(new Assignment(_)).raw)
 


### PR DESCRIPTION
A sample query for identifying truncations in `strlen` assignments, and a few improvements for the operator extension.