### PR TITLE
Allow flows as related objects in findings

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/securityprofile.json
+++ b/codepropertygraph/src/main/resources/schemas/securityprofile.json
@@ -112,6 +112,7 @@
       {"id" : 214, "name" : "FINDING", "comment" : "", "keys" : [], "outEdges" : [], "containedNodes" : [
 	  {"localName" : "ioflows", "nodeType" : "IOFLOW", "cardinality" : "list"},
 	  {"localName" : "methods", "nodeType" : "METHOD", "cardinality" : "list"},
+	  {"localName" : "flows", "nodeType" : "FLOW", "cardinality" : "list"},
 	  {"localName" : "keyValuePairs", "nodeType" : "KEY_VALUE_PAIR", "cardinality" : "list"}
    ]
    },


### PR DESCRIPTION
Previously, we only allowed IoFlows or Methods as related objects in findings. With this PR, we also allow flows.