### PR TITLE
Fix CFG node calculation for METHOD_REF nodes.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/generalizations/TrackingPointToCfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/generalizations/TrackingPointToCfgNode.scala
@@ -39,7 +39,7 @@ trait TrackingPointToCfgNode extends NodeVisitor[nodes.CfgNode] with ExpressionG
   }
 
   override def visit(node: nodes.MethodRef): nodes.CfgNode = {
-    ExpandTo.argumentToCallOrReturn(node)
+    node
   }
 
   override def visit(node: nodes.Literal): nodes.CfgNode = {


### PR DESCRIPTION
METHOD_REF nodes are not part of a call like identifiers or literals.
Instead they are complex calls itself and thus are their on CFG node.