### PR TITLE
additionally generate neighbourAccessors we know actually exist

### DIFF
--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -21,7 +21,7 @@ class Schema(schemaFile: String) {
   lazy val nodeTypeByName: Map[String, NodeType] =
     nodeTypes.map { node => (node.name, node)}.toMap
 
-  /* nodes only specify their `outEdges` - this builds a reverse map (essentially `node.inEdges`) */
+  /* schema only specifies `node.outEdges` - this builds a reverse map (essentially `node.inEdges`) */
   lazy val nodeToInEdges: Map[NodeType, Set[String]] = {
     val nodeToInEdges = new mutable.HashMap[NodeType, mutable.Set[String]] with mutable.MultiMap[NodeType, String]
 
@@ -38,25 +38,6 @@ class Schema(schemaFile: String) {
     }
 
     nodeToInEdges.mapValues(_.toSet).toMap
-  }
-
-  /* nodes only specify their `outEdges.inNodes` - this builds a reverse map (essentially `node.inEdges.outNodes`) */
-  lazy val nodeToInNodes: Map[NodeType, Set[String]] = {
-    val nodeToInNodes = new mutable.HashMap[NodeType, mutable.Set[String]] with mutable.MultiMap[NodeType, String]
-
-    for {
-      nodeType <- nodeTypes
-      outEdge  <- nodeType.outEdges
-      inNodeName   <- outEdge.inNodes
-      inNode = nodeTypeByName.get(inNodeName) if inNode.isDefined
-    } nodeToInNodes.addBinding(inNode.get, nodeType.name)
-
-    // all nodes can have incoming `CONTAINS_NODE` edges
-    nodeTypes.foreach { nodeType =>
-      nodeToInNodes.addBinding(nodeType, "CONTAINS_NODE")
-    }
-
-    nodeToInNodes.mapValues(_.toSet).toMap
   }
 }
 

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -885,4 +885,21 @@ object Helpers {
     nodeToInEdges.mapValues(_.toSet).toMap
   }
 
+  /* nodes only specify their `outEdges.inNodes` - this builds a reverse map (essentially `node.inEdges.outNodes`) */
+  def calculateNodeToInNodes(nodeTypes: List[NodeType]): Map[String, Set[String]] = {
+    val nodeToInNodes = new mutable.HashMap[String, mutable.Set[String]] with mutable.MultiMap[String, String]
+
+    for {
+      nodeType <- nodeTypes
+      outEdge  <- nodeType.outEdges
+      inNode   <- outEdge.inNodes
+    } nodeToInNodes.addBinding(inNode, nodeType.name)
+
+    // all nodes can have incoming `CONTAINS_NODE` edges
+    nodeTypes.foreach { nodeType =>
+      nodeToInNodes.addBinding(nodeType.name, "CONTAINS_NODE")
+    }
+
+    nodeToInNodes.mapValues(_.toSet).toMap
+  }
 }

--- a/project/DomainClassCreator.scala
+++ b/project/DomainClassCreator.scala
@@ -488,7 +488,9 @@ class DomainClassCreator(schemaFile: String, basePackage: String) {
           inEdges.map(edge => neighborAccessorName(edge, "IN")))
         .map { nbaName =>
           /* generic and specific neighbor accessors - as mentioned in comment above, we may not need generic ones (prefixed with `_`) in future */
-          s"override def _$nbaName(): JIterator[StoredNode] = get()._$nbaName()"
+          s"""def $nbaName: JIterator[StoredNode] = get().$nbaName
+             |override def _$nbaName(): JIterator[StoredNode] = $nbaName
+             |""".stripMargin
         }.mkString("\n")
 
       val nodeRefImpl = {
@@ -522,7 +524,9 @@ class DomainClassCreator(schemaFile: String, basePackage: String) {
         (outEdges.map(edge => neighborAccessorName(edge, "OUT")) ++
           inEdges.map(edge => neighborAccessorName(edge, "IN"))).zipWithIndex
         .map { case (nbaName: String, offsetPos: Int) =>
-          s"override def _$nbaName : JIterator[StoredNode] = createAdjacentNodeIteratorByOffSet($offsetPos).asInstanceOf[JIterator[StoredNode]]"
+          /* generic and specific neighbor accessors - as mentioned in comment above, we may not need generic ones (prefixed with `_`) in future */
+          s"""def $nbaName : JIterator[StoredNode] = createAdjacentNodeIteratorByOffSet($offsetPos).asInstanceOf[JIterator[StoredNode]]
+             |override def _$nbaName : JIterator[StoredNode] = $nbaName""".stripMargin
         }.mkString("\n")
 
       val classImpl =


### PR DESCRIPTION
personally I'd just remove the generic ones, since we're not making use of
the schema to help us with the available steps. other differ, however,
based on performance considerations. will leave those in for now.

also lot's of refactoring