### PR TITLE
Shorthands for NodeTypeStarters

### DIFF
--- a/console/src/test/scala/io/shiftleft/console/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ScriptManagerTest.scala
@@ -39,20 +39,21 @@ class ScriptManagerTest extends WordSpec with Matchers with Inside {
       val scripts = scriptManager.scripts()
       val expected = List(
         ScriptCollections("general",
-          ScriptDescriptions(
-            "A collection of general purpose scripts.",
-            List(ScriptDescription("list-funcs", "Lists all functions."))
-          )),
+                          ScriptDescriptions(
+                            "A collection of general purpose scripts.",
+                            List(ScriptDescription("list-funcs", "Lists all functions."))
+                          )),
         ScriptCollections("java",
-          ScriptDescriptions(
-            "A collection of java-specific scripts.",
-            List(ScriptDescription("list-sl-ns", "Lists all shiftleft namespaces."))
-          )),
+                          ScriptDescriptions(
+                            "A collection of java-specific scripts.",
+                            List(ScriptDescription("list-sl-ns", "Lists all shiftleft namespaces."))
+                          )),
         ScriptCollections("general/general_plus",
-          ScriptDescriptions(
-            "Even more general purpose scripts.",
-            List.empty
-          )))
+                          ScriptDescriptions(
+                            "Even more general purpose scripts.",
+                            List.empty
+                          ))
+      )
 
       scripts should contain theSameElementsAs expected
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -27,7 +27,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Comment(scalaGraph.V.hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
 
   /**
-    * Shorthand for `cpg.comment.code($code)`
+    * Shorthand for `cpg.comment.code(code)`
     * */
   def comment(code: String): Comment = comment.code(code)
 
@@ -38,7 +38,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new File(scalaGraph.V.hasLabel(NodeTypes.FILE).cast[nodes.File])
 
   /**
-    * Shorthand for `cpg.file.name($name)`
+    * Shorthand for `cpg.file.name(name)`
     * */
   def file(name: String): File = file.name(name)
 
@@ -49,7 +49,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Namespace(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE).cast[nodes.Namespace])
 
   /**
-    * Shorthand for `cpg.namespace.name($name)`
+    * Shorthand for `cpg.namespace.name(name)`
     * */
   def namespace(name: String): Namespace = namespace.name(name)
 
@@ -60,7 +60,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new NamespaceBlock(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
 
   /**
-    * Shorthand for `cpg.namespaceBlock.name($name)`
+    * Shorthand for `cpg.namespaceBlock.name(name)`
     * */
   def namespaceBlock(name: String): NamespaceBlock = namespaceBlock.name(name)
 
@@ -71,7 +71,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Type(scalaGraph.V.hasLabel(NodeTypes.TYPE).cast[nodes.Type])
 
   /**
-    * Shorthand for `cpg.types.fullName($fullname)`
+    * Shorthand for `cpg.types.fullName(fullName)`
     * */
   def types(fullName: String): Type = types.fullName(fullName)
 
@@ -82,7 +82,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new TypeDecl(scalaGraph.V.hasLabel(NodeTypes.TYPE_DECL).cast[nodes.TypeDecl])
 
   /**
-    * Shorthand for cpg.typeDecl.fullName($fullName)
+    * Shorthand for cpg.typeDecl.fullName(fullName)
     * */
   def typeDecl(fullName: String): TypeDecl = typeDecl.fullName(fullName)
 
@@ -93,7 +93,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Method(scalaGraph.V.hasLabel(NodeTypes.METHOD).cast[nodes.Method])
 
   /**
-    * Shorthand for `cpg.method.fullName($fullName)`
+    * Shorthand for `cpg.method.fullName(fullName)`
     * */
   def method(fullName: String): Method = method.fullName(fullName)
 
@@ -110,7 +110,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new MethodParameter(scalaGraph.V.hasLabel(NodeTypes.METHOD_PARAMETER_IN).cast[nodes.MethodParameterIn])
 
   /**
-    * Shorthand for `cpg.parameter.name($name)`
+    * Shorthand for `cpg.parameter.name(name)`
     * */
   def parameter(name: String): MethodParameter = parameter.name(name)
 
@@ -121,7 +121,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Member(scalaGraph.V.hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
 
   /**
-    * Shorthand for `cpg.member.name($name)`
+    * Shorthand for `cpg.member.name(name)`
     * */
   def member(name: String): Member = member.name(name)
 
@@ -132,7 +132,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Call(scalaGraph.V.hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**
-    * Shorthand for `cpg.call.name($name)`
+    * Shorthand for `cpg.call.name(name)`
     * */
   def call(name: String): Call = call.name(name)
 
@@ -155,7 +155,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Literal(scalaGraph.V.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
   /**
-    * Shorthand for `cpg.literal.code($code)`
+    * Shorthand for `cpg.literal.code(code)`
     * */
   def literal(code: String): Literal = literal.code(code)
 
@@ -166,7 +166,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Identifier(scalaGraph.V.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
-    * Shorthand for `cpg.identifier.name($name)`
+    * Shorthand for `cpg.identifier.name(name)`
     * */
   def identifier(name: String): Identifier = identifier.name(name)
 
@@ -177,7 +177,7 @@ class NodeTypeStarters(cpg: Cpg) {
     call.argument
 
   /**
-    * Shorthand for `cpg.argument.code($code)`
+    * Shorthand for `cpg.argument.code(code)`
     * */
   def argument(code: String): Expression = argument.code(code)
 
@@ -188,7 +188,7 @@ class NodeTypeStarters(cpg: Cpg) {
     new Return(scalaGraph.V.hasLabel(NodeTypes.RETURN).cast[nodes.Return])
 
   /**
-    * Shorthand for `returns.code($code)`
+    * Shorthand for `returns.code(code)`
     * */
   def returns(code: String): Return = returns.code(code)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -3,7 +3,6 @@ package io.shiftleft.semanticcpg.language
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.structure._
@@ -28,10 +27,20 @@ class NodeTypeStarters(cpg: Cpg) {
     new Comment(scalaGraph.V.hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
 
   /**
+    * Shorthand for `cpg.comment.code($code)`
+    * */
+  def comment(code : String) : Comment = comment.code(code)
+
+  /**
     Traverse to all source files
     */
   def file: File =
     new File(scalaGraph.V.hasLabel(NodeTypes.FILE).cast[nodes.File])
+
+  /**
+    * Shorthand for `cpg.file.name($name)`
+    * */
+  def file(name : String) : File = file.name(name)
 
   /**
     Traverse to all namespaces, e.g., packages in Java.
@@ -40,10 +49,20 @@ class NodeTypeStarters(cpg: Cpg) {
     new Namespace(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE).cast[nodes.Namespace])
 
   /**
+    * Shorthand for `cpg.namespace.name($name)`
+    * */
+  def namespace(name : String) : Namespace  = namespace.name(name)
+
+  /**
   Traverse to all namespace blocks, e.g., packages in Java.
     */
   def namespaceBlock: NamespaceBlock =
     new NamespaceBlock(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
+
+  /**
+    * Shorthand for `cpg.namespaceBlock.name($name)`
+    * */
+  def namespaceBlock(name : String) : NamespaceBlock = namespaceBlock.name(name)
 
   /**
     Traverse to all types, e.g., Set<String>
@@ -52,16 +71,31 @@ class NodeTypeStarters(cpg: Cpg) {
     new Type(scalaGraph.V.hasLabel(NodeTypes.TYPE).cast[nodes.Type])
 
   /**
+    * Shorthand for `cpg.types.fullName($fullname)`
+    * */
+  def types(fullName : String) : Type = types.fullName(fullName)
+
+  /**
     Traverse to all declarations, e.g., Set<T>
     */
   def typeDecl: TypeDecl =
     new TypeDecl(scalaGraph.V.hasLabel(NodeTypes.TYPE_DECL).cast[nodes.TypeDecl])
 
   /**
+    * Shorthand for cpg.typeDecl.fullName($fullName)
+    * */
+  def typeDecl(fullName : String) : TypeDecl = typeDecl.fullName(fullName)
+
+  /**
     Traverse to all methods
     */
   def method: Method =
     new Method(scalaGraph.V.hasLabel(NodeTypes.METHOD).cast[nodes.Method])
+
+  /**
+    * Shorthand for `cpg.method.fullName($fullName)`
+    * */
+  def method(fullName : String) : Method = method.fullName(fullName)
 
   /**
     Traverse to all formal return parameters
@@ -76,10 +110,20 @@ class NodeTypeStarters(cpg: Cpg) {
     new MethodParameter(scalaGraph.V.hasLabel(NodeTypes.METHOD_PARAMETER_IN).cast[nodes.MethodParameterIn])
 
   /**
+    * Shorthand for `cpg.parameter.name($name)`
+    * */
+  def parameter(name : String) : MethodParameter = parameter.name(name)
+
+  /**
     Traverse to all class members
     */
   def member: Member =
     new Member(scalaGraph.V.hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
+
+  /**
+    * Shorthand for `cpg.member.name($name)`
+    * */
+  def member(name : String) : Member = member.name(name)
 
   /**
     Traverse to all call sites
@@ -87,7 +131,10 @@ class NodeTypeStarters(cpg: Cpg) {
   def call: Call =
     new Call(scalaGraph.V.hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
-  def call(regex: String): Call = call.name(regex)
+  /**
+    * Shorthand for `cpg.call.name($name)`
+    * */
+  def call(name: String): Call = call.name(name)
 
   /**
     Traverse to all local variable declarations
@@ -97,10 +144,20 @@ class NodeTypeStarters(cpg: Cpg) {
     new Local(scalaGraph.V.hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
   /**
+    * Shorthand for `cpg.local.name`
+    * */
+  def local(name : String) : Local = local.name(name)
+
+  /**
     Traverse to all literals (constant strings and numbers provided directly in the code).
     */
   def literal: Literal =
     new Literal(scalaGraph.V.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
+
+  /**
+    * Shorthand for `cpg.literal.code($code)`
+    * */
+  def literal(code : String) : Literal = literal.code(code)
 
   /**
     Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
@@ -109,16 +166,31 @@ class NodeTypeStarters(cpg: Cpg) {
     new Identifier(scalaGraph.V.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
+    * Shorthand for `cpg.identifier.name($name)`
+    * */
+  def identifier(name : String) : Identifier = identifier.name(name)
+
+  /**
     Traverse to all arguments passed to methods
     */
   def argument: Expression =
     call.argument
 
   /**
+    * Shorthand for `cpg.argument.code($code)`
+    * */
+  def argument(code : String) : Expression = argument.code(code)
+
+  /**
     * Traverse to all return expressions
     */
-  def returnExpression: Return =
+  def returns: Return =
     new Return(scalaGraph.V.hasLabel(NodeTypes.RETURN).cast[nodes.Return])
+
+  /**
+    * Shorthand for `returns.code($code)`
+    * */
+  def returns(code : String) : Return = returns.code(code)
 
   /**
     * Traverse to all meta data entries
@@ -132,6 +204,14 @@ class NodeTypeStarters(cpg: Cpg) {
   def methodRef: MethodRef =
     new MethodRef(scalaGraph.V.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
 
+
+  /**
+    * Shorthand for `cpg.methodRef
+    * .filter(_.referencedMethod.fullName(fullName))`
+    * */
+  def methodRef(fullName : String) : MethodRef = methodRef
+    .filter(_.referencedMethod.fullName(fullName))
+
   /**
   Begin traversal at node with id.
     */
@@ -143,9 +223,6 @@ class NodeTypeStarters(cpg: Cpg) {
   def id[NodeType <: nodes.StoredNode](ids: Seq[Any]): NodeSteps[NodeType] =
     if (ids.isEmpty) new NodeSteps[NodeType](scalaGraph.V(-1).cast[NodeType])
     else new NodeSteps[NodeType](scalaGraph.V(ids: _*).cast[NodeType])
-
-  @deprecated("", "October 2019")
-  def atVerticesWithId[NodeType <: nodes.StoredNode](ids: Seq[Any]): NodeSteps[NodeType] = id(ids)
 
   /**
   Traverse to all tags

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -29,7 +29,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.comment.code($code)`
     * */
-  def comment(code : String) : Comment = comment.code(code)
+  def comment(code: String): Comment = comment.code(code)
 
   /**
     Traverse to all source files
@@ -40,7 +40,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.file.name($name)`
     * */
-  def file(name : String) : File = file.name(name)
+  def file(name: String): File = file.name(name)
 
   /**
     Traverse to all namespaces, e.g., packages in Java.
@@ -51,7 +51,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.namespace.name($name)`
     * */
-  def namespace(name : String) : Namespace  = namespace.name(name)
+  def namespace(name: String): Namespace = namespace.name(name)
 
   /**
   Traverse to all namespace blocks, e.g., packages in Java.
@@ -62,7 +62,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.namespaceBlock.name($name)`
     * */
-  def namespaceBlock(name : String) : NamespaceBlock = namespaceBlock.name(name)
+  def namespaceBlock(name: String): NamespaceBlock = namespaceBlock.name(name)
 
   /**
     Traverse to all types, e.g., Set<String>
@@ -73,7 +73,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.types.fullName($fullname)`
     * */
-  def types(fullName : String) : Type = types.fullName(fullName)
+  def types(fullName: String): Type = types.fullName(fullName)
 
   /**
     Traverse to all declarations, e.g., Set<T>
@@ -84,7 +84,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for cpg.typeDecl.fullName($fullName)
     * */
-  def typeDecl(fullName : String) : TypeDecl = typeDecl.fullName(fullName)
+  def typeDecl(fullName: String): TypeDecl = typeDecl.fullName(fullName)
 
   /**
     Traverse to all methods
@@ -95,7 +95,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.method.fullName($fullName)`
     * */
-  def method(fullName : String) : Method = method.fullName(fullName)
+  def method(fullName: String): Method = method.fullName(fullName)
 
   /**
     Traverse to all formal return parameters
@@ -112,7 +112,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.parameter.name($name)`
     * */
-  def parameter(name : String) : MethodParameter = parameter.name(name)
+  def parameter(name: String): MethodParameter = parameter.name(name)
 
   /**
     Traverse to all class members
@@ -123,7 +123,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.member.name($name)`
     * */
-  def member(name : String) : Member = member.name(name)
+  def member(name: String): Member = member.name(name)
 
   /**
     Traverse to all call sites
@@ -146,7 +146,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.local.name`
     * */
-  def local(name : String) : Local = local.name(name)
+  def local(name: String): Local = local.name(name)
 
   /**
     Traverse to all literals (constant strings and numbers provided directly in the code).
@@ -157,7 +157,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.literal.code($code)`
     * */
-  def literal(code : String) : Literal = literal.code(code)
+  def literal(code: String): Literal = literal.code(code)
 
   /**
     Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
@@ -168,7 +168,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.identifier.name($name)`
     * */
-  def identifier(name : String) : Identifier = identifier.name(name)
+  def identifier(name: String): Identifier = identifier.name(name)
 
   /**
     Traverse to all arguments passed to methods
@@ -179,7 +179,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `cpg.argument.code($code)`
     * */
-  def argument(code : String) : Expression = argument.code(code)
+  def argument(code: String): Expression = argument.code(code)
 
   /**
     * Traverse to all return expressions
@@ -190,7 +190,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Shorthand for `returns.code($code)`
     * */
-  def returns(code : String) : Return = returns.code(code)
+  def returns(code: String): Return = returns.code(code)
 
   /**
     * Traverse to all meta data entries
@@ -204,13 +204,13 @@ class NodeTypeStarters(cpg: Cpg) {
   def methodRef: MethodRef =
     new MethodRef(scalaGraph.V.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
 
-
   /**
     * Shorthand for `cpg.methodRef
     * .filter(_.referencedMethod.fullName(fullName))`
     * */
-  def methodRef(fullName : String) : MethodRef = methodRef
-    .filter(_.referencedMethod.fullName(fullName))
+  def methodRef(fullName: String): MethodRef =
+    methodRef
+      .filter(_.referencedMethod.fullName(fullName))
 
   /**
   Begin traversal at node with id.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -126,7 +126,7 @@ package object language {
   implicit def toBinding(steps: Steps[nodes.Binding]): Binding =
     new Binding(steps.raw)
 
-  implicit def toComment(steps : Steps[nodes.Comment]) : Comment =
+  implicit def toComment(steps: Steps[nodes.Comment]): Comment =
     new Comment(steps.raw)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -126,6 +126,9 @@ package object language {
   implicit def toBinding(steps: Steps[nodes.Binding]): Binding =
     new Binding(steps.raw)
 
+  implicit def toComment(steps : Steps[nodes.Comment]) : Comment =
+    new Comment(steps.raw)
+
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing
      * from a known nodeType via AST edges, so we have to cast */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/argumentcompat/ArgumentCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/argumentcompat/ArgumentCompat.scala
@@ -18,7 +18,7 @@ class ArgumentCompat(cpg: Cpg) extends CpgPass(cpg) {
       val diffGraph = new DiffGraph
       val callIterator = cpg.call.toIterator()
       callIterator.foreach(addArgumentEdges(_, diffGraph))
-      val returnIterator = cpg.returnExpression.toIterator()
+      val returnIterator = cpg.returns.toIterator()
       returnIterator.foreach(addArgumentEdges(_, diffGraph))
       Iterator(diffGraph)
     } else {


### PR DESCRIPTION
Some time in October, we brought in `cpg.call($name)` as a shorthand for `cpg.call.name($name)`. While writing queries, I have been using this quite extensively, and soon found that similar shorthands would make sense for almost all NodeTypeStarters. Also, there is usually one field that is intuitively the primary field one would filter on, e.g., `name` for `call`, `fullName` for `method` or `name` for member.

This PR introduces shorthands for NodeTypeStarters. Roughly, the rule is: if there is a `fullName` field, filter on that, if not filter on `name`, and if that doesn't exist, filter on `code`. An exception is `methodRef`, where we filter on the fullName of the referenced method.

Minor edit: renamed `returnExpression` to `returns`. The correct name would be `return`, however, `return` is a reserved keyword. The rule we used in the case where the correct function name is a reserved keyword was to switch to plural, e.g., `types` as opposed to `type`. Consequently, it must be `returns`, not `returnExpression`.