### PR TITLE
Relax visibility of methods in AmmoniteExecutor.

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.console.scripting
 
+import ammonite.Main
 import ammonite.runtime.Storage
 import ammonite.util.Res
 import cats.effect.IO
@@ -20,11 +21,11 @@ import java.nio.file.{Files, Path}
 trait AmmoniteExecutor {
   protected def predef: String
 
-  private lazy val ammoniteMain = ammonite.Main(predefCode = predef,
-                                                remoteLogging = false,
-                                                verboseOutput = false,
-                                                welcomeBanner = None,
-                                                storageBackend = Storage.InMemory())
+  protected lazy val ammoniteMain: Main = ammonite.Main(predefCode = predef,
+    remoteLogging = false,
+    verboseOutput = false,
+    welcomeBanner = None,
+    storageBackend = Storage.InMemory())
 
   /**
     * Runs the given script, passing any defined parameters in addition to bringing the target CPG
@@ -46,10 +47,10 @@ trait AmmoniteExecutor {
         }.toSeq)
       }
       result <- ammoniteResult match {
-        case Res.Success(res)     => IO.pure(res)
+        case Res.Success(res) => IO.pure(res)
         case Res.Exception(ex, _) => IO.raiseError(ex)
-        case Res.Failure(msg)     => IO.raiseError(new RuntimeException(msg))
-        case _                    => IO.pure(())
+        case Res.Failure(msg) => IO.raiseError(new RuntimeException(msg))
+        case _ => IO.pure(())
       }
     } yield result
   }
@@ -75,7 +76,7 @@ trait AmmoniteExecutor {
     * Runs a query against the provided CPG.
     *
     * @param query The query to run against the CPG.
-    * @param cpg The CPG made implicitly available in the query
+    * @param cpg   The CPG made implicitly available in the query
     * @return The result of running the query.
     */
   def runQuery(query: String, cpg: Cpg): IO[Any] = {

--- a/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
@@ -108,17 +108,15 @@ trait AmmoniteExecutor {
     * @return The result of running the query.
     */
   def runQuery(query: String, cpg: Cpg): IO[Any] = {
-    val sb = new StringBuilder
-    sb.append("@main def main() = {")
-    sb.append(System.lineSeparator)
-    sb.append(query)
-    sb.append(System.lineSeparator)
-    sb.append("}")
-    sb.append(System.lineSeparator)
+    val queryContent =
+      s"""|@main def main() = {
+          |$query
+          |}
+          |""".stripMargin
 
     for {
       tempFile <- IO(Files.createTempFile("sl_query", ".sc"))
-      _ <- IO(Files.write(tempFile, sb.toString.getBytes(StandardCharsets.UTF_8)))
+      _ <- IO(Files.write(tempFile, queryContent.getBytes(StandardCharsets.UTF_8)))
       result <- runScript(tempFile, Map.empty, cpg)
     } yield result
   }

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScriptManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScriptManager.scala
@@ -92,7 +92,7 @@ abstract class ScriptManager(executor: AmmoniteExecutor) {
       .toList
   }
 
-  private def withScriptFile[T](scriptName: String)(f: File => IO[T]): IO[T] = {
+  protected def withScriptFile[T](scriptName: String)(f: File => IO[T]): IO[T] = {
     val scriptPath = scriptsTempDir / s"$scriptName.sc"
     if (scriptPath.exists) {
       f(scriptPath)

--- a/console/src/test/scala/io/shiftleft/console/scripting/AmmoniteExecutorTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/AmmoniteExecutorTest.scala
@@ -55,5 +55,19 @@ class AmmoniteExecutorTest extends WordSpec with Matchers {
         executor.runScript(script, Map.empty, Cpg.emptyCpg).unsafeRunSync()
       }
     }
+
+    "run a string query" in withExecutor { executor =>
+      val query = "cpg.method.l"
+
+      executor.runQuery(query, Cpg.emptyCpg).unsafeRunSync() shouldBe List()
+    }
+
+    "propagate errors if the string query fails" in withExecutor { executor =>
+      val query = "cake"
+
+      intercept[RuntimeException] {
+        executor.runQuery(query, Cpg.emptyCpg).unsafeRunSync()
+      }
+    }
   }
 }


### PR DESCRIPTION
- Update `runScript` to accept any arbitrary set of variable bindings (for re-usability).
- Add convenience methods for adding a binding to the CPG.