### PR TITLE
Revert "Fix CFG node calculation for METHOD_REF nodes. (#514)"

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/generalizations/TrackingPointToCfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/generalizations/TrackingPointToCfgNode.scala
@@ -39,7 +39,7 @@ trait TrackingPointToCfgNode extends NodeVisitor[nodes.CfgNode] with ExpressionG
   }
 
   override def visit(node: nodes.MethodRef): nodes.CfgNode = {
-    node
+    ExpandTo.argumentToCallOrReturn(node)
   }
 
   override def visit(node: nodes.Literal): nodes.CfgNode = {


### PR DESCRIPTION
This reverts commit d50abee2fe76ca3715bde091d24eba9e2044d9ce.

Current assumption of a METHOD_REF being always part of an expression
needs to stay a little bit longer.