### PR TITLE
use AstNode via implicit extension, rather than mixin

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/package.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/package.scala
@@ -24,6 +24,7 @@ package object language {
     case _                              => ??? //TODO markus/fabs?
   }
 
-  implicit def trackingPointToAstBase(trav: TrackingPoint): AstNode = new AstNode(trav.map(trackingPointToAstNode).raw)
+  implicit def trackingPointToAstBase(steps: NodeSteps[nodes.TrackingPoint]): AstNode[nodes.AstNode] =
+    new AstNode(steps.map(trackingPointToAstNode).raw)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -13,13 +13,13 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
   /**
     * All nodes of the abstract syntax tree rooted in this node
     * */
-  def ast: AstNode = node.start.ast
+  def ast: AstNode[nodes.AstNode] = node.start.ast
 
   /**
     * All nodes of the abstract syntax tree rooted in this node,
     * minus this node.
     * */
-  def astMinusRoot: AstNode = node.start.astMinusRoot
+  def astMinusRoot: AstNode[nodes.AstNode] = node.start.astMinusRoot
 
   /**
     * Indicate whether the AST node represents a control structure,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -22,7 +22,8 @@ class MethodMethods(val node: nodes.Method) extends AnyVal {
 
   def controlStructure: ControlStructure = node.start.controlStructure
 
-  def ast: AstNode = node.start.ast
+  def ast: NodeSteps[nodes.AstNode] =
+    node.start.ast
 
   def numberOfLines: Int = {
     if (node.lineNumber.isDefined && node.lineNumberEnd.isDefined) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTrav.scala
@@ -1,27 +1,26 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import gremlin.scala.GremlinScala
-
-import io.shiftleft.codepropertygraph.generated.{nodes => basenodes}
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.AstNode
 
-class OpAstNodeTrav[NodeType <: basenodes.AstNode](raw: GremlinScala[NodeType]) {
+class OpAstNodeTrav[NodeType <: nodes.AstNode](raw: GremlinScala[NodeType]) {
 
   def inAssignment = new AssignmentTrav(astNode.flatMap(_.inAssignment).raw)
 
-  private def astNode: AstNode =
-    new AstNode(raw.cast[basenodes.AstNode])
+  private def astNode: NodeSteps[nodes.AstNode] =
+    new NodeSteps[nodes.AstNode](raw.cast[nodes.AstNode])
 
   def assignments: AssignmentTrav =
     new AssignmentTrav(
-      new AstNode(raw.cast[basenodes.AstNode])
+      new AstNode(raw.cast[nodes.AstNode])
         .flatMap(_.assignments)
         .raw)
 
   def arithmetics: ArithmeticTrav =
     new ArithmeticTrav(
-      new AstNode(raw.cast[basenodes.AstNode])
+      new AstNode(raw.cast[nodes.AstNode])
         .flatMap(_.arithmetics)
         .raw)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -55,7 +55,7 @@ package object language {
   implicit def withMethodMethodsQp(node: nodes.WithinMethod): WithinMethodMethods =
     new WithinMethodMethods(node)
 
-  implicit def astNodeMethodsQp(node: nodes.AstNode): AstNodeMethods =
+  implicit def toAstNodeMethods(node: nodes.AstNode): AstNodeMethods =
     new AstNodeMethods(node)
 
   implicit def toMethodMethods(node: nodes.Method): MethodMethods =
@@ -126,7 +126,7 @@ package object language {
   implicit def toCfgNode(steps: Steps[nodes.CfgNode]): CfgNode =
     new CfgNode(steps.raw)
 
-  implicit def toAstNode(steps: Steps[nodes.AstNode]): AstNode =
+  implicit def toAstNode[A <: nodes.AstNode](steps: Steps[A]): AstNode[A] =
     new AstNode(steps.raw)
 
   implicit def toFile(steps: Steps[nodes.File]): File =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.expressions
 
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{AstNode, Expression, ExpressionBase}
+import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{Expression, ExpressionBase}
 import io.shiftleft.semanticcpg.language._
 
 object ControlStructure {
@@ -24,11 +24,11 @@ class ControlStructure(raw: GremlinScala[nodes.ControlStructure])
   def condition: Expression =
     new Expression(raw.out(EdgeTypes.CONDITION).cast[nodes.Expression])
 
-  def whenTrue: AstNode = new AstNode(
+  def whenTrue: NodeSteps[nodes.AstNode] = new NodeSteps(
     raw.out.has(NodeKeys.ORDER, secondChildIndex).cast[nodes.AstNode]
   )
 
-  def whenFalse: AstNode = new AstNode(
+  def whenFalse: NodeSteps[nodes.AstNode] = new NodeSteps(
     raw.out.has(NodeKeys.ORDER, thirdChildIndex).cast[nodes.AstNode]
   )
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.Method
 import io.shiftleft.semanticcpg.utils.ExpandTo
 
-class CfgNode(raw: GremlinScala[nodes.CfgNode]) extends NodeSteps[nodes.CfgNode](raw) with AstNodeBase[nodes.CfgNode] {
+class CfgNode(raw: GremlinScala[nodes.CfgNode]) extends NodeSteps[nodes.CfgNode](raw) {
 
   /**
   Traverse to enclosing method

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -17,8 +17,7 @@ class Expression(raw: GremlinScala[nodes.Expression])
 
 trait ExpressionBase[NodeType <: nodes.Expression]
     extends ArgumentIndexAccessors[NodeType]
-    with EvalTypeAccessors[NodeType]
-    with AstNodeBase[NodeType] { this: NodeSteps[NodeType] =>
+    with EvalTypeAccessors[NodeType] { this: NodeSteps[NodeType] =>
 
   /**
     Traverse to enclosing expression

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -3,12 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{
-  AstNodeBase,
-  CfgNode,
-  DeclarationBase,
-  Expression
-}
+import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{CfgNode, DeclarationBase, Expression}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.{Call, ControlStructure, Literal}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
@@ -20,7 +15,6 @@ class Method(override val raw: GremlinScala[nodes.Method])
     extends NodeSteps[nodes.Method](raw)
     with DeclarationBase[nodes.Method]
     with EvalTypeAccessors[nodes.Method]
-    with AstNodeBase[nodes.Method]
     with ModifierAccessors[nodes.Method] {
 
   /**
@@ -58,12 +52,14 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * All control structures of this method
     * */
-  def controlStructure: ControlStructure = ast.isControlStructure
+  def controlStructure: ControlStructure =
+    this.ast.isControlStructure
 
   /**
     * Shorthand to traverse to control structures where condition matches `regex`
     * */
-  def controlStructure(regex: String): ControlStructure = ast.isControlStructure.code(regex)
+  def controlStructure(regex: String): ControlStructure =
+    this.ast.isControlStructure.code(regex)
 
   /**
     * Outgoing call sites
@@ -182,7 +178,7 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse to literals of method
     * */
-  override def literal: Literal =
+  def literal: Literal =
     new Literal(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
   def topLevelExpressions: Expression =


### PR DESCRIPTION
similar to
https://github.com/ShiftLeftSecurity/codepropertygraph/pull/548, this
simplifies our type hierarchy and prepares us for the new dsl