### PR TITLE
WIP add edge cardinalities

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -72,7 +72,7 @@
          "keys": ["NAME", "ORDER"],
          "comment": "Node representing a source file. Often also the AST root",
          "outEdges": [
-             {"edgeName": "AST", "inNodes": ["NAMESPACE_BLOCK"]}
+           {"edgeName": "AST", "inNodes": ["NAMESPACE_BLOCK"], "cardinality": "oneToOne"}
          ],
 	 "is" : ["AST_NODE"]
         },
@@ -86,8 +86,11 @@
          "is": ["DECLARATION", "CFG_NODE", "AST_NODE"],
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["METHOD_RETURN", "METHOD_PARAMETER_IN",
-                                             "MODIFIER", "BLOCK", "TYPE_PARAMETER"]},
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "METHOD_RETURN", "RETURN", "BLOCK", "UNKNOWN"]}
+                                             "MODIFIER", "BLOCK", "TYPE_PARAMETER"],
+              "cardinality": "oneToMany"},
+             {"edgeName": "CFG", 
+              "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "METHOD_RETURN", "RETURN", "BLOCK", "UNKNOWN"],
+              "cardinality": "oneToOne" }
          ]
         },
 
@@ -122,8 +125,8 @@
          "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME", "ALIAS_TYPE_FULL_NAME", "ORDER"],
          "comment" : "A type declaration",
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["TYPE_PARAMETER", "MEMBER", "MODIFIER"]},
-             {"edgeName": "BINDS", "inNodes": ["BINDING"]},
+             {"edgeName": "AST", "inNodes": ["TYPE_PARAMETER", "MEMBER", "MODIFIER"], "cardinality": "oneToMany"},
+             {"edgeName": "BINDS", "inNodes": ["BINDING"], "cardinality": "oneToMany"},
              {"edgeName": "VTABLE", "inNodes": ["METHOD"]}
          ],
 	 "is" : ["AST_NODE"]


### PR DESCRIPTION
If we statically know the edge cardinality (1:1, 1:n, n:1, n:n) we can
generate more specific code, and e.g. our neighbor accessors could
return a `nodes.Xyz` instead of an `Iterator[nodes.Xyz]`. There are many
areas where this knowledge is already baked into the usage of the cpg,
and moving it into the schema improves readability, performance and
correctness.

This is just a start in order to get initial feedback on the idea. To
obtain the cardinalities I loaded the helloshiftleft cpg/sp and
performed groupCounts on the nodes/edge combinations:
```scala
def cardinalityAnalysis(nodeType: String, edgeType: String) = {
  def nodesTrav = cpg.graph.V.hasLabel(nodeType)
  val nodes = nodesTrav.toList
  val outNodes = nodesTrav.out(edgeType).toList

  println("out cardinalities:")
  println(nodes.groupBy(_.outE(edgeType).count.head).mapValues(_.size).toList.sortBy(_._1))

  println("in cardinalities:")
  outNodes.groupBy(_.label).foreach { case (label, node) =>
    println(label + ": " + node.groupBy(_.inE(edgeType).count.head).mapValues(_.size).toList.sortBy(_._1))
  }
}

cardinalityAnalysis("FILE", "CFG")
cardinalityAnalysis("METHOD", "AST")
cardinalityAnalysis("METHOD", "CFG")
cardinalityAnalysis("TYPE", "AST")
cardinalityAnalysis("TYPE_DECL", "AST")
cardinalityAnalysis("TYPE_DECL", "BINDS")
cardinalityAnalysis("TYPE_DECL", "VTABLE")
```