### PR TITLE
do not nest Traversals in the return types if we can avoid it

### DIFF
--- a/queries/src/test/scala/io/shiftleft/queries/CopyOperations.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/CopyOperations.scala
@@ -27,8 +27,9 @@ class CopyOperations extends WordSpec with Matchers {
 
   CodeToCpgFixture(code) { cpg =>
     "find indexed buffer assigment targets" in {
-      cpg.assignment.target.isArrayAccess.subscripts.map(_.code.toSet).toSet shouldBe Set(Set("k"),
-                                                                                          Set("i", "j", "offset"))
+      cpg.assignment.target.isArrayAccess.toSet.map { arrAccess =>
+        arrAccess.subscripts.code.toSet
+      } shouldBe Set(Set("k"), Set("i", "j", "offset"))
     }
 
     "find indexed buffer assignment targets in loops where index is incremented" in {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -174,13 +174,13 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
     */
-  def identifier: Identifier =
-    new Identifier(scalaGraph.V.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def identifier: IdentifierTrav =
+    new IdentifierTrav(scalaGraph.V.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * Shorthand for `cpg.identifier.name(name)`
     * */
-  def identifier(name: String): Identifier =
+  def identifier(name: String): IdentifierTrav =
     identifier.name(name)
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language
 
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
-import io.shiftleft.semanticcpg.language.types.expressions.{Call, Identifier, Literal}
+import io.shiftleft.semanticcpg.language.types.expressions.{Call, IdentifierTrav, Literal}
 import io.shiftleft.semanticcpg.language.types.structure._
 import io.shiftleft.semanticcpg.language.{NodeSteps => OriginalNodeSteps}
 
@@ -48,8 +48,8 @@ class Tag(override val raw: GremlinScala[nodes.Tag]) extends OriginalNodeSteps[n
         .order(By((x: Vertex) => x.id))
         .cast[nodes.Call])
 
-  def identifier: Identifier =
-    new Identifier(
+  def identifier: IdentifierTrav =
+    new IdentifierTrav(
       raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.IDENTIFIER)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTrav.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import gremlin.scala.GremlinScala
-
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language.types.expressions.Identifier
+import io.shiftleft.semanticcpg.language.types.expressions.IdentifierTrav
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 import io.shiftleft.semanticcpg.language.Steps
 import io.shiftleft.semanticcpg.language._
@@ -12,6 +11,6 @@ class ArrayAccessTrav(raw: GremlinScala[nodes.Call]) extends Steps[nodes.Call](r
 
   def array: Expression[nodes.Expression] = map(_.array)
 
-  def subscripts: Steps[Identifier] = map(_.subscripts)
+  def subscripts: IdentifierTrav = flatMap(_.subscripts)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/package.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.semanticcpg.language
 
-import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call, Expression}
 import io.shiftleft.semanticcpg.language.nodemethods.CallMethods
-import io.shiftleft.semanticcpg.language.types.expressions.Identifier
+import io.shiftleft.semanticcpg.language.types.expressions.IdentifierTrav
 
 package object operatorextension {
 
@@ -12,7 +11,7 @@ package object operatorextension {
 
     def array: Expression = call.argument(1)
 
-    def subscripts: Identifier = call.argument(2).ast.isIdentifier
+    def subscripts: IdentifierTrav = call.argument(2).ast.isIdentifier
   }
 
   implicit class AssignmentExt(val call: Call) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -87,8 +87,8 @@ package object language {
   implicit def toControlStructure(steps: Steps[nodes.ControlStructure]): ControlStructure =
     new ControlStructure(steps.raw)
 
-  implicit def toIdentifier(steps: Steps[nodes.Identifier]): Identifier =
-    new Identifier(steps.raw)
+  implicit def toIdentifier(steps: Steps[nodes.Identifier]): IdentifierTrav =
+    new IdentifierTrav(steps.raw)
 
   implicit def toMember(steps: Steps[nodes.Member]): Member =
     new Member(steps.raw)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTrav.scala
@@ -9,7 +9,7 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 /**
   An identifier, e.g., an instance of a local variable, or a temporary variable
   */
-class Identifier(raw: GremlinScala[nodes.Identifier])
+class IdentifierTrav(raw: GremlinScala[nodes.Identifier])
     extends NodeSteps[nodes.Identifier](raw)
     with EvalTypeAccessors[nodes.Identifier] {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -129,8 +129,8 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
   /**
     * Traverse only to AST nodes that are identifier
     * */
-  def isIdentifier: Identifier =
-    new Identifier(raw.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def isIdentifier: IdentifierTrav =
+    new IdentifierTrav(raw.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * Traverse only to AST nodes that are return nodes

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions.Identifier
+import io.shiftleft.semanticcpg.language.types.expressions.IdentifierTrav
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
 /**
@@ -30,8 +30,8 @@ class Local(raw: GremlinScala[nodes.Local]) extends NodeSteps[nodes.Local](raw) 
   /**
     * Places (identifier) where this local is being referenced
     * */
-  def referencingIdentifiers: Identifier =
-    new Identifier(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def referencingIdentifiers: IdentifierTrav =
+    new IdentifierTrav(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * The type of the local.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions.Identifier
+import io.shiftleft.semanticcpg.language.types.expressions.IdentifierTrav
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
@@ -65,8 +65,8 @@ class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
   /**
     * Places (identifier) where this parameter is being referenced
     * */
-  def referencingIdentifiers: Identifier =
-    new Identifier(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def referencingIdentifiers: IdentifierTrav =
+    new IdentifierTrav(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * Traverse to parameter type


### PR DESCRIPTION
Due to confusing namings we ended up returning a
`Steps[Steps[node.Identifier]]` from `arrayaccess.subscripts`. This PR
addresses both issues: the return type as well as the confusing naming.