### PR TITLE
use `def` instead of `lazy val` for contained nodes

### DIFF
--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -429,7 +429,7 @@ $neighborAccesors
 
               s"""
               /** link to 'contained' node of type $containedNodeType */
-              lazy val ${containedNode.localName}: $completeType =
+              def ${containedNode.localName}: $completeType =
                 edges(Direction.OUT, "CONTAINS_NODE").asScala.toList
                   .filter(_.valueOption(EdgeKeys.LOCAL_NAME).map(_  == "${containedNode.localName}").getOrElse(false))
                   .sortBy(_.valueOption(EdgeKeys.INDEX))


### PR DESCRIPTION
using `lazy val` results in higher memory usage, even if it's not
initialized yet - that's because there are some bytes reserved for
this class member in each node instance

n.b. contained nodes are just conceptually 'contained', they're actually
connected to the 'main' node.