### PR TITLE
rip ExpandTo.walkAST

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -19,7 +19,6 @@ import scala.collection.mutable
   * There are no constraints on the element types, unlike e.g. [[NodeSteps]]
   */
 class Steps[A](val raw: GremlinScala[A]) {
-
   implicit lazy val graph: Graph = raw.traversal.asAdmin.getGraph.get
 
   def toIterator(): Iterator[A] = {
@@ -52,6 +51,8 @@ class Steps[A](val raw: GremlinScala[A]) {
     @deprecated
     */
   def exec(): List[A] = toList()
+
+  def iterate(): Unit = raw.iterate()
 
   /**
     Execute the travel and convert it to a Java stream.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -11,7 +11,7 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors.OrderAccessors
 class AstNode(raw: GremlinScala[nodes.AstNode])
     extends NodeSteps[nodes.AstNode](raw)
     with AstNodeBase[nodes.AstNode]
-    with OrderAccessors[nodes.AstNode] {}
+    with OrderAccessors[nodes.AstNode]
 
 trait AstNodeBase[NodeType <: nodes.AstNode] { this: NodeSteps[NodeType] =>
 
@@ -143,5 +143,14 @@ trait AstNodeBase[NodeType <: nodes.AstNode] { this: NodeSteps[NodeType] =>
   def isMethodRef: MethodRef = new MethodRef(
     raw.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef]
   )
+
+  def walkAstUntilReaching(labels: List[String]): NodeSteps[nodes.StoredNode] =
+    new NodeSteps[nodes.StoredNode](
+      raw
+        .repeat(_.out(EdgeTypes.AST))
+        .until(_.hasLabel(labels.head, labels.tail: _*))
+        .emit
+        .dedup
+        .cast)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -148,10 +148,6 @@ object ExpandTo {
     node.asInstanceOf[nodes.StoredNode]._refOut.nextOption
   }
 
-  def walkAST(expression: GremlinScala[Vertex]): GremlinScala[Vertex] = {
-    expression.emit.repeat(_.out(EdgeTypes.AST)).dedup()
-  }
-
   def implicitCallToMethod(implicitCall: nodes.ImplicitCall): nodes.Method = {
     implicitCall.vertices(Direction.IN, EdgeTypes.AST).next.asInstanceOf[nodes.Method]
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/ContainsEdgePassTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/ContainsEdgePassTest.scala
@@ -11,20 +11,6 @@ class ContainsEdgePassTest extends WordSpec with Matchers {
 
   import ContainsEdgePassTest.Fixture
 
-  "foo" in {
-    implicit val graph: ScalaGraph = OverflowDbTestInstance.create
-    val fileVertex = graph + NodeTypes.FILE
-    val typeDeclVertex = graph + NodeTypes.TYPE_DECL
-//    fileVertex --- EdgeTypes.AST --> typeDeclVertex
-
-    graph.traversal.V(fileVertex).addE(EdgeTypes.AST).to(typeDeclVertex).toList //Nil
-    println(fileVertex.start.outE().toList()) //Nil
-
-    fileVertex.addEdge("AST", typeDeclVertex)
-    println(fileVertex.start.outE().toList()) //Nil
-
-  }
-
   "Files " can {
     "contain Methods" in Fixture { fixture =>
       fixture.methodVertex.in(EdgeTypes.CONTAINS).toList should contain only fixture.fileVertex


### PR DESCRIPTION
this is the start of an effort to disintegrate ExpandTo, and instead move
the functionality to the query language - see the comment at the top of the
class