### PR TITLE
Fixed Cpg loading.

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -1,7 +1,5 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
-import java.nio.file.FileSystemNotFoundException
-
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import org.apache.logging.log4j.LogManager
@@ -15,7 +13,6 @@ object CpgLoader {
     *
     * @param filename name of file that stores the code property graph
     * @param config loader configuration
-    * @throws FileSystemNotFoundException if filename refers to a non-existing file
     */
   def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig()): Cpg =
     new CpgLoader().load(filename, config)

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -1,8 +1,7 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
-import java.io.FileNotFoundException
+import java.nio.file.FileSystemNotFoundException
 
-import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import org.apache.logging.log4j.LogManager
@@ -16,7 +15,7 @@ object CpgLoader {
     *
     * @param filename name of file that stores the code property graph
     * @param config loader configuration
-    * @throws FileNotFoundException if filename refers to a non-existing file
+    * @throws FileSystemNotFoundException if filename refers to a non-existing file
     */
   def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig()): Cpg =
     new CpgLoader().load(filename, config)
@@ -44,9 +43,6 @@ private class CpgLoader {
   private val logger = LogManager.getLogger(getClass)
 
   def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.withoutOverflow): Cpg = {
-    if (!File(filename).exists) {
-      throw new FileNotFoundException(s"'$filename' does not exists!")
-    }
     logger.debug("Loading " + filename)
 
     val cpg =

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -1,5 +1,8 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
+import java.io.FileNotFoundException
+
+import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import org.apache.logging.log4j.LogManager
@@ -13,6 +16,7 @@ object CpgLoader {
     *
     * @param filename name of file that stores the code property graph
     * @param config loader configuration
+    * @throws FileNotFoundException if filename refers to a non-existing file
     */
   def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig()): Cpg =
     new CpgLoader().load(filename, config)
@@ -40,6 +44,9 @@ private class CpgLoader {
   private val logger = LogManager.getLogger(getClass)
 
   def load(filename: String, config: CpgLoaderConfig = CpgLoaderConfig.withoutOverflow): Cpg = {
+    if (!File(filename).exists) {
+      throw new FileNotFoundException(s"'$filename' does not exists!")
+    }
     logger.debug("Loading " + filename)
 
     val cpg =

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -1,5 +1,7 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
+import java.io.FileNotFoundException
+
 import io.shiftleft.overflowdb.{OdbConfig, OdbGraph}
 import org.scalatest.{Matchers, WordSpec}
 
@@ -22,6 +24,10 @@ class CpgLoaderTests extends WordSpec with Matchers {
     "allow loading of CPG from bin.zip file" in {
       val cpg = CpgLoader.load(filename)
       cpg.graph.vertices().hasNext shouldBe true
+    }
+
+    "throw an appropriate exception if the provided filename that refers to a non-existing file" in {
+      an[FileNotFoundException] should be thrownBy CpgLoader.load("invalid/path/cpg.bin.zip")
     }
 
     /**

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
-import java.io.FileNotFoundException
+import java.nio.file.FileSystemNotFoundException
 
 import io.shiftleft.overflowdb.{OdbConfig, OdbGraph}
 import org.scalatest.{Matchers, WordSpec}
@@ -27,7 +27,7 @@ class CpgLoaderTests extends WordSpec with Matchers {
     }
 
     "throw an appropriate exception if the provided filename that refers to a non-existing file" in {
-      an[FileNotFoundException] should be thrownBy CpgLoader.load("invalid/path/cpg.bin.zip")
+      an[FileSystemNotFoundException] should be thrownBy CpgLoader.load("invalid/path/cpg.bin.zip")
     }
 
     /**


### PR DESCRIPTION
Throw a FileNotFoundException if filename refers to a non-existing file during CpgLoader#load. (issue #511)