### PR TITLE
Add missing `METHOD_REF` handling.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -91,6 +91,14 @@ object LocationCreator {
           local.lineNumber,
           local.start.method.head
         )
+      case methodRef: nodes.MethodRef =>
+        apply(
+          methodRef,
+          methodRef.code,
+          methodRef.label,
+          methodRef.lineNumber,
+          methodRef.start.method.head
+        )
       case source: nodes.Source =>
         apply(source.node)
       case vertex: Vertex =>


### PR DESCRIPTION
Code field wasn't missing on `METHOD_REF` nodes, it's the empty location that
was created instead that caused the empty symbol in the flows.

For <https://github.com/ShiftLeftSecurity/codescience/pull/3071>.