### PR TITLE
Fixes for the CPG validator

### DIFF
--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/InFactsValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/InFactsValidator.scala
@@ -31,7 +31,7 @@ class InFactsValidator(errorRegistry: ValidationErrorRegistry) extends Validator
                 inFactsByEdgeType.foreach {
                   case (edgeType, inFacts) =>
                     val actualSrcNodes =
-                      inEdges.filter(_.label == edgeType).map(_.outVertex).filterNot(_.label() == NodeTypes.UNKNOWN)
+                      inEdges.filter(_.label == edgeType).map(_.outVertex)
                     inFacts.foreach { inFact =>
                       validateInDegree(dstNode, actualSrcNodes, inFact)
                     }
@@ -43,7 +43,7 @@ class InFactsValidator(errorRegistry: ValidationErrorRegistry) extends Validator
                       inFacts
                     )
                 }
-                val allowedEdgeTypes = inFactsByEdgeType.map(_._1)
+                val allowedEdgeTypes = inFactsByEdgeType.map(_._1) :+ NodeTypes.UNKNOWN
                 validateAllInEdgesTypes(dstNode, inEdges, allowedEdgeTypes)
               case _ => // Do nothing. Hence, we skip UNKNOWN nodes
             }

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/InFactsValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/InFactsValidator.scala
@@ -76,7 +76,7 @@ class InFactsValidator(errorRegistry: ValidationErrorRegistry) extends Validator
                                       edgeType: String,
                                       actualSrcNodes: List[Vertex],
                                       inFacts: List[InFact]): Unit = {
-    val allAllowedSrcTypes = inFacts.flatMap(_.srcNodeTypes).distinct
+    val allAllowedSrcTypes = inFacts.flatMap(_.srcNodeTypes).distinct :+ NodeTypes.UNKNOWN
 
     val invalidSrcNodes = actualSrcNodes.filter(
       actualSrcNode => !allAllowedSrcTypes.contains(actualSrcNode.label)

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/OutFactsValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/OutFactsValidator.scala
@@ -31,7 +31,7 @@ class OutFactsValidator(errorRegistry: ValidationErrorRegistry) extends Validato
                 outFactsByEdgeType.foreach {
                   case (edgeType, outFacts) =>
                     val actualDstNodes =
-                      outEdges.filter(_.label == edgeType).map(_.inVertex).filterNot(_.label() == NodeTypes.UNKNOWN)
+                      outEdges.filter(_.label == edgeType).map(_.inVertex)
                     outFacts.foreach { outFact =>
                       validateOutDegree(srcNode, actualDstNodes, outFact)
                     }
@@ -43,7 +43,7 @@ class OutFactsValidator(errorRegistry: ValidationErrorRegistry) extends Validato
                       outFacts
                     )
                 }
-                val allowedEdgeTypes = outFactsByEdgeType.map(_._1)
+                val allowedEdgeTypes = outFactsByEdgeType.map(_._1) :+ NodeTypes.UNKNOWN
                 validateAllOutEdgesTypes(srcNode, outEdges, allowedEdgeTypes)
               case _ => // Do nothing. Hence, we skip UNKNOWN nodes
             }
@@ -98,7 +98,7 @@ class OutFactsValidator(errorRegistry: ValidationErrorRegistry) extends Validato
                                       edgeType: String,
                                       actualDstNodes: List[Vertex],
                                       outFacts: List[OutFact]): Unit = {
-    val allAllowedDstTypes = outFacts.flatMap(_.dstNodeTypes).distinct
+    val allAllowedDstTypes = outFacts.flatMap(_.dstNodeTypes).distinct :+ NodeTypes.UNKNOWN
 
     val invalidDstNodes = actualDstNodes.filter(
       actualDstNode => !allAllowedDstTypes.contains(actualDstNode.label)


### PR DESCRIPTION
Fixes for the CPG validator:
 * do not ignore NodeTypes.UNKNOWN as src/dst nodes during in/out facts validation any more
 * added NodeTypes.UNKNOWN to possible in/out nodes for ARGUMENT edges