### PR TITLE
trim nodes

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "overflowdb-traversal" % "0.46",
+  "io.shiftleft" %% "overflowdb-traversal" % "0.48",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -11,6 +11,7 @@ import io.shiftleft.semanticcpg.passes.compat.bindingtablecompat.BindingTableCom
 import io.shiftleft.semanticcpg.passes.compat.argumentcompat.ArgumentCompat
 import io.shiftleft.semanticcpg.passes.compat.callnamecompat.CallNameFixup
 import io.shiftleft.semanticcpg.passes.containsedges.ContainsEdgePass
+import io.shiftleft.semanticcpg.passes.trim.TrimPass
 import io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc.{MethodStubCreator, TypeDeclStubCreator}
 import io.shiftleft.semanticcpg.passes.linking.calllinker.CallLinker
 import io.shiftleft.semanticcpg.passes.linking.capturinglinker.CapturingLinker
@@ -44,6 +45,7 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
           new NamespaceCreator(cpg),
           new CfgDominatorPass(cpg),
           new CdgPass(cpg),
+          new TrimPass(cpg),
         )
       case Languages.C =>
         List(
@@ -63,6 +65,7 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
           new NamespaceCreator(cpg),
           new CfgDominatorPass(cpg),
           new CdgPass(cpg),
+          new TrimPass(cpg),
         )
     }
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/trim/TrimPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/trim/TrimPass.scala
@@ -4,19 +4,15 @@ import io.shiftleft.overflowdb.{NodeRef, OdbNode}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import org.apache.logging.log4j.{LogManager, Logger}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.codepropertygraph.generated.nodes
 
 class TrimPass(cpg: Cpg) extends CpgPass(cpg) {
   override def run():Iterator[DiffGraph] = {
     val reduction = cpg.all.toStream().mapToLong {
-      _ match {
-        case (onode: io.shiftleft.overflowdb.OdbNode) => onode.trim()
-        case oref if oref.isInstanceOf[io.shiftleft.overflowdb.NodeRef[_]] => oref.asInstanceOf[io.shiftleft.overflowdb.NodeRef[OdbNode]].get().trim()
-      }
-    }.sum()
-    val oldsz = reduction >> 32
-    val newsz = reduction & 0x00000000ffffffffL
-    TrimPass.logger.debug(s"Trim pass: reduced number of refs from ${oldsz} to ${newsz}, i.e. by factor of ${1.0 - newsz.toFloat / oldsz.toFloat}")
+      _.asInstanceOf[io.shiftleft.overflowdb.NodeRef[OdbNode]].get().trim()
+      }.sum()
+    val oldSize = reduction >>> 32
+    val newSize = reduction & 0x00000000ffffffffL
+    TrimPass.logger.debug(s"Trim pass: reduced number of refs from ${oldSize} to ${newSize}, i.e. by factor of ${1.0 - newSize.toFloat / oldSize.toFloat}")
     Iterator.empty[DiffGraph]
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/trim/TrimPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/trim/TrimPass.scala
@@ -1,0 +1,26 @@
+package io.shiftleft.semanticcpg.passes.trim
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.overflowdb.{NodeRef, OdbNode}
+import io.shiftleft.passes.{CpgPass, DiffGraph}
+import org.apache.logging.log4j.{LogManager, Logger}
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.codepropertygraph.generated.nodes
+
+class TrimPass(cpg: Cpg) extends CpgPass(cpg) {
+  override def run():Iterator[DiffGraph] = {
+    val reduction = cpg.all.toStream().mapToLong {
+      _ match {
+        case (onode: io.shiftleft.overflowdb.OdbNode) => onode.trim()
+        case oref if oref.isInstanceOf[io.shiftleft.overflowdb.NodeRef[_]] => oref.asInstanceOf[io.shiftleft.overflowdb.NodeRef[OdbNode]].get().trim()
+      }
+    }.sum()
+    val oldsz = reduction >> 32
+    val newsz = reduction & 0x00000000ffffffffL
+    TrimPass.logger.debug(s"Trim pass: reduced number of refs from ${oldsz} to ${newsz}, i.e. by factor of ${1.0 - newsz.toFloat / oldsz.toFloat}")
+    Iterator.empty[DiffGraph]
+  }
+}
+
+object TrimPass {
+  private val logger: Logger = LogManager.getLogger(classOf[TrimPass])
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/trim/TrimPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/trim/TrimPass.scala
@@ -6,13 +6,17 @@ import org.apache.logging.log4j.{LogManager, Logger}
 import io.shiftleft.semanticcpg.language._
 
 class TrimPass(cpg: Cpg) extends CpgPass(cpg) {
-  override def run():Iterator[DiffGraph] = {
-    val reduction = cpg.all.toStream().mapToLong {
-      _.asInstanceOf[io.shiftleft.overflowdb.NodeRef[OdbNode]].get().trim()
-      }.sum()
+  override def run(): Iterator[DiffGraph] = {
+    val reduction = cpg.all
+      .toStream()
+      .mapToLong {
+        _.asInstanceOf[io.shiftleft.overflowdb.NodeRef[OdbNode]].get().trim()
+      }
+      .sum()
     val oldSize = reduction >>> 32
     val newSize = reduction & 0x00000000ffffffffL
-    TrimPass.logger.debug(s"Trim pass: reduced number of refs from ${oldSize} to ${newSize}, i.e. by factor of ${1.0 - newSize.toFloat / oldSize.toFloat}")
+    TrimPass.logger.debug(
+      s"Trim pass: reduced number of refs from ${oldSize} to ${newSize}, i.e. by factor of ${1.0 - newSize.toFloat / oldSize.toFloat}")
     Iterator.empty[DiffGraph]
   }
 }


### PR DESCRIPTION
Adds a pass that trims overallocations for node neighbors. I ran this on codescience/sptest; we save around 40% of the memory consumed by actual edges. OTOH typical CPGs have very few edges, so the savings don't amount to a lot of memory; but the pass is fast enough that it should still pay off.

Once this is merged, I'll make a followup pr that adds this to codescience.