### PR TITLE
Allow application of enhancements without serialization

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -67,7 +67,13 @@ private class CpgLoader {
   }
 
   def loadFromOverflowDb(config: CpgLoaderConfig = CpgLoaderConfig()): Cpg = {
-    val cpg = new ProtoToCpg(config.overflowDbConfig).build()
+    val odbGraph =
+      OdbGraph.open(
+        config.overflowDbConfig,
+        io.shiftleft.codepropertygraph.generated.nodes.Factories.allAsJava,
+        io.shiftleft.codepropertygraph.generated.edges.Factories.allAsJava
+      )
+    val cpg = Cpg(odbGraph)
     if (config.createIndexes) { createIndexes(cpg) }
     cpg
   }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
@@ -8,9 +8,16 @@ import io.shiftleft.dataflowengine.semanticsloader.Semantics
 
 class DataFlowRunner(semantics: Semantics) {
 
-  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
+  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = run(cpg, Some(serializedCpg))
+
+  def run(cpg: Cpg, serializedCpg: Option[SerializedCpg] = None): Unit = {
     val enhancementExecList = List(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
-    enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
+
+    if (serializedCpg.isDefined) {
+      enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg.get))
+    } else {
+      enhancementExecList.foreach(_.createAndApply())
+    }
   }
 
 }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
@@ -13,7 +13,10 @@ class DataFlowRunner(semantics: Semantics) {
   def run(cpg: Cpg, serializedCpg: Option[SerializedCpg] = None): Unit = {
     val enhancementExecList = List(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
 
-    if (serializedCpg.isDefined) {
+    serializedCpg match {
+      case Some(serializedCpg) => enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
+      case None =>                enhancementExecList.foreach(_.createAndApply)
+    }
       enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg.get))
     } else {
       enhancementExecList.foreach(_.createAndApply())

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
@@ -13,10 +13,7 @@ class DataFlowRunner(semantics: Semantics) {
   def run(cpg: Cpg, serializedCpg: Option[SerializedCpg] = None): Unit = {
     val enhancementExecList = List(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
 
-    serializedCpg match {
-      case Some(serializedCpg) => enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
-      case None =>                enhancementExecList.foreach(_.createAndApply)
-    }
+    if (serializedCpg.isDefined) {
       enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg.get))
     } else {
       enhancementExecList.foreach(_.createAndApply())

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.dataflowengine.language
 
-import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengine.layers.dataflows.DataFlowRunner
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
@@ -17,7 +16,7 @@ object DataFlowCodeToCpgFixture {
   private def passes(cpg: Cpg): Unit = {
     new EnhancementRunner().run(cpg)
     val semantics = new SemanticsLoader("dataflowengine/src/test/resources/default.semantics").load()
-    new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
+    new DataFlowRunner(semantics).run(cpg)
   }
 
 }

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
@@ -15,7 +15,7 @@ object DataFlowCodeToCpgFixture {
     new CodeToCpgFixture(frontend).buildCpg(sourceCode, passes)(fun)
 
   private def passes(cpg: Cpg): Unit = {
-    new EnhancementRunner().run(cpg, new SerializedCpg())
+    new EnhancementRunner().run(cpg)
     val semantics = new SemanticsLoader("dataflowengine/src/test/resources/default.semantics").load()
     new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -22,6 +22,9 @@ import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.semanticcpg.passes.receiveredges.ReceiverEdgePass
 
 class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: Option[SerializedCpg] = None) {
+
+  def this(cpg: Cpg, language: String, serializedCpg: SerializedCpg) = this(cpg, language, Some(serializedCpg))
+
   private val enhancementExecList = createEnhancementExecList(language)
 
   private def createEnhancementExecList(language: String): List[CpgPass] = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -9,7 +9,6 @@ import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
 import io.shiftleft.semanticcpg.passes.codepencegraph.CdgPass
 import io.shiftleft.semanticcpg.passes.compat.bindingtablecompat.BindingTableCompat
 import io.shiftleft.semanticcpg.passes.compat.argumentcompat.ArgumentCompat
-import io.shiftleft.semanticcpg.passes.compat.callnamecompat.CallNameFixup
 import io.shiftleft.semanticcpg.passes.containsedges.ContainsEdgePass
 import io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc.{MethodStubCreator, TypeDeclStubCreator}
 import io.shiftleft.semanticcpg.passes.linking.calllinker.CallLinker
@@ -22,7 +21,7 @@ import io.shiftleft.semanticcpg.passes.compat.methodinstcompat.MethodInstCompat
 import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.semanticcpg.passes.receiveredges.ReceiverEdgePass
 
-class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedCpg) {
+class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: Option[SerializedCpg] = None) {
   private val enhancementExecList = createEnhancementExecList(language)
 
   private def createEnhancementExecList(language: String): List[CpgPass] = {
@@ -68,6 +67,10 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
   }
 
   def create(): Unit = {
-    enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
+    if (serializedCpg.isDefined) {
+      enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg.get))
+    } else {
+      enhancementExecList.foreach(_.createAndApply())
+    }
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancementRunner.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancementRunner.scala
@@ -5,6 +5,9 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
 
 class EnhancementRunner {
+
+  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = run(cpg, Some(serializedCpg))
+
   def run(cpg: Cpg, serializedCpg: Option[SerializedCpg] = None): Unit = {
     val language = cpg.metaData.language.headOption.getOrElse("")
     new EnhancedBaseCreator(cpg, language, serializedCpg).create

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancementRunner.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancementRunner.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
 
 class EnhancementRunner {
-  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
+  def run(cpg: Cpg, serializedCpg: Option[SerializedCpg] = None): Unit = {
     val language = cpg.metaData.language.headOption.getOrElse("")
     new EnhancedBaseCreator(cpg, language, serializedCpg).create
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
@@ -3,7 +3,6 @@ package io.shiftleft.semanticcpg.testfixtures
 import java.io.{File, PrintWriter}
 import java.nio.file.Files
 
-import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
@@ -19,7 +18,7 @@ object CodeToCpgFixture {
     new CodeToCpgFixture(frontend).buildCpg(sourceCode, passes)(fun)
 
   private def createEnhancements(cpg: Cpg): Unit = {
-    new EnhancementRunner().run(cpg, new SerializedCpg())
+    new EnhancementRunner().run(cpg)
   }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/ExistingCpgFixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/ExistingCpgFixture.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.semanticcpg.testfixtures
 
 import gremlin.scala._
-import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
 
@@ -9,7 +8,7 @@ private class ExistingCpgFixture(projectName: String) {
   private val config = CpgLoaderConfig.withoutOverflow
   private val cpgFilename = s"resources/testcode/cpgs/$projectName/cpg.bin.zip"
   lazy val cpg = CpgLoader.load(cpgFilename, config)
-  new EnhancementRunner().run(cpg, new SerializedCpg())
+  new EnhancementRunner().run(cpg)
   implicit val graph: Graph = cpg.graph
   lazy val scalaGraph: ScalaGraph = graph
 }


### PR DESCRIPTION
Prior to this PR, we called the EnhancementsRunner and DataFlowRunner in a few places where we needed enhancements/dataflow to be applied to the CPG, but we did not want them to be serialized into proto. We achieved this by simply passing a SerializedCpg without a filename. While this works, it means that the enhancementsRunner still serializes, it just does not write the serialized files anywhere. As serialization comes at a cost, with this PR, we now allow passing in no SerializedCpg at all, in which case the EnhancementRunner/DataflowRunner only applies but does not serialize the graph.

This change is backward compatible.