### PR TITLE
Fix double-wrapping of error type in default query executor.

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/query/DefaultCpgQueryExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/query/DefaultCpgQueryExecutor.scala
@@ -75,8 +75,8 @@ class DefaultCpgQueryExecutor(scriptEngineManager: ScriptEngineManager)(implicit
       e <- engine
       _ <- IO(e.put("aCpg", cpg))
       result <- IO(e.eval(completeQuery))
-        .handleErrorWith(err => IO(CpgOperationFailure(err)))
         .map(v => CpgOperationSuccess(v))
+        .handleErrorWith(err => IO(CpgOperationFailure(err)))
     } yield result
   }
 }


### PR DESCRIPTION
Errors would previously be wrapped in a success, e.g.
```
CpgOperationSuccess(CpgOperationFailure(...))
```

This was hidden as we return the result as an `AnyRef`