### PR TITLE
Bump to latest gremlin-scala

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -4,7 +4,7 @@ dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
   "io.shiftleft" %% "overflowdb-traversal" % "0.46",
-  "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.1",
+  "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",
   "commons-io" % "commons-io" % "2.5",


### PR DESCRIPTION
The previous versions added scala-reflect 2.13.1 as a dependency, which
doesn't play well with codepropertygraph's 2.13.0 (due to a bug in Scala)