### PR TITLE
provide steps via implicit conversions rather than inheritance

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
@@ -3,12 +3,10 @@ package io.shiftleft.semanticcpg.language
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.types.expressions.{Call, Identifier, Literal}
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.ValueAccessors
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.{NodeSteps => OriginalNodeSteps}
 
-class Tag(override val raw: GremlinScala[nodes.Tag]) extends OriginalNodeSteps[nodes.Tag](raw)
-    with ValueAccessors[nodes.Tag] {
+class Tag(override val raw: GremlinScala[nodes.Tag]) extends OriginalNodeSteps[nodes.Tag](raw) {
 
   def method: Method =
     new Method(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
@@ -3,13 +3,11 @@ package io.shiftleft.semanticcpg.language
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.types.expressions.{Call, Identifier, Literal}
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{NameAccessors, ValueAccessors}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.ValueAccessors
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.{NodeSteps => OriginalNodeSteps}
 
-class Tag(override val raw: GremlinScala[nodes.Tag])
-    extends OriginalNodeSteps[nodes.Tag](raw)
-    with NameAccessors[nodes.Tag]
+class Tag(override val raw: GremlinScala[nodes.Tag]) extends OriginalNodeSteps[nodes.Tag](raw)
     with ValueAccessors[nodes.Tag] {
 
   def method: Method =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasLineNumber, HasLineNumberEnd, HasName, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -12,7 +12,7 @@ import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.structure.{Method => OriginalMethod}
 import io.shiftleft.semanticcpg.language.types.expressions.{Call => OriginalCall}
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{FullNameAccessors, LineNumberAccessors, LineNumberEndAccessors, NameAccessors}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
 /**
   Language for traversing the code property graph
@@ -124,6 +124,12 @@ package object language {
   implicit def toComment(steps: Steps[nodes.Comment]): Comment =
     new Comment(steps.raw)
 
+  implicit def toIsExternalAccessors[A <: StoredNode with HasIsExternal](steps: Steps[A]): IsExternalAccessors[A] =
+    new IsExternalAccessors(steps)
+  
+  implicit def toFullNameAccessors[A <: StoredNode with HasFullName](steps: Steps[A]): FullNameAccessors[A] =
+    new FullNameAccessors(steps)
+  
   implicit def toLineNumberAccessors[A <: StoredNode with HasLineNumber](steps: Steps[A]): LineNumberAccessors[A] =
     new LineNumberAccessors(steps)
 
@@ -133,9 +139,6 @@ package object language {
 
   implicit def toNameAccessors[A <: StoredNode with HasName](steps: Steps[A]): NameAccessors[A] =
     new NameAccessors(steps)
-
-  implicit def toFullNameAccessors[A <: StoredNode with HasFullName](steps: Steps[A]): FullNameAccessors[A] =
-    new FullNameAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasLineNumber, HasLineNumberEnd, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasLineNumber, HasLineNumberEnd, HasName, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -12,7 +12,7 @@ import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.structure.{Method => OriginalMethod}
 import io.shiftleft.semanticcpg.language.types.expressions.{Call => OriginalCall}
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{LineNumberAccessors, LineNumberEndAccessors}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.{LineNumberAccessors, LineNumberEndAccessors, NameAccessors}
 
 /**
   Language for traversing the code property graph
@@ -130,6 +130,9 @@ package object language {
   implicit def toLineNumberEndAccessors[A <: StoredNode with HasLineNumberEnd](
       steps: Steps[A]): LineNumberEndAccessors[A] =
     new LineNumberEndAccessors(steps)
+
+  implicit def toNameAccessors[A <: StoredNode with HasName](steps: Steps[A]): NameAccessors[A] =
+    new NameAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -145,6 +145,9 @@ package object language {
 
   implicit def toParserTypeNameAccessors[A <: StoredNode with HasParserTypeName](steps: Steps[A]): ParserTypeNameAccessors[A] =
     new ParserTypeNameAccessors(steps)
+
+  implicit def toSignatureAccessors[A <: StoredNode with HasSignature](steps: Steps[A]): SignatureAccessors[A] =
+    new SignatureAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasDispatchType, HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, HasValue, HasVersion, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasDependencyGroupId, HasDispatchType, HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, HasValue, HasVersion, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -123,6 +123,9 @@ package object language {
 
   implicit def toComment(steps: Steps[nodes.Comment]): Comment =
     new Comment(steps.raw)
+
+  implicit def toDependencyGroupIdAccessors[A <: StoredNode with HasDependencyGroupId](steps: Steps[A]): DependencyGroupIdAccessors[A] =
+    new DependencyGroupIdAccessors(steps)
 
   implicit def toDispatchTypeAccessors[A <: StoredNode with HasDispatchType](steps: Steps[A]): DispatchTypeAccessors[A] =
     new DispatchTypeAccessors(steps)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, HasValue, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -148,6 +148,9 @@ package object language {
 
   implicit def toSignatureAccessors[A <: StoredNode with HasSignature](steps: Steps[A]): SignatureAccessors[A] =
     new SignatureAccessors(steps)
+
+  implicit def toValueAccessors[A <: StoredNode with HasValue](steps: Steps[A]): ValueAccessors[A] =
+    new ValueAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, HasValue, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, HasValue, HasVersion, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -151,6 +151,9 @@ package object language {
 
   implicit def toValueAccessors[A <: StoredNode with HasValue](steps: Steps[A]): ValueAccessors[A] =
     new ValueAccessors(steps)
+
+  implicit def toVersionAccessors[A <: StoredNode with HasVersion](steps: Steps[A]): VersionAccessors[A] =
+    new VersionAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -142,6 +142,9 @@ package object language {
 
   implicit def toOrderAccessors[A <: StoredNode with HasOrder](steps: Steps[A]): OrderAccessors[A] =
     new OrderAccessors(steps)
+
+  implicit def toParserTypeNameAccessors[A <: StoredNode with HasParserTypeName](steps: Steps[A]): ParserTypeNameAccessors[A] =
+    new ParserTypeNameAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,10 +3,33 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasDependencyGroupId, HasDispatchType, HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, HasValue, HasVersion, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  HasCode,
+  HasDependencyGroupId,
+  HasDispatchType,
+  HasFullName,
+  HasIsExternal,
+  HasLineNumber,
+  HasLineNumberEnd,
+  HasName,
+  HasOrder,
+  HasParserTypeName,
+  HasSignature,
+  HasValue,
+  HasVersion,
+  Node,
+  StoredNode
+}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
-import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
+import io.shiftleft.semanticcpg.language.nodemethods.{
+  AstNodeMethods,
+  CallMethods,
+  MethodMethods,
+  MethodReturnMethods,
+  NodeMethods,
+  WithinMethodMethods
+}
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
@@ -124,18 +147,23 @@ package object language {
   implicit def toComment(steps: Steps[nodes.Comment]): Comment =
     new Comment(steps.raw)
 
-  implicit def toDependencyGroupIdAccessors[A <: StoredNode with HasDependencyGroupId](steps: Steps[A]): DependencyGroupIdAccessors[A] =
+  implicit def toCodeAccessors[A <: StoredNode with HasCode](steps: Steps[A]): CodeAccessors[A] =
+    new CodeAccessors(steps)
+
+  implicit def toDependencyGroupIdAccessors[A <: StoredNode with HasDependencyGroupId](
+      steps: Steps[A]): DependencyGroupIdAccessors[A] =
     new DependencyGroupIdAccessors(steps)
 
-  implicit def toDispatchTypeAccessors[A <: StoredNode with HasDispatchType](steps: Steps[A]): DispatchTypeAccessors[A] =
+  implicit def toDispatchTypeAccessors[A <: StoredNode with HasDispatchType](
+      steps: Steps[A]): DispatchTypeAccessors[A] =
     new DispatchTypeAccessors(steps)
 
   implicit def toIsExternalAccessors[A <: StoredNode with HasIsExternal](steps: Steps[A]): IsExternalAccessors[A] =
     new IsExternalAccessors(steps)
-  
+
   implicit def toFullNameAccessors[A <: StoredNode with HasFullName](steps: Steps[A]): FullNameAccessors[A] =
     new FullNameAccessors(steps)
-  
+
   implicit def toLineNumberAccessors[A <: StoredNode with HasLineNumber](steps: Steps[A]): LineNumberAccessors[A] =
     new LineNumberAccessors(steps)
 
@@ -149,7 +177,8 @@ package object language {
   implicit def toOrderAccessors[A <: StoredNode with HasOrder](steps: Steps[A]): OrderAccessors[A] =
     new OrderAccessors(steps)
 
-  implicit def toParserTypeNameAccessors[A <: StoredNode with HasParserTypeName](steps: Steps[A]): ParserTypeNameAccessors[A] =
+  implicit def toParserTypeNameAccessors[A <: StoredNode with HasParserTypeName](
+      steps: Steps[A]): ParserTypeNameAccessors[A] =
     new ParserTypeNameAccessors(steps)
 
   implicit def toSignatureAccessors[A <: StoredNode with HasSignature](steps: Steps[A]): SignatureAccessors[A] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.semanticcpg
 
 import gremlin.scala._
-
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasLineNumberEnd, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{
@@ -21,6 +20,7 @@ import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.structure.{Method => OriginalMethod}
 import io.shiftleft.semanticcpg.language.types.expressions.{Call => OriginalCall}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.LineNumberEndAccessors
 
 /**
   Language for traversing the code property graph
@@ -131,6 +131,10 @@ package object language {
 
   implicit def toComment(steps: Steps[nodes.Comment]): Comment =
     new Comment(steps.raw)
+
+  implicit def toLineNumberEndAccessors[A <: StoredNode with HasLineNumberEnd](
+      steps: Steps[A]): LineNumberEndAccessors[A] =
+    new LineNumberEndAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,24 +3,16 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasLineNumberEnd, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasLineNumber, HasLineNumberEnd, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
-import io.shiftleft.semanticcpg.language.nodemethods.{
-  AstNodeMethods,
-  CallMethods,
-  MethodMethods,
-  MethodReturnMethods,
-  NodeMethods,
-  WithinMethodMethods
-}
-import io.shiftleft.semanticcpg.language.operatorextension.ArrayAccessTrav
+import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.structure.{Method => OriginalMethod}
 import io.shiftleft.semanticcpg.language.types.expressions.{Call => OriginalCall}
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.LineNumberEndAccessors
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.{LineNumberAccessors, LineNumberEndAccessors}
 
 /**
   Language for traversing the code property graph
@@ -131,6 +123,9 @@ package object language {
 
   implicit def toComment(steps: Steps[nodes.Comment]): Comment =
     new Comment(steps.raw)
+
+  implicit def toLineNumberAccessors[A <: StoredNode with HasLineNumber](steps: Steps[A]): LineNumberAccessors[A] =
+    new LineNumberAccessors(steps)
 
   implicit def toLineNumberEndAccessors[A <: StoredNode with HasLineNumberEnd](
       steps: Steps[A]): LineNumberEndAccessors[A] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, HasValue, HasVersion, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasDispatchType, HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, HasParserTypeName, HasSignature, HasValue, HasVersion, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -123,6 +123,9 @@ package object language {
 
   implicit def toComment(steps: Steps[nodes.Comment]): Comment =
     new Comment(steps.raw)
+
+  implicit def toDispatchTypeAccessors[A <: StoredNode with HasDispatchType](steps: Steps[A]): DispatchTypeAccessors[A] =
+    new DispatchTypeAccessors(steps)
 
   implicit def toIsExternalAccessors[A <: StoredNode with HasIsExternal](steps: Steps[A]): IsExternalAccessors[A] =
     new IsExternalAccessors(steps)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasIsExternal, HasLineNumber, HasLineNumberEnd, HasName, HasOrder, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -139,6 +139,9 @@ package object language {
 
   implicit def toNameAccessors[A <: StoredNode with HasName](steps: Steps[A]): NameAccessors[A] =
     new NameAccessors(steps)
+
+  implicit def toOrderAccessors[A <: StoredNode with HasOrder](steps: Steps[A]): OrderAccessors[A] =
+    new OrderAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{HasLineNumber, HasLineNumberEnd, HasName, Node, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, HasLineNumber, HasLineNumberEnd, HasName, Node, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.MethodDOT
 import io.shiftleft.semanticcpg.language.nodemethods.{AstNodeMethods, CallMethods, MethodMethods, MethodReturnMethods, NodeMethods, WithinMethodMethods}
@@ -12,7 +12,7 @@ import io.shiftleft.semanticcpg.language.types.expressions._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.structure.{Method => OriginalMethod}
 import io.shiftleft.semanticcpg.language.types.expressions.{Call => OriginalCall}
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{LineNumberAccessors, LineNumberEndAccessors, NameAccessors}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.{FullNameAccessors, LineNumberAccessors, LineNumberEndAccessors, NameAccessors}
 
 /**
   Language for traversing the code property graph
@@ -133,6 +133,9 @@ package object language {
 
   implicit def toNameAccessors[A <: StoredNode with HasName](steps: Steps[A]): NameAccessors[A] =
     new NameAccessors(steps)
+
+  implicit def toFullNameAccessors[A <: StoredNode with HasFullName](steps: Steps[A]): FullNameAccessors[A] =
+    new FullNameAccessors(steps)
 
   implicit class GremlinScalaDeco[End](raw: GremlinScala[End]) {
     /* in some cases we cannot statically determine the type of the node, e.g. when traversing

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -14,7 +14,6 @@ import io.shiftleft.semanticcpg.language.types.structure.{Member, Method, Method
   */
 class Call(raw: GremlinScala[nodes.Call])
     extends NodeSteps[nodes.Call](raw)
-    with CodeAccessors[nodes.Call]
     with EvalTypeAccessors[nodes.Call]
     with ExpressionBase[nodes.Call] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -15,7 +15,6 @@ import io.shiftleft.semanticcpg.language.types.structure.{Member, Method, Method
 class Call(raw: GremlinScala[nodes.Call])
     extends NodeSteps[nodes.Call](raw)
     with CodeAccessors[nodes.Call]
-    with SignatureAccessors[nodes.Call]
     with DispatchTypeAccessors[nodes.Call]
     with EvalTypeAccessors[nodes.Call]
     with ExpressionBase[nodes.Call] {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -15,7 +15,6 @@ import io.shiftleft.semanticcpg.language.types.structure.{Member, Method, Method
 class Call(raw: GremlinScala[nodes.Call])
     extends NodeSteps[nodes.Call](raw)
     with CodeAccessors[nodes.Call]
-    with OrderAccessors[nodes.Call]
     with SignatureAccessors[nodes.Call]
     with DispatchTypeAccessors[nodes.Call]
     with EvalTypeAccessors[nodes.Call]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -19,7 +19,6 @@ class Call(raw: GremlinScala[nodes.Call])
     with OrderAccessors[nodes.Call]
     with SignatureAccessors[nodes.Call]
     with DispatchTypeAccessors[nodes.Call]
-    with LineNumberAccessors[nodes.Call]
     with EvalTypeAccessors[nodes.Call]
     with ExpressionBase[nodes.Call] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -15,7 +15,6 @@ import io.shiftleft.semanticcpg.language.types.structure.{Member, Method, Method
 class Call(raw: GremlinScala[nodes.Call])
     extends NodeSteps[nodes.Call](raw)
     with CodeAccessors[nodes.Call]
-    with NameAccessors[nodes.Call]
     with OrderAccessors[nodes.Call]
     with SignatureAccessors[nodes.Call]
     with DispatchTypeAccessors[nodes.Call]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -15,19 +15,20 @@ import io.shiftleft.semanticcpg.language.types.structure.{Member, Method, Method
 class Call(raw: GremlinScala[nodes.Call])
     extends NodeSteps[nodes.Call](raw)
     with CodeAccessors[nodes.Call]
-    with DispatchTypeAccessors[nodes.Call]
     with EvalTypeAccessors[nodes.Call]
     with ExpressionBase[nodes.Call] {
 
   /**
     Only statically dispatched calls
     */
-  def isStatic: Call = dispatchType("STATIC_DISPATCH")
+  def isStatic: Call =
+    this.dispatchType("STATIC_DISPATCH")
 
   /**
     Only dynamically dispatched calls
     */
-  def isDynamic: Call = dispatchType("DYNAMIC_DISPATCH")
+  def isDynamic: Call =
+    this.dispatchType("DYNAMIC_DISPATCH")
 
   /**
     The caller

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
@@ -3,7 +3,6 @@ package io.shiftleft.semanticcpg.language.types.expressions
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{AstNode, Expression, ExpressionBase}
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.ParserTypeNameAccessors
 import io.shiftleft.semanticcpg.language._
 
 object ControlStructure {
@@ -15,7 +14,6 @@ object ControlStructure {
 
 class ControlStructure(raw: GremlinScala[nodes.ControlStructure])
     extends NodeSteps[nodes.ControlStructure](raw)
-    with ParserTypeNameAccessors[nodes.ControlStructure]
     with ExpressionBase[nodes.ControlStructure] {
 
   import ControlStructure._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
@@ -14,7 +14,6 @@ class Identifier(raw: GremlinScala[nodes.Identifier])
     extends NodeSteps[nodes.Identifier](raw)
     with ExpressionBase[nodes.Identifier]
     with CodeAccessors[nodes.Identifier]
-    with NameAccessors[nodes.Identifier]
     with OrderAccessors[nodes.Identifier]
     with EvalTypeAccessors[nodes.Identifier] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
@@ -13,7 +13,6 @@ import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 class Identifier(raw: GremlinScala[nodes.Identifier])
     extends NodeSteps[nodes.Identifier](raw)
     with ExpressionBase[nodes.Identifier]
-    with CodeAccessors[nodes.Identifier]
     with EvalTypeAccessors[nodes.Identifier] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
@@ -16,7 +16,6 @@ class Identifier(raw: GremlinScala[nodes.Identifier])
     with CodeAccessors[nodes.Identifier]
     with NameAccessors[nodes.Identifier]
     with OrderAccessors[nodes.Identifier]
-    with LineNumberAccessors[nodes.Identifier]
     with EvalTypeAccessors[nodes.Identifier] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Identifier.scala
@@ -14,7 +14,6 @@ class Identifier(raw: GremlinScala[nodes.Identifier])
     extends NodeSteps[nodes.Identifier](raw)
     with ExpressionBase[nodes.Identifier]
     with CodeAccessors[nodes.Identifier]
-    with OrderAccessors[nodes.Identifier]
     with EvalTypeAccessors[nodes.Identifier] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
@@ -13,7 +13,6 @@ import io.shiftleft.semanticcpg.language.types.structure.Method
 class Literal(raw: GremlinScala[nodes.Literal])
     extends NodeSteps[nodes.Literal](raw)
     with ExpressionBase[nodes.Literal]
-    with CodeAccessors[nodes.Literal]
     with EvalTypeAccessors[nodes.Literal] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
@@ -14,7 +14,6 @@ class Literal(raw: GremlinScala[nodes.Literal])
     extends NodeSteps[nodes.Literal](raw)
     with ExpressionBase[nodes.Literal]
     with CodeAccessors[nodes.Literal]
-    with LineNumberAccessors[nodes.Literal]
     with EvalTypeAccessors[nodes.Literal] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRef.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRef.scala
@@ -4,13 +4,11 @@ import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.ExpressionBase
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.LineNumberAccessors
 import io.shiftleft.semanticcpg.language.types.structure.Method
 
 class MethodRef(raw: GremlinScala[nodes.MethodRef])
     extends NodeSteps[nodes.MethodRef](raw)
-    with ExpressionBase[nodes.MethodRef]
-    with LineNumberAccessors[nodes.MethodRef] {
+    with ExpressionBase[nodes.MethodRef] {
 
   /**
     * Traverse to referenced method.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Return.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Return.scala
@@ -7,7 +7,6 @@ import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expre
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
   ArgumentIndexAccessors,
   CodeAccessors,
-  OrderAccessors
 }
 
 // TODO: ColumnNumberAccessor missing
@@ -15,6 +14,5 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
 class Return(raw: GremlinScala[nodes.Return])
     extends NodeSteps[nodes.Return](raw)
     with ExpressionBase[nodes.Return]
-    with OrderAccessors[nodes.Return]
     with ArgumentIndexAccessors[nodes.Return]
     with CodeAccessors[nodes.Return] {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Return.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Return.scala
@@ -4,15 +4,11 @@ import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.ExpressionBase
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
-  ArgumentIndexAccessors,
-  CodeAccessors,
-}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.ArgumentIndexAccessors
 
 // TODO: ColumnNumberAccessor missing
 
 class Return(raw: GremlinScala[nodes.Return])
     extends NodeSteps[nodes.Return](raw)
     with ExpressionBase[nodes.Return]
-    with ArgumentIndexAccessors[nodes.Return]
-    with CodeAccessors[nodes.Return] {}
+    with ArgumentIndexAccessors[nodes.Return] {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Return.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Return.scala
@@ -7,7 +7,6 @@ import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expre
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
   ArgumentIndexAccessors,
   CodeAccessors,
-  LineNumberAccessors,
   OrderAccessors
 }
 
@@ -16,7 +15,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
 class Return(raw: GremlinScala[nodes.Return])
     extends NodeSteps[nodes.Return](raw)
     with ExpressionBase[nodes.Return]
-    with LineNumberAccessors[nodes.Return]
     with OrderAccessors[nodes.Return]
     with ArgumentIndexAccessors[nodes.Return]
     with CodeAccessors[nodes.Return] {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -7,9 +7,7 @@ import io.shiftleft.semanticcpg.language.types.structure.Block
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions._
 
-class AstNode(raw: GremlinScala[nodes.AstNode])
-    extends NodeSteps[nodes.AstNode](raw)
-    with AstNodeBase[nodes.AstNode]
+class AstNode(raw: GremlinScala[nodes.AstNode]) extends NodeSteps[nodes.AstNode](raw) with AstNodeBase[nodes.AstNode]
 
 trait AstNodeBase[NodeType <: nodes.AstNode] { this: NodeSteps[NodeType] =>
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -6,12 +6,10 @@ import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language.types.structure.Block
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions._
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.OrderAccessors
 
 class AstNode(raw: GremlinScala[nodes.AstNode])
     extends NodeSteps[nodes.AstNode](raw)
     with AstNodeBase[nodes.AstNode]
-    with OrderAccessors[nodes.AstNode]
 
 trait AstNodeBase[NodeType <: nodes.AstNode] { this: NodeSteps[NodeType] =>
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -3,14 +3,10 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.CodeAccessors
 import io.shiftleft.semanticcpg.language.types.structure.Method
 import io.shiftleft.semanticcpg.utils.ExpandTo
 
-class CfgNode(raw: GremlinScala[nodes.CfgNode])
-    extends NodeSteps[nodes.CfgNode](raw)
-    with CodeAccessors[nodes.CfgNode]
-    with AstNodeBase[nodes.CfgNode] {
+class CfgNode(raw: GremlinScala[nodes.CfgNode]) extends NodeSteps[nodes.CfgNode](raw) with AstNodeBase[nodes.CfgNode] {
 
   /**
   Traverse to enclosing method

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -18,7 +18,6 @@ class Expression(raw: GremlinScala[nodes.Expression])
 trait ExpressionBase[NodeType <: nodes.Expression]
     extends ArgumentIndexAccessors[NodeType]
     with EvalTypeAccessors[NodeType]
-    with CodeAccessors[NodeType]
     with AstNodeBase[NodeType] { this: NodeSteps[NodeType] =>
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -16,8 +16,7 @@ class Expression(raw: GremlinScala[nodes.Expression])
     with ExpressionBase[nodes.Expression] {}
 
 trait ExpressionBase[NodeType <: nodes.Expression]
-    extends OrderAccessors[NodeType]
-    with ArgumentIndexAccessors[NodeType]
+    extends ArgumentIndexAccessors[NodeType]
     with EvalTypeAccessors[NodeType]
     with CodeAccessors[NodeType]
     with AstNodeBase[NodeType] { this: NodeSteps[NodeType] =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -20,7 +20,6 @@ trait ExpressionBase[NodeType <: nodes.Expression]
     with ArgumentIndexAccessors[NodeType]
     with EvalTypeAccessors[NodeType]
     with CodeAccessors[NodeType]
-    with LineNumberAccessors[NodeType]
     with AstNodeBase[NodeType] { this: NodeSteps[NodeType] =>
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/CodeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/CodeAccessors.scala
@@ -1,29 +1,32 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait CodeAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class CodeAccessors[A <: StoredNode](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
+
   def code(): Steps[String] =
     stringProperty(NodeKeys.CODE)
 
-  def code(value: String): NodeSteps[T] =
+  def code(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.CODE, value)
 
-  def code(value: String*): NodeSteps[T] =
+  def code(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.CODE, value: _*)
 
-  def codeExact(value: String): NodeSteps[T] =
+  def codeExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.CODE, value)
 
-  def codeExact(values: String*): NodeSteps[T] =
+  def codeExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.CODE, values: _*)
 
-  def codeNot(value: String): NodeSteps[T] =
+  def codeNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.CODE, value)
 
-  def codeNot(values: String*): NodeSteps[T] =
+  def codeNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.CODE, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DependencyGroupIdAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DependencyGroupIdAccessors.scala
@@ -1,28 +1,31 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasDependencyGroupId, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait DependencyGroupIdAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class DependencyGroupIdAccessors[A <: StoredNode with HasDependencyGroupId](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
+
   def dependencyGroupId(): Steps[String] =
     stringProperty(NodeKeys.DEPENDENCY_GROUP_ID)
 
-  def dependencyGroupId(value: String): NodeSteps[T] =
+  def dependencyGroupId(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.DEPENDENCY_GROUP_ID, value)
 
-  def dependencyGroupId(value: String*): NodeSteps[T] =
+  def dependencyGroupId(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.DEPENDENCY_GROUP_ID, value: _*)
 
-  def dependencyGroupIdExact(value: String): NodeSteps[T] =
+  def dependencyGroupIdExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.DEPENDENCY_GROUP_ID, value)
 
-  def dependencyGroupIdExact(values: String*): NodeSteps[T] =
+  def dependencyGroupIdExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.DEPENDENCY_GROUP_ID, values: _*)
 
-  def dependencyGroupIdNot(value: String): NodeSteps[T] =
+  def dependencyGroupIdNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.DEPENDENCY_GROUP_ID, value)
 
-  def dependencyGroupIdNot(values: String*): NodeSteps[T] =
+  def dependencyGroupIdNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.DEPENDENCY_GROUP_ID, values: _*)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DependencyGroupIdAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DependencyGroupIdAccessors.scala
@@ -5,7 +5,8 @@ import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.{HasDependencyGroupId, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-class DependencyGroupIdAccessors[A <: StoredNode with HasDependencyGroupId](steps: Steps[A]) extends StringPropertyAccessors[A] {
+class DependencyGroupIdAccessors[A <: StoredNode with HasDependencyGroupId](steps: Steps[A])
+    extends StringPropertyAccessors[A] {
   override val raw: GremlinScala[A] = steps.raw
 
   def dependencyGroupId(): Steps[String] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DispatchTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/DispatchTypeAccessors.scala
@@ -1,10 +1,12 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasDispatchType, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait DispatchTypeAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class DispatchTypeAccessors[A <: StoredNode with HasDispatchType](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
 
   /**
     * Traverse to dispatchType
@@ -15,37 +17,37 @@ trait DispatchTypeAccessors[T <: StoredNode] extends StringPropertyAccessors[T] 
   /**
     * Traverse to nodes where the dispatchType matches the regular expression `value`
     * */
-  def dispatchType(value: String): NodeSteps[T] =
+  def dispatchType(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.DISPATCH_TYPE, value)
 
   /**
     * Traverse to nodes where the dispatchType matches at least one of the regular expressions in `values`
     * */
-  def dispatchType(value: String*): NodeSteps[T] =
+  def dispatchType(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.DISPATCH_TYPE, value: _*)
 
   /**
     * Traverse to nodes where dispatchType matches `value` exactly.
     * */
-  def dispatchTypeExact(value: String): NodeSteps[T] =
+  def dispatchTypeExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.DISPATCH_TYPE, value)
 
   /**
     * Traverse to nodes where dispatchType matches one of the elements in `values` exactly.
     * */
-  def dispatchTypeExact(values: String*): NodeSteps[T] =
+  def dispatchTypeExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.DISPATCH_TYPE, values: _*)
 
   /**
     * Traverse to nodes where dispatchType does not match the regular expression `value`.
     * */
-  def dispatchTypeNot(value: String): NodeSteps[T] =
+  def dispatchTypeNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.DISPATCH_TYPE, value)
 
   /**
     * Traverse to nodes where dispatchType does not match any of the regular expressions in `values`.
     * */
-  def dispatchTypeNot(values: String*): NodeSteps[T] =
+  def dispatchTypeNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.DISPATCH_TYPE, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/FullNameAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/FullNameAccessors.scala
@@ -1,29 +1,31 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasFullName, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait FullNameAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class FullNameAccessors[A <: StoredNode with HasFullName](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
+
   def fullName(): Steps[String] =
     stringProperty(NodeKeys.FULL_NAME)
 
-  def fullName(value: String): NodeSteps[T] =
+  def fullName(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.FULL_NAME, value)
 
-  def fullName(value: String*): NodeSteps[T] =
+  def fullName(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.FULL_NAME, value: _*)
 
-  def fullNameExact(value: String): NodeSteps[T] =
+  def fullNameExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.FULL_NAME, value)
 
-  def fullNameExact(values: String*): NodeSteps[T] =
+  def fullNameExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.FULL_NAME, values: _*)
 
-  def fullNameNot(value: String): NodeSteps[T] =
+  def fullNameNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.FULL_NAME, value)
 
-  def fullNameNot(values: String*): NodeSteps[T] =
+  def fullNameNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.FULL_NAME, values: _*)
-
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/IsExternalAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/IsExternalAccessors.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasIsExternal, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 import java.lang.{Boolean => JBoolean}
 
 import gremlin.scala.GremlinScala
 
-class IsExternalAccessors[A <: StoredNode](steps: Steps[A]) extends PropertyAccessors[A] {
+class IsExternalAccessors[A <: StoredNode with HasIsExternal](steps: Steps[A]) extends PropertyAccessors[A] {
   override val raw: GremlinScala[A] = steps.raw
 
   def isExternal(): Steps[JBoolean] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/IsExternalAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/IsExternalAccessors.scala
@@ -5,20 +5,24 @@ import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 import java.lang.{Boolean => JBoolean}
 
-trait IsExternalAccessors[T <: StoredNode] extends PropertyAccessors[T] {
+import gremlin.scala.GremlinScala
+
+class IsExternalAccessors[A <: StoredNode](steps: Steps[A]) extends PropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
+
   def isExternal(): Steps[JBoolean] =
     property(NodeKeys.IS_EXTERNAL)
 
-  def isExternal(value: JBoolean): NodeSteps[T] =
+  def isExternal(value: JBoolean): NodeSteps[A] =
     propertyFilter(NodeKeys.IS_EXTERNAL, value)
 
-  def isExternal(value: JBoolean*): NodeSteps[T] =
+  def isExternal(value: JBoolean*): NodeSteps[A] =
     propertyFilterMultiple(NodeKeys.IS_EXTERNAL, value: _*)
 
-  def isExternalNot(value: JBoolean): NodeSteps[T] =
+  def isExternalNot(value: JBoolean): NodeSteps[A] =
     propertyFilterNot(NodeKeys.IS_EXTERNAL, value)
 
-  def isExternalNot(values: JBoolean*): NodeSteps[T] =
+  def isExternalNot(values: JBoolean*): NodeSteps[A] =
     propertyFilterNotMultiple(NodeKeys.IS_EXTERNAL, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/LineNumberAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/LineNumberAccessors.scala
@@ -1,23 +1,26 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasLineNumber, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait LineNumberAccessors[T <: StoredNode] extends PropertyAccessors[T] {
+class LineNumberAccessors[A <: StoredNode with HasLineNumber](steps: Steps[A]) extends PropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
+
   def lineNumber(): Steps[Integer] =
     property(NodeKeys.LINE_NUMBER)
 
-  def lineNumber(value: Integer): NodeSteps[T] =
+  def lineNumber(value: Integer): NodeSteps[A] =
     propertyFilter(NodeKeys.LINE_NUMBER, value)
 
-  def lineNumber(value: Integer*): NodeSteps[T] =
+  def lineNumber(value: Integer*): NodeSteps[A] =
     propertyFilterMultiple(NodeKeys.LINE_NUMBER, value: _*)
 
-  def lineNumberNot(value: Integer): NodeSteps[T] =
+  def lineNumberNot(value: Integer): NodeSteps[A] =
     propertyFilterNot(NodeKeys.LINE_NUMBER, value)
 
-  def lineNumberNot(values: Integer*): NodeSteps[T] =
+  def lineNumberNot(values: Integer*): NodeSteps[A] =
     propertyFilterNotMultiple(NodeKeys.LINE_NUMBER, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/LineNumberEndAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/LineNumberEndAccessors.scala
@@ -1,24 +1,26 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasLineNumberEnd, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait LineNumberEndAccessors[T <: StoredNode] extends PropertyAccessors[T] {
+class LineNumberEndAccessors[A <: StoredNode with HasLineNumberEnd](steps: Steps[A]) extends PropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
 
   def lineNumberEnd(): Steps[Integer] =
     property(NodeKeys.LINE_NUMBER_END)
 
-  def lineNumberEnd(value: Integer): NodeSteps[T] =
+  def lineNumberEnd(value: Integer): NodeSteps[A] =
     propertyFilter(NodeKeys.LINE_NUMBER_END, value)
 
-  def lineNumberEnd(value: Integer*): NodeSteps[T] =
+  def lineNumberEnd(value: Integer*): NodeSteps[A] =
     propertyFilterMultiple(NodeKeys.LINE_NUMBER_END, value: _*)
 
-  def lineNumberEndNot(value: Integer): NodeSteps[T] =
+  def lineNumberEndNot(value: Integer): NodeSteps[A] =
     propertyFilterNot(NodeKeys.LINE_NUMBER_END, value)
 
-  def lineNumberEndNot(values: Integer*): NodeSteps[T] =
+  def lineNumberEndNot(values: Integer*): NodeSteps[A] =
     propertyFilterNotMultiple(NodeKeys.LINE_NUMBER_END, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/NameAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/NameAccessors.scala
@@ -1,10 +1,12 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasName, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait NameAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class NameAccessors[A <: StoredNode with HasName](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
 
   /**
     * Traverse to name
@@ -15,37 +17,37 @@ trait NameAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
   /**
     * Traverse to nodes where the name matches the regular expression `value`
     * */
-  def name(value: String): NodeSteps[T] =
+  def name(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.NAME, value)
 
   /**
     * Traverse to nodes where the name matches at least one of the regular expressions in `values`
     * */
-  def name(value: String*): NodeSteps[T] =
+  def name(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.NAME, value: _*)
 
   /**
     * Traverse to nodes where name matches `value` exactly.
     * */
-  def nameExact(value: String): NodeSteps[T] =
+  def nameExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.NAME, value)
 
   /**
     * Traverse to nodes where name matches one of the elements in `values` exactly.
     * */
-  def nameExact(values: String*): NodeSteps[T] =
+  def nameExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.NAME, values: _*)
 
   /**
     * Traverse to nodes where name does not match the regular expression `value`.
     * */
-  def nameNot(value: String): NodeSteps[T] =
+  def nameNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.NAME, value)
 
   /**
     * Traverse to nodes where name does not match any of the regular expressions in `values`.
     * */
-  def nameNot(values: String*): NodeSteps[T] =
+  def nameNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.NAME, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/OrderAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/OrderAccessors.scala
@@ -1,22 +1,25 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasOrder, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait OrderAccessors[T <: StoredNode] extends PropertyAccessors[T] {
+class OrderAccessors[A <: StoredNode with HasOrder](steps: Steps[A]) extends PropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
+
   def order(): Steps[Integer] =
     property(NodeKeys.ORDER)
 
-  def order(value: Integer): NodeSteps[T] =
+  def order(value: Integer): NodeSteps[A] =
     propertyFilter(NodeKeys.ORDER, value)
 
-  def order(value: Integer*): NodeSteps[T] =
+  def order(value: Integer*): NodeSteps[A] =
     propertyFilterMultiple(NodeKeys.ORDER, value: _*)
 
-  def orderNot(value: Integer): NodeSteps[T] =
+  def orderNot(value: Integer): NodeSteps[A] =
     propertyFilterNot(NodeKeys.ORDER, value)
 
-  def orderNot(values: Integer*): NodeSteps[T] =
+  def orderNot(values: Integer*): NodeSteps[A] =
     propertyFilterNotMultiple(NodeKeys.ORDER, values: _*)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ParserTypeNameAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ParserTypeNameAccessors.scala
@@ -1,30 +1,32 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasParserTypeName, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait ParserTypeNameAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class ParserTypeNameAccessors[A <: StoredNode with HasParserTypeName](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
 
   def parserTypeName(): Steps[String] =
     stringProperty(NodeKeys.PARSER_TYPE_NAME)
 
-  def parserTypeName(value: String): NodeSteps[T] =
+  def parserTypeName(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.PARSER_TYPE_NAME, value)
 
-  def parserTypeName(value: String*): NodeSteps[T] =
+  def parserTypeName(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.PARSER_TYPE_NAME, value: _*)
 
-  def parserTypeNameExact(value: String): NodeSteps[T] =
+  def parserTypeNameExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.PARSER_TYPE_NAME, value)
 
-  def parserTypeNameExact(values: String*): NodeSteps[T] =
+  def parserTypeNameExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.PARSER_TYPE_NAME, values: _*)
 
-  def parserTypeNameNot(value: String): NodeSteps[T] =
+  def parserTypeNameNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.PARSER_TYPE_NAME, value)
 
-  def parserTypeNameNot(values: String*): NodeSteps[T] =
+  def parserTypeNameNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.PARSER_TYPE_NAME, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ParserTypeNameAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ParserTypeNameAccessors.scala
@@ -5,7 +5,8 @@ import io.shiftleft.codepropertygraph.generated.NodeKeys
 import io.shiftleft.codepropertygraph.generated.nodes.{HasParserTypeName, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-class ParserTypeNameAccessors[A <: StoredNode with HasParserTypeName](steps: Steps[A]) extends StringPropertyAccessors[A] {
+class ParserTypeNameAccessors[A <: StoredNode with HasParserTypeName](steps: Steps[A])
+    extends StringPropertyAccessors[A] {
   override val raw: GremlinScala[A] = steps.raw
 
   def parserTypeName(): Steps[String] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/PropertyAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/PropertyAccessors.scala
@@ -4,33 +4,33 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait PropertyAccessors[T <: StoredNode] {
-  val raw: GremlinScala[T]
+trait PropertyAccessors[A <: StoredNode] {
+  def raw: GremlinScala[A]
 
   def property[P](property: Key[P]): Steps[P] =
     new Steps[P](raw.value(property))
 
-  def propertyFilter[Out, P](property: Key[P], value: P): NodeSteps[T] =
-    new NodeSteps[T](raw.has(property, value))
+  def propertyFilter[Out, P](property: Key[P], value: P): NodeSteps[A] =
+    new NodeSteps[A](raw.has(property, value))
 
-  def propertyFilterMultiple[Out, P](property: Key[P], values: P*): NodeSteps[T] =
+  def propertyFilterMultiple[Out, P](property: Key[P], values: P*): NodeSteps[A] =
     if (values.nonEmpty) {
-      new NodeSteps[T](raw.or(values.map { value => (trav: GremlinScala[T]) =>
+      new NodeSteps[A](raw.or(values.map { value => (trav: GremlinScala[A]) =>
         trav.has(property, value)
       }: _*))
     } else {
-      new NodeSteps[T](raw.filterOnEnd(_ => false))
+      new NodeSteps[A](raw.filterOnEnd(_ => false))
     }
 
-  def propertyFilterNot[Out, P](property: Key[P], value: P): NodeSteps[T] =
-    new NodeSteps[T](raw.hasNot(property, value))
+  def propertyFilterNot[Out, P](property: Key[P], value: P): NodeSteps[A] =
+    new NodeSteps[A](raw.hasNot(property, value))
 
-  def propertyFilterNotMultiple[Out, P](property: Key[P], values: P*): NodeSteps[T] =
+  def propertyFilterNotMultiple[Out, P](property: Key[P], values: P*): NodeSteps[A] =
     if (values.nonEmpty) {
-      new NodeSteps[T](raw.or(values.map { value => (trav: GremlinScala[T]) =>
+      new NodeSteps[A](raw.or(values.map { value => (trav: GremlinScala[A]) =>
         trav.hasNot(property, value)
       }: _*))
     } else {
-      new NodeSteps[T](raw)
+      new NodeSteps[A](raw)
     }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/SignatureAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/SignatureAccessors.scala
@@ -1,10 +1,12 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasSignature, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait SignatureAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class SignatureAccessors[A <: StoredNode with HasSignature](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
 
   /**
     * Traverse to signature
@@ -15,37 +17,37 @@ trait SignatureAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
   /**
     * Traverse to nodes where the signature matches the regular expression `value`
     * */
-  def signature(value: String): NodeSteps[T] =
+  def signature(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.SIGNATURE, value)
 
   /**
     * Traverse to nodes where the signature matches at least one of the regular expressions in `values`
     * */
-  def signature(value: String*): NodeSteps[T] =
+  def signature(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.SIGNATURE, value: _*)
 
   /**
     * Traverse to nodes where signature matches `value` exactly.
     * */
-  def signatureExact(value: String): NodeSteps[T] =
+  def signatureExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.SIGNATURE, value)
 
   /**
     * Traverse to nodes where signature matches one of the elements in `values` exactly.
     * */
-  def signatureExact(values: String*): NodeSteps[T] =
+  def signatureExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.SIGNATURE, values: _*)
 
   /**
     * Traverse to nodes where signature does not match the regular expression `value`.
     * */
-  def signatureNot(value: String): NodeSteps[T] =
+  def signatureNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.SIGNATURE, value)
 
   /**
     * Traverse to nodes where signature does not match any of the regular expressions in `values`.
     * */
-  def signatureNot(values: String*): NodeSteps[T] =
+  def signatureNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.SIGNATURE, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ValueAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ValueAccessors.scala
@@ -1,29 +1,32 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasValue, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait ValueAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class ValueAccessors[A <: StoredNode with HasValue](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
+
   def value(): Steps[String] =
     stringProperty(NodeKeys.VALUE)
 
-  def value(value: String): NodeSteps[T] =
+  def value(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.VALUE, value)
 
-  def value(value: String*): NodeSteps[T] =
+  def value(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.VALUE, value: _*)
 
-  def valueExact(value: String): NodeSteps[T] =
+  def valueExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.VALUE, value)
 
-  def valueExact(values: String*): NodeSteps[T] =
+  def valueExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.VALUE, values: _*)
 
-  def valueNot(value: String): NodeSteps[T] =
+  def valueNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.VALUE, value)
 
-  def valueNot(values: String*): NodeSteps[T] =
+  def valueNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.VALUE, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/VersionAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/VersionAccessors.scala
@@ -1,29 +1,32 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.nodes.{HasVersion, StoredNode}
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
-trait VersionAccessors[T <: StoredNode] extends StringPropertyAccessors[T] {
+class VersionAccessors[A <: StoredNode with HasVersion](steps: Steps[A]) extends StringPropertyAccessors[A] {
+  override val raw: GremlinScala[A] = steps.raw
+
   def version(): Steps[String] =
     stringProperty(NodeKeys.VERSION)
 
-  def version(value: String): NodeSteps[T] =
+  def version(value: String): NodeSteps[A] =
     stringPropertyFilter(NodeKeys.VERSION, value)
 
-  def version(value: String*): NodeSteps[T] =
+  def version(value: String*): NodeSteps[A] =
     stringPropertyFilterMultiple(NodeKeys.VERSION, value: _*)
 
-  def versionExact(value: String): NodeSteps[T] =
+  def versionExact(value: String): NodeSteps[A] =
     stringPropertyFilterExact(NodeKeys.VERSION, value)
 
-  def versionExact(values: String*): NodeSteps[T] =
+  def versionExact(values: String*): NodeSteps[A] =
     stringPropertyFilterExactMultiple(NodeKeys.VERSION, values: _*)
 
-  def versionNot(value: String): NodeSteps[T] =
+  def versionNot(value: String): NodeSteps[A] =
     stringPropertyFilterNot(NodeKeys.VERSION, value)
 
-  def versionNot(values: String*): NodeSteps[T] =
+  def versionNot(values: String*): NodeSteps[A] =
     stringPropertyFilterNotMultiple(NodeKeys.VERSION, values: _*)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Binding.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Binding.scala
@@ -3,11 +3,8 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{NameAccessors, SignatureAccessors}
 
-class Binding(raw: GremlinScala[nodes.Binding])
-    extends NodeSteps[nodes.Binding](raw)
-    with SignatureAccessors[nodes.Binding] {
+class Binding(raw: GremlinScala[nodes.Binding]) extends NodeSteps[nodes.Binding](raw) {
 
   /**
     * Traverse to the method bound by this method binding.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Binding.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Binding.scala
@@ -7,7 +7,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors.{NameAccessors,
 
 class Binding(raw: GremlinScala[nodes.Binding])
     extends NodeSteps[nodes.Binding](raw)
-    with NameAccessors[nodes.Binding]
     with SignatureAccessors[nodes.Binding] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Comment.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Comment.scala
@@ -2,12 +2,9 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{CodeAccessors, LineNumberAccessors}
 import io.shiftleft.semanticcpg.language._
 
-class Comment(raw: GremlinScala[nodes.Comment])
-    extends NodeSteps[nodes.Comment](raw)
-    with CodeAccessors[nodes.Comment] {
+class Comment(raw: GremlinScala[nodes.Comment]) extends NodeSteps[nodes.Comment](raw) {
 
   override def file: File =
     new File(raw.in(EdgeTypes.AST).hasLabel(NodeTypes.FILE).cast[nodes.File])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Comment.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Comment.scala
@@ -7,7 +7,6 @@ import io.shiftleft.semanticcpg.language._
 
 class Comment(raw: GremlinScala[nodes.Comment])
     extends NodeSteps[nodes.Comment](raw)
-    with LineNumberAccessors[nodes.Comment]
     with CodeAccessors[nodes.Comment] {
 
   override def file: File =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/File.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/File.scala
@@ -4,12 +4,11 @@ import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.NameAccessors
 
 /**
   * A compilation unit
   * */
-class File(raw: GremlinScala[nodes.File]) extends NodeSteps[nodes.File](raw) with NameAccessors[nodes.File] {
+class File(raw: GremlinScala[nodes.File]) extends NodeSteps[nodes.File](raw) {
 
   def typeDecl: TypeDecl =
     new TypeDecl(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -14,7 +14,6 @@ class Local(raw: GremlinScala[nodes.Local])
     extends NodeSteps[nodes.Local](raw)
     with DeclarationBase[nodes.Local]
     with CodeAccessors[nodes.Local]
-    with NameAccessors[nodes.Local]
     with OrderAccessors[nodes.Local]
     with EvalTypeAccessors[nodes.Local] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -14,7 +14,6 @@ class Local(raw: GremlinScala[nodes.Local])
     extends NodeSteps[nodes.Local](raw)
     with DeclarationBase[nodes.Local]
     with CodeAccessors[nodes.Local]
-    with OrderAccessors[nodes.Local]
     with EvalTypeAccessors[nodes.Local] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -16,7 +16,6 @@ class Local(raw: GremlinScala[nodes.Local])
     with CodeAccessors[nodes.Local]
     with NameAccessors[nodes.Local]
     with OrderAccessors[nodes.Local]
-    with LineNumberAccessors[nodes.Local]
     with EvalTypeAccessors[nodes.Local] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -13,7 +13,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 class Local(raw: GremlinScala[nodes.Local])
     extends NodeSteps[nodes.Local](raw)
     with DeclarationBase[nodes.Local]
-    with CodeAccessors[nodes.Local]
     with EvalTypeAccessors[nodes.Local] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
@@ -9,8 +9,7 @@ import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Decla
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
   CodeAccessors,
   EvalTypeAccessors,
-  ModifierAccessors,
-  NameAccessors
+  ModifierAccessors
 }
 
 /**
@@ -20,7 +19,6 @@ class Member(raw: GremlinScala[nodes.Member])
     extends NodeSteps[nodes.Member](raw)
     with DeclarationBase[nodes.Member]
     with CodeAccessors[nodes.Member]
-    with NameAccessors[nodes.Member]
     with EvalTypeAccessors[nodes.Member]
     with ModifierAccessors[nodes.Member] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
@@ -6,11 +6,7 @@ import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.Call
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.DeclarationBase
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
-  CodeAccessors,
-  EvalTypeAccessors,
-  ModifierAccessors
-}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.{EvalTypeAccessors, ModifierAccessors}
 
 /**
   * A member variable of a class/type.
@@ -18,7 +14,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
 class Member(raw: GremlinScala[nodes.Member])
     extends NodeSteps[nodes.Member](raw)
     with DeclarationBase[nodes.Member]
-    with CodeAccessors[nodes.Member]
     with EvalTypeAccessors[nodes.Member]
     with ModifierAccessors[nodes.Member] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MetaData.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MetaData.scala
@@ -3,14 +3,11 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.NodeSteps
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.VersionAccessors
 
 /**
   * A meta data entry
   * */
-class MetaData(raw: GremlinScala[nodes.MetaData])
-    extends NodeSteps[nodes.MetaData](raw)
-    with VersionAccessors[nodes.MetaData] {
+class MetaData(raw: GremlinScala[nodes.MetaData]) extends NodeSteps[nodes.MetaData](raw) {
 
   /**
     * Returns the programming language of the code for which this CPG was

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -23,7 +23,6 @@ class Method(override val raw: GremlinScala[nodes.Method])
     with FullNameAccessors[nodes.Method]
     with SignatureAccessors[nodes.Method]
     with LineNumberAccessors[nodes.Method]
-    with LineNumberEndAccessors[nodes.Method]
     with EvalTypeAccessors[nodes.Method]
     with AstNodeBase[nodes.Method]
     with ModifierAccessors[nodes.Method] {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -19,7 +19,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 class Method(override val raw: GremlinScala[nodes.Method])
     extends NodeSteps[nodes.Method](raw)
     with DeclarationBase[nodes.Method]
-    with FullNameAccessors[nodes.Method]
     with SignatureAccessors[nodes.Method]
     with EvalTypeAccessors[nodes.Method]
     with AstNodeBase[nodes.Method]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -19,7 +19,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 class Method(override val raw: GremlinScala[nodes.Method])
     extends NodeSteps[nodes.Method](raw)
     with DeclarationBase[nodes.Method]
-    with NameAccessors[nodes.Method]
     with FullNameAccessors[nodes.Method]
     with SignatureAccessors[nodes.Method]
     with EvalTypeAccessors[nodes.Method]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -19,7 +19,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 class Method(override val raw: GremlinScala[nodes.Method])
     extends NodeSteps[nodes.Method](raw)
     with DeclarationBase[nodes.Method]
-    with SignatureAccessors[nodes.Method]
     with EvalTypeAccessors[nodes.Method]
     with AstNodeBase[nodes.Method]
     with ModifierAccessors[nodes.Method] {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -22,7 +22,6 @@ class Method(override val raw: GremlinScala[nodes.Method])
     with NameAccessors[nodes.Method]
     with FullNameAccessors[nodes.Method]
     with SignatureAccessors[nodes.Method]
-    with LineNumberAccessors[nodes.Method]
     with EvalTypeAccessors[nodes.Method]
     with AstNodeBase[nodes.Method]
     with ModifierAccessors[nodes.Method] {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -16,7 +16,6 @@ class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
     with CodeAccessors[nodes.MethodParameterIn]
     with NameAccessors[nodes.MethodParameterIn]
     with OrderAccessors[nodes.MethodParameterIn]
-    with LineNumberAccessors[nodes.MethodParameterIn]
     with EvalTypeAccessors[nodes.MethodParameterIn] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -14,14 +14,13 @@ class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
     extends NodeSteps[nodes.MethodParameterIn](raw)
     with DeclarationBase[nodes.MethodParameterIn]
     with CodeAccessors[nodes.MethodParameterIn]
-    with OrderAccessors[nodes.MethodParameterIn]
     with EvalTypeAccessors[nodes.MethodParameterIn] {
 
   /**
     * Traverse to all `num`th parameters
     * */
   def index(num: Int): MethodParameter =
-    order(num)
+    this.order(num)
 
   /**
     * Traverse to all parameters with index greater or equal than `num`

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -13,7 +13,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
     extends NodeSteps[nodes.MethodParameterIn](raw)
     with DeclarationBase[nodes.MethodParameterIn]
-    with CodeAccessors[nodes.MethodParameterIn]
     with EvalTypeAccessors[nodes.MethodParameterIn] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -14,7 +14,6 @@ class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
     extends NodeSteps[nodes.MethodParameterIn](raw)
     with DeclarationBase[nodes.MethodParameterIn]
     with CodeAccessors[nodes.MethodParameterIn]
-    with NameAccessors[nodes.MethodParameterIn]
     with OrderAccessors[nodes.MethodParameterIn]
     with EvalTypeAccessors[nodes.MethodParameterIn] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -13,7 +13,6 @@ class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
     with CodeAccessors[nodes.MethodParameterOut]
     with NameAccessors[nodes.MethodParameterOut]
     with OrderAccessors[nodes.MethodParameterOut]
-    with LineNumberAccessors[nodes.MethodParameterOut]
     with EvalTypeAccessors[nodes.MethodParameterOut] {
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -11,7 +11,6 @@ class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
     extends NodeSteps[nodes.MethodParameterOut](raw)
     with DeclarationBase[nodes.MethodParameterOut]
     with CodeAccessors[nodes.MethodParameterOut]
-    with NameAccessors[nodes.MethodParameterOut]
     with OrderAccessors[nodes.MethodParameterOut]
     with EvalTypeAccessors[nodes.MethodParameterOut] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -10,7 +10,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
     extends NodeSteps[nodes.MethodParameterOut](raw)
     with DeclarationBase[nodes.MethodParameterOut]
-    with CodeAccessors[nodes.MethodParameterOut]
     with EvalTypeAccessors[nodes.MethodParameterOut] {
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -11,12 +11,11 @@ class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
     extends NodeSteps[nodes.MethodParameterOut](raw)
     with DeclarationBase[nodes.MethodParameterOut]
     with CodeAccessors[nodes.MethodParameterOut]
-    with OrderAccessors[nodes.MethodParameterOut]
     with EvalTypeAccessors[nodes.MethodParameterOut] {
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def index(num: Int): MethodParameterOut =
-    order(num)
+    this.order(num)
 
   /* get all parameters from (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
@@ -6,12 +6,11 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.Call
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{CodeAccessors, EvalTypeAccessors, LineNumberAccessors}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.{CodeAccessors, EvalTypeAccessors}
 
 class MethodReturn(raw: GremlinScala[nodes.MethodReturn])
     extends NodeSteps[nodes.MethodReturn](raw)
     with CodeAccessors[nodes.MethodReturn]
-    with LineNumberAccessors[nodes.MethodReturn]
     with EvalTypeAccessors[nodes.MethodReturn] {
 
   def method: Method =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
@@ -6,11 +6,10 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.Call
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{CodeAccessors, EvalTypeAccessors}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.EvalTypeAccessors
 
 class MethodReturn(raw: GremlinScala[nodes.MethodReturn])
     extends NodeSteps[nodes.MethodReturn](raw)
-    with CodeAccessors[nodes.MethodReturn]
     with EvalTypeAccessors[nodes.MethodReturn] {
 
   def method: Method =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Namespace.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Namespace.scala
@@ -4,14 +4,11 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.NameAccessors
 
 /**
   * A namespace, e.g., Java package or C# namespace
   * */
-class Namespace(raw: GremlinScala[nodes.Namespace])
-    extends NodeSteps[nodes.Namespace](raw)
-    with NameAccessors[nodes.Namespace] {
+class Namespace(raw: GremlinScala[nodes.Namespace]) extends NodeSteps[nodes.Namespace](raw) {
 
   /**
     * The type declarations defined in this namespace

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
@@ -3,11 +3,8 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.NameAccessors
 
-class NamespaceBlock(raw: GremlinScala[nodes.NamespaceBlock])
-    extends NodeSteps[nodes.NamespaceBlock](raw)
-    with NameAccessors[nodes.NamespaceBlock] {
+class NamespaceBlock(raw: GremlinScala[nodes.NamespaceBlock]) extends NodeSteps[nodes.NamespaceBlock](raw) {
 
   /**
     * Namespaces for namespace blocks.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -5,11 +5,8 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.FullNameAccessors
 
-class Type(raw: GremlinScala[nodes.Type])
-    extends NodeSteps[nodes.Type](raw)
-    with FullNameAccessors[nodes.Type] {
+class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
 
   /**
     * Namespaces in which the corresponding type declaration is defined.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -5,11 +5,10 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{FullNameAccessors, NameAccessors}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.FullNameAccessors
 
 class Type(raw: GremlinScala[nodes.Type])
     extends NodeSteps[nodes.Type](raw)
-    with NameAccessors[nodes.Type]
     with FullNameAccessors[nodes.Type] {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -10,8 +10,9 @@ import org.apache.tinkerpop.gremlin.structure.Direction
 /**
   * Type declaration - possibly a template that requires instantiation
   * */
-class TypeDecl(raw: GremlinScala[nodes.TypeDecl]) extends NodeSteps[nodes.TypeDecl](raw)
-  with ModifierAccessors[nodes.TypeDecl] {
+class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
+    extends NodeSteps[nodes.TypeDecl](raw)
+    with ModifierAccessors[nodes.TypeDecl] {
   import TypeDecl._
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -4,19 +4,14 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
-  IsExternalAccessors,
-  ModifierAccessors,
-}
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.ModifierAccessors
 import org.apache.tinkerpop.gremlin.structure.Direction
 
 /**
   * Type declaration - possibly a template that requires instantiation
   * */
-class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
-    extends NodeSteps[nodes.TypeDecl](raw)
-    with IsExternalAccessors[nodes.TypeDecl]
-    with ModifierAccessors[nodes.TypeDecl] {
+class TypeDecl(raw: GremlinScala[nodes.TypeDecl]) extends NodeSteps[nodes.TypeDecl](raw)
+  with ModifierAccessors[nodes.TypeDecl] {
   import TypeDecl._
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
-  FullNameAccessors,
   IsExternalAccessors,
   ModifierAccessors,
 }
@@ -16,7 +15,6 @@ import org.apache.tinkerpop.gremlin.structure.Direction
   * */
 class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
     extends NodeSteps[nodes.TypeDecl](raw)
-    with FullNameAccessors[nodes.TypeDecl]
     with IsExternalAccessors[nodes.TypeDecl]
     with ModifierAccessors[nodes.TypeDecl] {
   import TypeDecl._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -8,7 +8,6 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors.{
   FullNameAccessors,
   IsExternalAccessors,
   ModifierAccessors,
-  NameAccessors
 }
 import org.apache.tinkerpop.gremlin.structure.Direction
 
@@ -17,7 +16,6 @@ import org.apache.tinkerpop.gremlin.structure.Direction
   * */
 class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
     extends NodeSteps[nodes.TypeDecl](raw)
-    with NameAccessors[nodes.TypeDecl]
     with FullNameAccessors[nodes.TypeDecl]
     with IsExternalAccessors[nodes.TypeDecl]
     with ModifierAccessors[nodes.TypeDecl] {


### PR DESCRIPTION
Going forward (and moving towards overflowdb-traversal) I think it
would simplify matters if we used a single concept to provide
node-specific steps.
The most flexible and commonly used (by us) mechanism is extension via implicit conversion.

To test the waters, this PR only tackles one simple case. Once approved,
I'll roll this out to all PropertyAccessors as well as all base trait
steps (e.g. `generalizations.Expression`).