### PR TITLE
Simpler version of #550

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -24,6 +24,8 @@ class SerializedCpg() {
     initZipFilesystem(filename)
   }
 
+  def isEmpty: Boolean = zipFileSystem == null
+
   @throws[URISyntaxException]
   @throws[IOException]
   private def initZipFilesystem(filename: String): Unit = {

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -67,13 +67,7 @@ private class CpgLoader {
   }
 
   def loadFromOverflowDb(config: CpgLoaderConfig = CpgLoaderConfig()): Cpg = {
-    val odbGraph =
-      OdbGraph.open(
-        config.overflowDbConfig,
-        io.shiftleft.codepropertygraph.generated.nodes.Factories.allAsJava,
-        io.shiftleft.codepropertygraph.generated.edges.Factories.allAsJava
-      )
-    val cpg = Cpg(odbGraph)
+    val cpg = new ProtoToCpg(config.overflowDbConfig).build()
     if (config.createIndexes) { createIndexes(cpg) }
     cpg
   }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -67,7 +67,13 @@ private class CpgLoader {
   }
 
   def loadFromOverflowDb(config: CpgLoaderConfig = CpgLoaderConfig()): Cpg = {
-    val cpg = new ProtoToCpg(config.overflowDbConfig).build()
+    val odbGraph =
+      OdbGraph.open(
+        config.overflowDbConfig,
+        io.shiftleft.codepropertygraph.generated.nodes.Factories.allAsJava,
+        io.shiftleft.codepropertygraph.generated.edges.Factories.allAsJava
+      )
+    val cpg = Cpg(odbGraph)
     if (config.createIndexes) { createIndexes(cpg) }
     cpg
   }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -60,11 +60,15 @@ abstract class CpgPass(cpg: Cpg) {
     * @param counter an optional integer to keep apart different runs of the same pass
     * */
   def createApplySerializeAndStore(serializedCpg: SerializedCpg, counter: Int = 0): Unit = {
-    val overlays = createApplyAndSerialize()
-    overlays.zipWithIndex.foreach {
-      case (overlay, index) => {
-        if (overlay.getSerializedSize > 0) {
-          serializedCpg.addOverlay(overlay, getClass.getSimpleName + counter.toString + "_" + index)
+    if (serializedCpg.isEmpty) {
+      createAndApply()
+    } else {
+      val overlays = createApplyAndSerialize()
+      overlays.zipWithIndex.foreach {
+        case (overlay, index) => {
+          if (overlay.getSerializedSize > 0) {
+            serializedCpg.addOverlay(overlay, getClass.getSimpleName + counter.toString + "_" + index)
+          }
         }
       }
     }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
@@ -8,16 +8,9 @@ import io.shiftleft.dataflowengine.semanticsloader.Semantics
 
 class DataFlowRunner(semantics: Semantics) {
 
-  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = run(cpg, Some(serializedCpg))
-
-  def run(cpg: Cpg, serializedCpg: Option[SerializedCpg] = None): Unit = {
+  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
     val enhancementExecList = List(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
-
-    if (serializedCpg.isDefined) {
-      enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg.get))
-    } else {
-      enhancementExecList.foreach(_.createAndApply())
-    }
+    enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
   }
 
 }

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.dataflowengine.language
 
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengine.layers.dataflows.DataFlowRunner
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
@@ -14,9 +15,9 @@ object DataFlowCodeToCpgFixture {
     new CodeToCpgFixture(frontend).buildCpg(sourceCode, passes)(fun)
 
   private def passes(cpg: Cpg): Unit = {
-    new EnhancementRunner().run(cpg)
+    new EnhancementRunner().run(cpg, new SerializedCpg())
     val semantics = new SemanticsLoader("dataflowengine/src/test/resources/default.semantics").load()
-    new DataFlowRunner(semantics).run(cpg)
+    new DataFlowRunner(semantics).run(cpg, new SerializedCpg())
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -9,6 +9,7 @@ import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
 import io.shiftleft.semanticcpg.passes.codepencegraph.CdgPass
 import io.shiftleft.semanticcpg.passes.compat.bindingtablecompat.BindingTableCompat
 import io.shiftleft.semanticcpg.passes.compat.argumentcompat.ArgumentCompat
+import io.shiftleft.semanticcpg.passes.compat.callnamecompat.CallNameFixup
 import io.shiftleft.semanticcpg.passes.containsedges.ContainsEdgePass
 import io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc.{MethodStubCreator, TypeDeclStubCreator}
 import io.shiftleft.semanticcpg.passes.linking.calllinker.CallLinker
@@ -21,10 +22,7 @@ import io.shiftleft.semanticcpg.passes.compat.methodinstcompat.MethodInstCompat
 import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.semanticcpg.passes.receiveredges.ReceiverEdgePass
 
-class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: Option[SerializedCpg] = None) {
-
-  def this(cpg: Cpg, language: String, serializedCpg: SerializedCpg) = this(cpg, language, Some(serializedCpg))
-
+class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedCpg) {
   private val enhancementExecList = createEnhancementExecList(language)
 
   private def createEnhancementExecList(language: String): List[CpgPass] = {
@@ -70,10 +68,6 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: Option[Seri
   }
 
   def create(): Unit = {
-    if (serializedCpg.isDefined) {
-      enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg.get))
-    } else {
-      enhancementExecList.foreach(_.createAndApply())
-    }
+    enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancementRunner.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancementRunner.scala
@@ -5,10 +5,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
 
 class EnhancementRunner {
-
-  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = run(cpg, Some(serializedCpg))
-
-  def run(cpg: Cpg, serializedCpg: Option[SerializedCpg] = None): Unit = {
+  def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
     val language = cpg.metaData.language.headOption.getOrElse("")
     new EnhancedBaseCreator(cpg, language, serializedCpg).create
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
@@ -3,6 +3,7 @@ package io.shiftleft.semanticcpg.testfixtures
 import java.io.{File, PrintWriter}
 import java.nio.file.Files
 
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
@@ -18,7 +19,7 @@ object CodeToCpgFixture {
     new CodeToCpgFixture(frontend).buildCpg(sourceCode, passes)(fun)
 
   private def createEnhancements(cpg: Cpg): Unit = {
-    new EnhancementRunner().run(cpg)
+    new EnhancementRunner().run(cpg, new SerializedCpg())
   }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/ExistingCpgFixture.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/ExistingCpgFixture.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.semanticcpg.testfixtures
 
 import gremlin.scala._
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.semanticcpg.layers.EnhancementRunner
 
@@ -8,7 +9,7 @@ private class ExistingCpgFixture(projectName: String) {
   private val config = CpgLoaderConfig.withoutOverflow
   private val cpgFilename = s"resources/testcode/cpgs/$projectName/cpg.bin.zip"
   lazy val cpg = CpgLoader.load(cpgFilename, config)
-  new EnhancementRunner().run(cpg)
+  new EnhancementRunner().run(cpg, new SerializedCpg())
   implicit val graph: Graph = cpg.graph
   lazy val scalaGraph: ScalaGraph = graph
 }


### PR DESCRIPTION
I realized that it makes more sense to check in `createApplySerializeAndStore` whether the serializedCpg is unbacked by a file, in which case we call `createAndApply` instead. This has the same effect as #550 (which is revert by this PR), but with much fewer changes to the code. It also already extends to all passes in `codescience`.