### PR TITLE
Add method to load CPG from overflowDB file

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -18,6 +18,24 @@ object CpgLoader {
     new CpgLoader().load(filename, config)
 
   /**
+    * Load Code Property Graph from an overflow DB file
+    *
+    * @param config loader config
+    *
+    *               This methods loads the CPG from an existing overflow DB file,
+    *               specified in config.overflowDbConfig. In particular, this config
+    *               specifies the filename. For example, to load the database at "foo.db",
+    *               you can issue the following:
+    *
+    * val odbConfig = OdbConfig.withDefaults().withStorageLocation(config.spPath)
+    * val config = CpgLoaderConfig().withOverflowConfig(odbConfig)
+    * CpgLoader.loadFromOverflowDb(config)
+    * */
+  def loadFromOverflowDb(config: CpgLoaderConfig = CpgLoaderConfig()): Cpg = {
+    new CpgLoader().loadFromOverflowDb(config)
+  }
+
+  /**
     * Create any indexes necessary for quick access.
     *
     * @param cpg the CPG to create indexes in
@@ -44,6 +62,12 @@ private class CpgLoader {
 
     val cpg =
       ProtoCpgLoader.loadFromProtoZip(filename, config.overflowDbConfig)
+    if (config.createIndexes) { createIndexes(cpg) }
+    cpg
+  }
+
+  def loadFromOverflowDb(config: CpgLoaderConfig = CpgLoaderConfig()): Cpg = {
+    val cpg = new ProtoToCpg(config.overflowDbConfig).build()
     if (config.createIndexes) { createIndexes(cpg) }
     cpg
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NewNodeStepsTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NewNodeStepsTests.scala
@@ -7,7 +7,7 @@ import io.shiftleft.codepropertygraph.generated.EdgeKeyNames
 import io.shiftleft.codepropertygraph.generated.edges.ContainsNode
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeKeyNames, ModifierTypes}
-import io.shiftleft.passes.{ DiffGraph}
+import io.shiftleft.passes.{DiffGraph}
 import io.shiftleft.passes.DiffGraph.{EdgeInDiffGraph, EdgeToOriginal}
 import io.shiftleft.overflowdb.OdbGraph
 import org.scalatest.{Matchers, WordSpec}


### PR DESCRIPTION
In cases where RAM is limited, it can make sense to store and exchange CPGs in overflowDB format. This PR adds a method to CpgLoader to allow loading of CPGs from overflowDB files.