### PR TITLE
return NodeSteps everywhere, do not extend NodeSteps

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -23,15 +23,15 @@ class TrackingPoint(raw: GremlinScala[nodes.TrackingPoint]) extends NodeSteps[no
   /**
     * The enclosing method of the tracking point
     * */
-  def method: Method =
-    new Method(raw.map { dataFlowObject =>
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.map { dataFlowObject =>
       methodFast(dataFlowObject)
     })
 
   /**
     * Convert to nearest CFG node
     * */
-  def cfgNode: Steps[nodes.CfgNode] = map(_.cfgNode)
+  def cfgNode: NodeSteps[nodes.CfgNode] = map(_.cfgNode)
 
   def reachableBy[NodeType <: nodes.TrackingPoint](sourceTravs: Steps[NodeType]*): Steps[NodeType] = {
     val pathReachables = reachableByInternal(sourceTravs)

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/package.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/package.scala
@@ -25,6 +25,6 @@ package object language {
   }
 
   implicit def trackingPointToAstBase(steps: NodeSteps[nodes.TrackingPoint]): AstNode[nodes.AstNode] =
-    new AstNode(steps.map(trackingPointToAstNode).raw)
+    new AstNode(steps.map(trackingPointToAstNode))
 
 }

--- a/queries/src/test/scala/io/shiftleft/queries/TruncationsTests.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/TruncationsTests.scala
@@ -3,6 +3,7 @@ package io.shiftleft.queries
 import io.shiftleft.dataflowengine.language.DataFlowCodeToCpgFixture
 import org.scalatest.{Matchers, WordSpec}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.operatorextension._
 
 class TruncationsTests extends WordSpec with Matchers {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -20,8 +20,8 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
   /**
     * Traverse to source file
     * */
-  def file: File =
-    new File(
+  def file: NodeSteps[nodes.File] =
+    new NodeSteps(
       raw
         .choose(
           on = _.label,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -88,7 +88,7 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
   /**
   Traverse to tags of nodes in enhanced graph
     */
-  def tag: Tag =
-    new Tag(raw.out(EdgeTypes.TAGGED_BY).cast[nodes.Tag])
+  def tag: NodeSteps[nodes.Tag] =
+    new NodeSteps(raw.out(EdgeTypes.TAGGED_BY).cast[nodes.Tag])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -3,9 +3,6 @@ package io.shiftleft.semanticcpg.language
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
-import io.shiftleft.semanticcpg.language.types.expressions._
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
-import io.shiftleft.semanticcpg.language.types.structure._
 
 class NodeTypeStarters(cpg: Cpg) {
 
@@ -47,152 +44,152 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all namespaces, e.g., packages in Java.
     */
-  def namespace: Namespace =
-    new Namespace(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE).cast[nodes.Namespace])
+  def namespace: NodeSteps[nodes.Namespace] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE).cast[nodes.Namespace])
 
   /**
     * Shorthand for `cpg.namespace.name(name)`
     * */
-  def namespace(name: String): Namespace =
+  def namespace(name: String): NodeSteps[nodes.Namespace] =
     namespace.name(name)
 
   /**
   Traverse to all namespace blocks, e.g., packages in Java.
     */
-  def namespaceBlock: NamespaceBlock =
-    new NamespaceBlock(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
+  def namespaceBlock: NodeSteps[nodes.NamespaceBlock] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
 
   /**
     * Shorthand for `cpg.namespaceBlock.name(name)`
     * */
-  def namespaceBlock(name: String): NamespaceBlock =
+  def namespaceBlock(name: String): NodeSteps[nodes.NamespaceBlock] =
     namespaceBlock.name(name)
 
   /**
     Traverse to all types, e.g., Set<String>
     */
-  def types: Type =
-    new Type(scalaGraph.V.hasLabel(NodeTypes.TYPE).cast[nodes.Type])
+  def types: NodeSteps[nodes.Type] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TYPE).cast[nodes.Type])
 
   /**
     * Shorthand for `cpg.types.fullName(fullName)`
     * */
-  def types(fullName: String): Type =
+  def types(fullName: String): NodeSteps[nodes.Type] =
     types.fullName(fullName)
 
   /**
     Traverse to all declarations, e.g., Set<T>
     */
-  def typeDecl: TypeDecl =
-    new TypeDecl(scalaGraph.V.hasLabel(NodeTypes.TYPE_DECL).cast[nodes.TypeDecl])
+  def typeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TYPE_DECL).cast[nodes.TypeDecl])
 
   /**
     * Shorthand for cpg.typeDecl.fullName(fullName)
     * */
-  def typeDecl(fullName: String): TypeDecl =
+  def typeDecl(fullName: String): NodeSteps[nodes.TypeDecl] =
     typeDecl.fullName(fullName)
 
   /**
     Traverse to all methods
     */
-  def method: Method =
-    new Method(scalaGraph.V.hasLabel(NodeTypes.METHOD).cast[nodes.Method])
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.METHOD).cast[nodes.Method])
 
   /**
     * Shorthand for `cpg.method.fullName(fullName)`
     * */
-  def method(fullName: String): Method =
+  def method(fullName: String): NodeSteps[nodes.Method] =
     method.fullName(fullName)
 
   /**
     Traverse to all formal return parameters
     */
-  def methodReturn: MethodReturn =
-    new MethodReturn(scalaGraph.V.hasLabel(NodeTypes.METHOD_RETURN).cast[nodes.MethodReturn])
+  def methodReturn: NodeSteps[nodes.MethodReturn] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.METHOD_RETURN).cast[nodes.MethodReturn])
 
   /**
     Traverse to all input parameters
     */
-  def parameter: MethodParameter =
-    new MethodParameter(scalaGraph.V.hasLabel(NodeTypes.METHOD_PARAMETER_IN).cast[nodes.MethodParameterIn])
+  def parameter: NodeSteps[nodes.MethodParameterIn] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.METHOD_PARAMETER_IN).cast[nodes.MethodParameterIn])
 
   /**
     * Shorthand for `cpg.parameter.name(name)`
     * */
-  def parameter(name: String): MethodParameter =
+  def parameter(name: String): NodeSteps[nodes.MethodParameterIn] =
     parameter.name(name)
 
   /**
     Traverse to all class members
     */
-  def member: Member =
-    new Member(scalaGraph.V.hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
+  def member: NodeSteps[nodes.Member] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
 
   /**
     * Shorthand for `cpg.member.name(name)`
     * */
-  def member(name: String): Member =
+  def member(name: String): NodeSteps[nodes.Member] =
     member.name(name)
 
   /**
     Traverse to all call sites
     */
-  def call: Call =
-    new Call(scalaGraph.V.hasLabel(NodeTypes.CALL).cast[nodes.Call])
+  def call: NodeSteps[nodes.Call] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**
     * Shorthand for `cpg.call.name(name)`
     * */
-  def call(name: String): Call =
+  def call(name: String): NodeSteps[nodes.Call] =
     call.name(name)
 
   /**
     Traverse to all local variable declarations
 
     */
-  def local: Local =
-    new Local(scalaGraph.V.hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
+  def local: NodeSteps[nodes.Local] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
   /**
     * Shorthand for `cpg.local.name`
     * */
-  def local(name: String): Local =
+  def local(name: String): NodeSteps[nodes.Local] =
     local.name(name)
 
   /**
     Traverse to all literals (constant strings and numbers provided directly in the code).
     */
-  def literal: Literal =
-    new Literal(scalaGraph.V.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
+  def literal: NodeSteps[nodes.Literal] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
   /**
     * Shorthand for `cpg.literal.code(code)`
     * */
-  def literal(code: String): Literal =
+  def literal(code: String): NodeSteps[nodes.Literal] =
     literal.code(code)
 
   /**
     Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
     */
-  def identifier: IdentifierTrav =
-    new IdentifierTrav(scalaGraph.V.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def identifier: NodeSteps[nodes.Identifier] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * Shorthand for `cpg.identifier.name(name)`
     * */
-  def identifier(name: String): IdentifierTrav =
+  def identifier(name: String): NodeSteps[nodes.Identifier] =
     identifier.name(name)
 
   /**
     Traverse to all arguments passed to methods
     */
-  def argument: Expression[nodes.Expression] =
+  def argument: NodeSteps[nodes.Expression] =
     call.argument
 
   /**
     * Shorthand for `cpg.argument.code(code)`
     * */
-  def argument(code: String): Expression[nodes.Expression] =
+  def argument(code: String): NodeSteps[nodes.Expression] =
     argument.code(code)
 
   /**
@@ -210,20 +207,20 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Traverse to all meta data entries
     */
-  def metaData: MetaData =
-    new MetaData(scalaGraph.V.hasLabel(NodeTypes.META_DATA).cast[nodes.MetaData])
+  def metaData: NodeSteps[nodes.MetaData] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.META_DATA).cast[nodes.MetaData])
 
   /**
     * Traverse to all method references
     * */
-  def methodRef: MethodRef =
-    new MethodRef(scalaGraph.V.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
+  def methodRef: NodeSteps[nodes.MethodRef] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
 
   /**
     * Shorthand for `cpg.methodRef
     * .filter(_.referencedMethod.fullName(fullName))`
     * */
-  def methodRef(fullName: String): MethodRef =
+  def methodRef(fullName: String): NodeSteps[nodes.MethodRef] =
     methodRef.filter(_.referencedMethod.fullName(fullName))
 
   /**
@@ -241,7 +238,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
   Traverse to all tags
     */
-  def tag: Tag =
-    new Tag(scalaGraph.V.hasLabel(NodeTypes.TAG).cast[nodes.Tag])
+  def tag: NodeSteps[nodes.Tag] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TAG).cast[nodes.Tag])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -35,13 +35,13 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all source files
     */
-  def file: File =
-    new File(scalaGraph.V.hasLabel(NodeTypes.FILE).cast[nodes.File])
+  def file: NodeSteps[nodes.File] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.FILE).cast[nodes.File])
 
   /**
     * Shorthand for `cpg.file.name(name)`
     * */
-  def file(name: String): File =
+  def file(name: String): NodeSteps[nodes.File] =
     file.name(name)
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
@@ -64,8 +64,8 @@ class Tag(override val raw: GremlinScala[nodes.Tag]) extends OriginalNodeSteps[n
         .order(By((x: Vertex) => x.id))
         .cast[nodes.Literal])
 
-  def local: Local =
-    new Local(
+  def local: NodeSteps[nodes.Local] =
+    new NodeSteps(
       raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.LOCAL)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
@@ -4,61 +4,60 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.types.expressions.{Call, IdentifierTrav, Literal}
 import io.shiftleft.semanticcpg.language.types.structure._
-import io.shiftleft.semanticcpg.language.{NodeSteps => OriginalNodeSteps}
 
-class Tag(override val raw: GremlinScala[nodes.Tag]) extends OriginalNodeSteps[nodes.Tag](raw) {
+class Tag(val wrapped: NodeSteps[nodes.Tag]) extends AnyVal {
 
-  def method: Method =
-    new Method(
-      raw
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(
+      wrapped.raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.METHOD)
         .order(By((x: Vertex) => x.id))
         .cast[nodes.Method])
 
-  def methodReturn: MethodReturn =
-    new MethodReturn(
-      raw
+  def methodReturn: NodeSteps[nodes.MethodReturn] =
+    new NodeSteps(
+      wrapped.raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.METHOD_RETURN)
         .order(By((x: Vertex) => x.id))
         .cast[nodes.MethodReturn])
 
-  def parameter: MethodParameter =
-    new MethodParameter(
-      raw
+  def parameter: NodeSteps[nodes.MethodParameterIn] =
+    new NodeSteps(
+      wrapped.raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
         .order(By((x: Vertex) => x.id))
         .cast[nodes.MethodParameterIn])
 
-  def parameterOut: MethodParameterOut =
-    new MethodParameterOut(
-      raw
+  def parameterOut: NodeSteps[nodes.MethodParameterOut] =
+    new NodeSteps(
+      wrapped.raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.METHOD_PARAMETER_OUT)
         .order(By((x: Vertex) => x.id))
         .cast[nodes.MethodParameterOut])
 
-  def call: Call =
-    new Call(
-      raw
+  def call: NodeSteps[nodes.Call] =
+    new NodeSteps(
+      wrapped.raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.CALL)
         .order(By((x: Vertex) => x.id))
         .cast[nodes.Call])
 
-  def identifier: IdentifierTrav =
-    new IdentifierTrav(
-      raw
+  def identifier: NodeSteps[nodes.Identifier] =
+    new NodeSteps(
+      wrapped.raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.IDENTIFIER)
         .order(By((x: Vertex) => x.id))
         .cast[nodes.Identifier])
 
-  def literal: Literal =
-    new Literal(
-      raw
+  def literal: NodeSteps[nodes.Literal] =
+    new NodeSteps(
+      wrapped.raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.LITERAL)
         .order(By((x: Vertex) => x.id))
@@ -66,7 +65,7 @@ class Tag(override val raw: GremlinScala[nodes.Tag]) extends OriginalNodeSteps[n
 
   def local: NodeSteps[nodes.Local] =
     new NodeSteps(
-      raw
+      wrapped.raw
         .in(EdgeTypes.TAGGED_BY)
         .hasLabel(NodeTypes.LOCAL)
         .order(By((x: Vertex) => x.id))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tags.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tags.scala
@@ -1,7 +1,0 @@
-package io.shiftleft.semanticcpg.language
-
-import gremlin.scala.GremlinScala
-import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language.{NodeSteps => OriginalNodeSteps}
-
-class Tags(override val raw: GremlinScala[nodes.Tags]) extends OriginalNodeSteps[nodes.Tags](raw) {}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
@@ -8,7 +8,9 @@ class Call(val wrapped: NodeSteps[nodes.Call]) extends AnyVal {
   /** The callee method */
   def calledMethod(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] = {
     new NodeSteps(
-      wrapped.sideEffect(callResolver.resolveDynamicCallSite).raw
+      wrapped
+        .sideEffect(callResolver.resolveDynamicCallSite)
+        .raw
         .out(EdgeTypes.CALL)
         .cast[nodes.Method])
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
@@ -1,17 +1,14 @@
 package io.shiftleft.semanticcpg.language.callgraphextension
 
-import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
 
-class Call(override val raw: GremlinScala[nodes.Call]) extends NodeSteps[nodes.Call](raw) {
+class Call(val wrapped: NodeSteps[nodes.Call]) extends AnyVal {
 
-  /**
-  The callee method
-    */
+  /** The callee method */
   def calledMethod(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] = {
     new NodeSteps(
-      sideEffect(callResolver.resolveDynamicCallSite).raw
+      wrapped.sideEffect(callResolver.resolveDynamicCallSite).raw
         .out(EdgeTypes.CALL)
         .cast[nodes.Method])
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -50,7 +50,7 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * Traverse to methods called by this method
     * */
   def callee(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] =
-    new OriginalMethod(wrapped.raw).callOut.calledMethod(callResolver)
+    new OriginalMethod(wrapped).callOut.calledMethod(callResolver)
 
   /**
     * Incoming call sites
@@ -71,6 +71,6 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * Outgoing call sites to methods where fullName matches `regex`.
     * */
   def callOutRegex(regex: String)(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] =
-    new OriginalMethod(wrapped.raw).callOut.filter(_.calledMethod.fullName(regex))
+    new OriginalMethod(wrapped).callOut.filter(_.calledMethod.fullName(regex))
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -55,25 +55,22 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
   /**
     * Incoming call sites
     * */
-  def callIn(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] = {
+  def callIn(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] =
     new NodeSteps(
       wrapped.sideEffect(callResolver.resolveDynamicMethodCallSites).raw
         .in(EdgeTypes.CALL)
         .cast[nodes.Call])
-  }
 
   /**
     * Traverse to direct and transitive callers of the method.
     * */
-  def calledBy(sourceTrav: Steps[nodes.Method])(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] = {
+  def calledBy(sourceTrav: Steps[nodes.Method])(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] =
     caller(callResolver).calledByIncludingSink(sourceTrav)(callResolver)
-  }
 
   /**
     * Outgoing call sites to methods where fullName matches `regex`.
     * */
-  def callOutRegex(regex: String)(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] = {
+  def callOutRegex(regex: String)(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] =
     new OriginalMethod(wrapped.raw).callOut.filter(_.calledMethod.fullName(regex))
-  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -57,7 +57,9 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * */
   def callIn(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] =
     new NodeSteps(
-      wrapped.sideEffect(callResolver.resolveDynamicMethodCallSites).raw
+      wrapped
+        .sideEffect(callResolver.resolveDynamicMethodCallSites)
+        .raw
         .in(EdgeTypes.CALL)
         .cast[nodes.Call])
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -55,8 +55,8 @@ class Method(override val raw: GremlinScala[nodes.Method]) extends Steps[nodes.M
   /**
     * Incoming call sites
     * */
-  def callIn(implicit callResolver: ICallResolver): Call = {
-    new Call(
+  def callIn(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] = {
+    new NodeSteps(
       sideEffect(callResolver.resolveDynamicMethodCallSites).raw
         .in(EdgeTypes.CALL)
         .cast[nodes.Call])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/MethodDOT.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/MethodDOT.scala
@@ -1,14 +1,12 @@
 package io.shiftleft.semanticcpg.language.dotextension
 
-import gremlin.scala._
-
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.dotgenerator.MethodDotGenerator
 import io.shiftleft.semanticcpg.language._
 
-class MethodDOT(override val raw: GremlinScala[nodes.Method]) extends Steps[nodes.Method](raw) {
+class MethodDOT(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
 
   def dot: List[String] =
-    MethodDotGenerator.toDotGraph(this)
+    MethodDotGenerator.toDotGraph(wrapped)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -2,15 +2,12 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions.ControlStructure
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.AstNode
-import io.shiftleft.semanticcpg.language.types.structure.{Local, MethodParameter}
 import scala.jdk.CollectionConverters._
 import io.shiftleft.Implicits.JavaIteratorDeco
 
 class MethodMethods(val node: nodes.Method) extends AnyVal {
 
-  def parameter: MethodParameter =
+  def parameter: NodeSteps[nodes.MethodParameterIn] =
     node.start.parameter
 
   def methodReturn: nodes.MethodReturn =
@@ -19,10 +16,10 @@ class MethodMethods(val node: nodes.Method) extends AnyVal {
       .asJava
       .nextChecked
 
-  def local: Local =
+  def local: NodeSteps[nodes.Local] =
     node.start.local
 
-  def controlStructure: ControlStructure =
+  def controlStructure: NodeSteps[nodes.ControlStructure] =
     node.start.controlStructure
 
   def ast: NodeSteps[nodes.AstNode] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTrav.scala
@@ -2,15 +2,12 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language.types.expressions.IdentifierTrav
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
-import io.shiftleft.semanticcpg.language.Steps
 import io.shiftleft.semanticcpg.language._
 
-class ArrayAccessTrav(raw: GremlinScala[nodes.Call]) extends Steps[nodes.Call](raw) {
+class ArrayAccessTrav(raw: GremlinScala[nodes.Call]) extends NodeSteps[nodes.Call](raw) {
 
-  def array: Expression[nodes.Expression] = map(_.array)
+  def array: NodeSteps[nodes.Expression] = map(_.array)
 
-  def subscripts: IdentifierTrav = flatMap(_.subscripts)
+  def subscripts: NodeSteps[nodes.Identifier] = flatMap(_.subscripts)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTrav.scala
@@ -5,9 +5,6 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 
 class ArrayAccessTrav(raw: GremlinScala[nodes.Call]) extends NodeSteps[nodes.Call](raw) {
-
   def array: NodeSteps[nodes.Expression] = map(_.array)
-
   def subscripts: NodeSteps[nodes.Identifier] = flatMap(_.subscripts)
-
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTrav.scala
@@ -1,16 +1,13 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import gremlin.scala.GremlinScala
-
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression}
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.Steps
 
 /**
   * A wrapper for assignment calls that offers syntactic sugar
   * */
-class AssignmentTrav(override val raw: GremlinScala[Call]) extends Steps[Call](raw) {
-
+class AssignmentTrav(override val raw: GremlinScala[nodes.Call]) extends Steps[nodes.Call](raw) {
   def target: TargetTrav = new TargetTrav(map(_.target).raw)
-
-  def source: Steps[Expression] = map(_.source)
+  def source: Steps[nodes.Expression] = map(_.source)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTrav.scala
@@ -7,10 +7,11 @@ import io.shiftleft.semanticcpg.language.types.expressions.generalizations.AstNo
 
 class OpAstNodeTrav[NodeType <: nodes.AstNode](raw: GremlinScala[NodeType]) {
 
-  def inAssignment = new AssignmentTrav(astNode.flatMap(_.inAssignment).raw)
+  def inAssignment: NodeSteps[nodes.Call] =
+    new NodeSteps(astNode.flatMap(_.inAssignment).raw)
 
-  private def astNode: AstNode[nodes.AstNode] =
-    new AstNode[nodes.AstNode](raw.cast[nodes.AstNode])
+  private def astNode: NodeSteps[nodes.AstNode] =
+    new NodeSteps[nodes.AstNode](raw.cast[nodes.AstNode])
 
   def assignments: AssignmentTrav =
     new AssignmentTrav(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNodeTrav.scala
@@ -3,25 +3,20 @@ package io.shiftleft.semanticcpg.language.operatorextension
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.AstNode
 
 class OpAstNodeTrav[NodeType <: nodes.AstNode](raw: GremlinScala[NodeType]) {
 
   def inAssignment: NodeSteps[nodes.Call] =
     new NodeSteps(astNode.flatMap(_.inAssignment).raw)
 
-  private def astNode: NodeSteps[nodes.AstNode] =
-    new NodeSteps[nodes.AstNode](raw.cast[nodes.AstNode])
-
   def assignments: AssignmentTrav =
-    new AssignmentTrav(
-      new AstNode(raw.cast[nodes.AstNode])
-        .flatMap(_.assignments)
-        .raw)
+    new NodeSteps(astNode.flatMap(_.assignments).raw)
 
   def arithmetics: ArithmeticTrav =
     new ArithmeticTrav(
-      new AstNode(raw.cast[nodes.AstNode])
-        .flatMap(_.arithmetics)
-        .raw)
+      astNode.flatMap(_.arithmetics).raw
+    )
+
+  private def astNode: NodeSteps[nodes.AstNode] =
+    new NodeSteps[nodes.AstNode](raw.cast[nodes.AstNode])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTrav.scala
@@ -1,15 +1,14 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import gremlin.scala.GremlinScala
-import io.shiftleft.codepropertygraph.generated.nodes.Expression
-import io.shiftleft.semanticcpg.language.Steps
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 
-class TargetTrav(override val raw: GremlinScala[Expression]) extends Steps[Expression](raw) {
+class TargetTrav(override val raw: GremlinScala[nodes.Expression]) extends NodeSteps[nodes.Expression](raw) {
 
-  def isArrayAccess: ArrayAccessTrav =
-    new ArrayAccessTrav(raw.map(_.isArrayAccess.l).l.flatten.start.raw)
+  def isArrayAccess: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.map(_.isArrayAccess.l).l.flatten.start.raw)
 
-  def expr: Steps[Expression] = map(_.expr)
+  def expr: NodeSteps[nodes.Expression] = map(_.expr)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/package.scala
@@ -3,13 +3,12 @@ package io.shiftleft.semanticcpg.language
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.nodemethods.CallMethods
-import io.shiftleft.semanticcpg.language.types.expressions.IdentifierTrav
 
 package object operatorextension {
 
   implicit class ArrayAccessExt(val call: nodes.Call) extends AnyVal {
     def array: nodes.Expression = call.argument(1)
-    def subscripts: IdentifierTrav = call.argument(2).ast.isIdentifier
+    def subscripts: NodeSteps[nodes.Identifier] = call.argument(2).ast.isIdentifier
   }
 
   implicit class AssignmentExt(val call: nodes.Call) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/package.scala
@@ -1,28 +1,23 @@
 package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.generated.Operators
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call, Expression}
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language.nodemethods.CallMethods
 import io.shiftleft.semanticcpg.language.types.expressions.IdentifierTrav
 
 package object operatorextension {
 
-  implicit class ArrayAccessExt(val call: Call) extends AnyVal {
-
-    def array: Expression = call.argument(1)
-
+  implicit class ArrayAccessExt(val call: nodes.Call) extends AnyVal {
+    def array: nodes.Expression = call.argument(1)
     def subscripts: IdentifierTrav = call.argument(2).ast.isIdentifier
   }
 
-  implicit class AssignmentExt(val call: Call) extends AnyVal {
-
-    def target: Expression = new CallMethods(call).argument(1)
-
-    def source: Expression = new CallMethods(call).argument(2)
+  implicit class AssignmentExt(val call: nodes.Call) extends AnyVal {
+    def target: nodes.Expression = new CallMethods(call).argument(1)
+    def source: nodes.Expression = new CallMethods(call).argument(2)
   }
 
-  implicit class OpAstNodeExt(val node: AstNode) extends AnyVal {
-
+  implicit class OpAstNodeExt(val node: nodes.AstNode) extends AnyVal {
     def inAssignment: AssignmentTrav =
       new AssignmentTrav(
         node.start.inAstMinusLeaf.isCall.name(NodeTypeStarters.assignmentPattern).raw
@@ -34,12 +29,11 @@ package object operatorextension {
     def arithmetics: ArithmeticTrav =
       new ArithmeticTrav(rawTravForPattern(NodeTypeStarters.arithmeticPattern).raw)
 
-    private def rawTravForPattern(pattern: String): NodeSteps[Call] =
+    private def rawTravForPattern(pattern: String): NodeSteps[nodes.Call] =
       node.ast.isCall.name(pattern)
   }
 
-  implicit class TargetExt(val expr: Expression) extends AnyVal {
-
+  implicit class TargetExt(val expr: nodes.Expression) extends AnyVal {
     def isArrayAccess: ArrayAccessTrav =
       new ArrayAccessTrav(
         expr.ast.isCall
@@ -48,7 +42,8 @@ package object operatorextension {
                      Operators.indexAccess,
                      Operators.indirectIndexAccess)
           .raw)
-
   }
+
+  implicit def toAssignmentTrav(steps: Steps[nodes.Call]): AssignmentTrav = new AssignmentTrav(steps.raw)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -130,7 +130,7 @@ package object language {
     new File(steps.raw)
 
   implicit def toBlock(steps: Steps[nodes.Block]): Block =
-    new Block(steps.raw)
+    new Block(steps)
 
   implicit def toMethodRef(steps: Steps[nodes.MethodRef]): MethodRef =
     new MethodRef(steps.raw)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -90,8 +90,7 @@ package object language {
   implicit def toIdentifier(steps: Steps[nodes.Identifier]): IdentifierTrav =
     new IdentifierTrav(steps.raw)
 
-  implicit def toMember(steps: Steps[nodes.Member]): Member =
-    new Member(steps.raw)
+  implicit def toMember(steps: Steps[nodes.Member]): Member = new Member(steps)
 
   implicit def toMetaData(steps: Steps[nodes.MetaData]): MetaData =
     new MetaData(steps.raw)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -126,14 +126,11 @@ package object language {
   implicit def toAstNode[A <: nodes.AstNode](steps: Steps[A]): AstNode[A] =
     new AstNode(steps.raw)
 
-  implicit def toFile(steps: Steps[nodes.File]): File =
-    new File(steps.raw)
+  implicit def toFile(steps: Steps[nodes.File]): File = new File(steps)
 
-  implicit def toBlock(steps: Steps[nodes.Block]): Block =
-    new Block(steps)
+  implicit def toBlock(steps: Steps[nodes.Block]): Block = new Block(steps)
 
-  implicit def toMethodRef(steps: Steps[nodes.MethodRef]): MethodRef =
-    new MethodRef(steps.raw)
+  implicit def toMethodRef(steps: Steps[nodes.MethodRef]): MethodRef = new MethodRef(steps.raw)
 
   implicit def toBinding(steps: Steps[nodes.Binding]): Binding =
     new Binding(steps)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -92,8 +92,7 @@ package object language {
 
   implicit def toMember(steps: Steps[nodes.Member]): Member = new Member(steps)
 
-  implicit def toMetaData(steps: Steps[nodes.MetaData]): MetaData =
-    new MetaData(steps.raw)
+  implicit def toMetaData(steps: Steps[nodes.MetaData]): MetaData = new MetaData(steps)
 
   implicit def toLocal(steps: Steps[nodes.Local]): Local = new Local(steps)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -255,15 +255,9 @@ package object language {
   }
 
   // Call graph extension
-
-  implicit def toMethodForCallGraph(steps: Steps[nodes.Method]): Method =
-    new Method(steps.raw)
-
-  implicit def toMethodDOTForCallGraph(steps: Steps[nodes.Method]): MethodDOT =
-    new MethodDOT(steps.raw)
-
+  implicit def toMethodForCallGraph(steps: Steps[nodes.Method]): Method = new Method(steps)
+  implicit def toMethodDOTForCallGraph(steps: Steps[nodes.Method]): MethodDOT = new MethodDOT(steps.raw)
   implicit def toCallForCallGraph(steps: Steps[nodes.Call]): Call = new Call(steps)
-
   // / Call graph extension
 
   // Operator extension

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -108,14 +108,11 @@ package object language {
 
   implicit def toNamespaceBlock(steps: Steps[nodes.NamespaceBlock]): NamespaceBlock = new NamespaceBlock(steps)
 
-  implicit def toExpression[A <: nodes.Expression](steps: Steps[A]): Expression[A] =
-    new Expression[A](steps.raw)
+  implicit def toExpression[A <: nodes.Expression](steps: Steps[A]): Expression[A] = new Expression[A](steps)
 
-  implicit def toCfgNode[A <: nodes.CfgNode](steps: Steps[A]): CfgNode[A] =
-    new CfgNode(steps.raw)
+  implicit def toCfgNode[A <: nodes.CfgNode](steps: Steps[A]): CfgNode[A] = new CfgNode(steps)
 
-  implicit def toAstNode[A <: nodes.AstNode](steps: Steps[A]): AstNode[A] =
-    new AstNode(steps.raw)
+  implicit def toAstNode[A <: nodes.AstNode](steps: Steps[A]): AstNode[A] = new AstNode(steps)
 
   implicit def toFile(steps: Steps[nodes.File]): File = new File(steps)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -80,7 +80,7 @@ package object language {
   implicit def toTypeDecl(steps: Steps[nodes.TypeDecl]): TypeDecl = new TypeDecl(steps)
 
   implicit def toCall(steps: Steps[nodes.Call]): OriginalCall =
-    new OriginalCall(steps.raw)
+    new OriginalCall(steps)
 
   implicit def toControlStructure(steps: Steps[nodes.ControlStructure]): ControlStructure =
     new ControlStructure(steps.raw)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -103,7 +103,7 @@ package object language {
     new MethodParameter(steps.raw)
 
   implicit def toMethodParameterOut(steps: Steps[nodes.MethodParameterOut]): MethodParameterOut =
-    new MethodParameterOut(steps.raw)
+    new MethodParameterOut(steps)
 
   implicit def toMethodReturn(steps: Steps[nodes.MethodReturn]): MethodReturn =
     new MethodReturn(steps.raw)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -86,7 +86,7 @@ package object language {
     new ControlStructure(steps.raw)
 
   implicit def toIdentifier(steps: Steps[nodes.Identifier]): IdentifierTrav =
-    new IdentifierTrav(steps.raw)
+    new IdentifierTrav(steps)
 
   implicit def toMember(steps: Steps[nodes.Member]): Member = new Member(steps)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -78,8 +78,7 @@ package object language {
   implicit def toType(steps: Steps[nodes.Type]): Type =
     new Type(steps.raw)
 
-  implicit def toTypeDecl(steps: Steps[nodes.TypeDecl]): TypeDecl =
-    new TypeDecl(steps.raw)
+  implicit def toTypeDecl(steps: Steps[nodes.TypeDecl]): TypeDecl = new TypeDecl(steps)
 
   implicit def toCall(steps: Steps[nodes.Call]): OriginalCall =
     new OriginalCall(steps.raw)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -96,8 +96,7 @@ package object language {
   implicit def toMetaData(steps: Steps[nodes.MetaData]): MetaData =
     new MetaData(steps.raw)
 
-  implicit def toLocal(steps: Steps[nodes.Local]): Local =
-    new Local(steps.raw)
+  implicit def toLocal(steps: Steps[nodes.Local]): Local = new Local(steps)
 
   implicit def toMethod(steps: Steps[nodes.Method]): OriginalMethod =
     new OriginalMethod(steps.raw)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -75,8 +75,7 @@ package object language {
   implicit def toLiteral(steps: Steps[nodes.Literal]): Literal =
     new Literal(steps.raw)
 
-  implicit def toType(steps: Steps[nodes.Type]): Type =
-    new Type(steps.raw)
+  implicit def toType(steps: Steps[nodes.Type]): Type = new Type(steps)
 
   implicit def toTypeDecl(steps: Steps[nodes.TypeDecl]): TypeDecl = new TypeDecl(steps)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -272,7 +272,6 @@ package object language {
   implicit def toNodeStepsTag[NodeType <: nodes.StoredNode](original: Steps[NodeType]): NodeSteps[NodeType] =
     new NodeSteps[NodeType](original.raw)
 
-  implicit def toTagTag(steps: Steps[nodes.Tag]): Tag =
-    new Tag(steps.raw)
+  implicit def toTagTag(steps: Steps[nodes.Tag]): Tag = new Tag(steps)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -262,8 +262,7 @@ package object language {
   implicit def toMethodDOTForCallGraph(steps: Steps[nodes.Method]): MethodDOT =
     new MethodDOT(steps.raw)
 
-  implicit def toCallForCallGraph(steps: Steps[nodes.Call]): Call =
-    new Call(steps.raw)
+  implicit def toCallForCallGraph(steps: Steps[nodes.Call]): Call = new Call(steps)
 
   // / Call graph extension
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -121,7 +121,7 @@ package object language {
 
   implicit def toBlock(steps: Steps[nodes.Block]): Block = new Block(steps)
 
-  implicit def toMethodRef(steps: Steps[nodes.MethodRef]): MethodRef = new MethodRef(steps.raw)
+  implicit def toMethodRef(steps: Steps[nodes.MethodRef]): MethodRef = new MethodRef(steps)
 
   implicit def toBinding(steps: Steps[nodes.Binding]): Binding =
     new Binding(steps)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -136,7 +136,7 @@ package object language {
     new MethodRef(steps.raw)
 
   implicit def toBinding(steps: Steps[nodes.Binding]): Binding =
-    new Binding(steps.raw)
+    new Binding(steps)
 
   implicit def toCodeAccessors[A <: StoredNode with HasCode](steps: Steps[A]): CodeAccessors[A] =
     new CodeAccessors(steps)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -73,7 +73,7 @@ package object language {
   // here.
 
   implicit def toLiteral(steps: Steps[nodes.Literal]): Literal =
-    new Literal(steps.raw)
+    new Literal(steps)
 
   implicit def toType(steps: Steps[nodes.Type]): Type = new Type(steps)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -83,7 +83,7 @@ package object language {
     new OriginalCall(steps)
 
   implicit def toControlStructure(steps: Steps[nodes.ControlStructure]): ControlStructure =
-    new ControlStructure(steps.raw)
+    new ControlStructure(steps)
 
   implicit def toIdentifier(steps: Steps[nodes.Identifier]): IdentifierTrav =
     new IdentifierTrav(steps)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -96,23 +96,19 @@ package object language {
 
   implicit def toLocal(steps: Steps[nodes.Local]): Local = new Local(steps)
 
-  implicit def toMethod(steps: Steps[nodes.Method]): OriginalMethod =
-    new OriginalMethod(steps.raw)
+  implicit def toMethod(steps: Steps[nodes.Method]): OriginalMethod = new OriginalMethod(steps)
 
   implicit def toMethodParameter(steps: Steps[nodes.MethodParameterIn]): MethodParameter =
-    new MethodParameter(steps.raw)
+    new MethodParameter(steps)
 
   implicit def toMethodParameterOut(steps: Steps[nodes.MethodParameterOut]): MethodParameterOut =
     new MethodParameterOut(steps)
 
-  implicit def toMethodReturn(steps: Steps[nodes.MethodReturn]): MethodReturn =
-    new MethodReturn(steps.raw)
+  implicit def toMethodReturn(steps: Steps[nodes.MethodReturn]): MethodReturn = new MethodReturn(steps)
 
-  implicit def toNamespace(steps: Steps[nodes.Namespace]): Namespace =
-    new Namespace(steps.raw)
+  implicit def toNamespace(steps: Steps[nodes.Namespace]): Namespace = new Namespace(steps)
 
-  implicit def toNamespaceBlock(steps: Steps[nodes.NamespaceBlock]): NamespaceBlock =
-    new NamespaceBlock(steps.raw)
+  implicit def toNamespaceBlock(steps: Steps[nodes.NamespaceBlock]): NamespaceBlock = new NamespaceBlock(steps)
 
   implicit def toExpression[A <: nodes.Expression](steps: Steps[A]): Expression[A] =
     new Expression[A](steps.raw)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -256,7 +256,7 @@ package object language {
 
   // Call graph extension
   implicit def toMethodForCallGraph(steps: Steps[nodes.Method]): Method = new Method(steps)
-  implicit def toMethodDOTForCallGraph(steps: Steps[nodes.Method]): MethodDOT = new MethodDOT(steps.raw)
+  implicit def toMethodDOTForCallGraph(steps: Steps[nodes.Method]): MethodDOT = new MethodDOT(steps)
   implicit def toCallForCallGraph(steps: Steps[nodes.Call]): Call = new Call(steps)
   // / Call graph extension
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -17,44 +17,44 @@ class Call(raw: GremlinScala[nodes.Call]) extends NodeSteps[nodes.Call](raw) wit
   /**
     Only statically dispatched calls
     */
-  def isStatic: Call =
+  def isStatic: NodeSteps[nodes.Call] =
     this.dispatchType("STATIC_DISPATCH")
 
   /**
     Only dynamically dispatched calls
     */
-  def isDynamic: Call =
+  def isDynamic: NodeSteps[nodes.Call] =
     this.dispatchType("DYNAMIC_DISPATCH")
 
   /**
     The caller
     */
-  def method: Method =
-    new Method(raw.in(EdgeTypes.CONTAINS).hasLabel(NodeTypes.METHOD).cast[nodes.Method])
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.in(EdgeTypes.CONTAINS).hasLabel(NodeTypes.METHOD).cast[nodes.Method])
 
   /**
     The receiver of a call if the call has a receiver associated.
     */
-  def receiver: Expression[nodes.Expression] =
-    new Expression(raw.out(EdgeTypes.RECEIVER).cast[nodes.Expression])
+  def receiver: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.out(EdgeTypes.RECEIVER).cast[nodes.Expression])
 
   /**
     Arguments of the call
     */
-  def argument: Expression[nodes.Expression] =
-    new Expression(raw.out(EdgeTypes.ARGUMENT).cast[nodes.Expression])
+  def argument: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.out(EdgeTypes.ARGUMENT).cast[nodes.Expression])
 
   /**
     `i'th` arguments of the call
     */
-  def argument(i: Integer): Expression[nodes.Expression] =
+  def argument(i: Integer): NodeSteps[nodes.Expression] =
     argument.argIndex(i)
 
   /**
     To formal method return parameter
     */
-  def toMethodReturn: MethodReturn =
-    new MethodReturn(
+  def toMethodReturn: NodeSteps[nodes.MethodReturn] =
+    new NodeSteps(
       raw
         .out(EdgeTypes.CALL)
         .out(EdgeTypes.AST)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -64,7 +64,7 @@ class Call(raw: GremlinScala[nodes.Call]) extends NodeSteps[nodes.Call](raw) wit
   /**
     * Traverse to referenced members
     * */
-  def referencedMember: Member =
-    new Member(raw.out(EdgeTypes.REF).cast[nodes.Member])
+  def referencedMember: NodeSteps[nodes.Member] =
+    new NodeSteps(raw.out(EdgeTypes.REF).cast[nodes.Member])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -12,19 +12,20 @@ import io.shiftleft.semanticcpg.language.types.structure.{Member, Method, Method
 /**
   A call site
   */
-class Call(raw: GremlinScala[nodes.Call]) extends NodeSteps[nodes.Call](raw) with EvalTypeAccessors[nodes.Call] {
+class Call(val wrapped: NodeSteps[nodes.Call]) extends EvalTypeAccessors[nodes.Call] {
+  override val raw: GremlinScala[nodes.Call] = wrapped.raw
 
   /**
     Only statically dispatched calls
     */
   def isStatic: NodeSteps[nodes.Call] =
-    this.dispatchType("STATIC_DISPATCH")
+    wrapped.dispatchType("STATIC_DISPATCH")
 
   /**
     Only dynamically dispatched calls
     */
   def isDynamic: NodeSteps[nodes.Call] =
-    this.dispatchType("DYNAMIC_DISPATCH")
+    wrapped.dispatchType("DYNAMIC_DISPATCH")
 
   /**
     The caller

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
@@ -16,8 +16,8 @@ class ControlStructure(raw: GremlinScala[nodes.ControlStructure]) extends NodeSt
   /**
     * The expression introduced by this control structure, if any
     * */
-  def condition: Expression[nodes.Expression] =
-    new Expression(raw.out(EdgeTypes.CONDITION).cast[nodes.Expression])
+  def condition: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.out(EdgeTypes.CONDITION).cast[nodes.Expression])
 
   def whenTrue: NodeSteps[nodes.AstNode] =
     new NodeSteps(raw.out.has(NodeKeys.ORDER, secondChildIndex).cast[nodes.AstNode])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
@@ -1,28 +1,26 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
-import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{AstNode, Expression}
 
 object ControlStructure {
   val secondChildIndex = new Integer(2)
   val thirdChildIndex = new Integer(3)
 }
 
-class ControlStructure(raw: GremlinScala[nodes.ControlStructure]) extends NodeSteps[nodes.ControlStructure](raw) {
+class ControlStructure(val wrapped: NodeSteps[nodes.ControlStructure]) extends AnyVal {
   import ControlStructure._
 
   /**
     * The expression introduced by this control structure, if any
     * */
   def condition: NodeSteps[nodes.Expression] =
-    new NodeSteps(raw.out(EdgeTypes.CONDITION).cast[nodes.Expression])
+    new NodeSteps(wrapped.raw.out(EdgeTypes.CONDITION).cast[nodes.Expression])
 
   def whenTrue: NodeSteps[nodes.AstNode] =
-    new NodeSteps(raw.out.has(NodeKeys.ORDER, secondChildIndex).cast[nodes.AstNode])
+    new NodeSteps(wrapped.raw.out.has(NodeKeys.ORDER, secondChildIndex).cast[nodes.AstNode])
 
   def whenFalse: NodeSteps[nodes.AstNode] =
-    new NodeSteps(raw.out.has(NodeKeys.ORDER, thirdChildIndex).cast[nodes.AstNode])
+    new NodeSteps(wrapped.raw.out.has(NodeKeys.ORDER, thirdChildIndex).cast[nodes.AstNode])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTrav.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTrav.scala
@@ -3,15 +3,15 @@ package io.shiftleft.semanticcpg.language.types.expressions
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.Identifier
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
 /**
   An identifier, e.g., an instance of a local variable, or a temporary variable
   */
-class IdentifierTrav(raw: GremlinScala[nodes.Identifier])
-    extends NodeSteps[nodes.Identifier](raw)
-    with EvalTypeAccessors[nodes.Identifier] {
+class IdentifierTrav(val wrapped: NodeSteps[nodes.Identifier]) extends EvalTypeAccessors[nodes.Identifier] {
+  override val raw: GremlinScala[Identifier] = wrapped.raw
 
   /**
     * Traverse to all declarations of this identifier

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
@@ -16,8 +16,8 @@ class Literal(raw: GremlinScala[nodes.Literal])
   /**
     * Traverse to method hosting this literal
     * */
-  def method: Method =
-    new Method(
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(
       raw
         .cast[nodes.StoredNode]
         .repeat(_.in(EdgeTypes.AST).cast[nodes.StoredNode])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Literal.scala
@@ -9,9 +9,8 @@ import io.shiftleft.semanticcpg.language.types.structure.Method
 /**
   A literal, e.g., a constant string or number
   */
-class Literal(raw: GremlinScala[nodes.Literal])
-    extends NodeSteps[nodes.Literal](raw)
-    with EvalTypeAccessors[nodes.Literal] {
+class Literal(val wrapped: NodeSteps[nodes.Literal]) extends EvalTypeAccessors[nodes.Literal] {
+  override val raw: GremlinScala[nodes.Literal] = wrapped.raw
 
   /**
     * Traverse to method hosting this literal

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRef.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRef.scala
@@ -1,15 +1,13 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
-import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.structure.Method
 
-class MethodRef(raw: GremlinScala[nodes.MethodRef]) extends NodeSteps[nodes.MethodRef](raw) {
+class MethodRef(val wrapped: NodeSteps[nodes.MethodRef]) extends AnyVal {
 
   /**
     * Traverse to referenced method.
     * */
   def referencedMethod: NodeSteps[nodes.Method] =
-    new NodeSteps(raw.out(EdgeTypes.REF).cast[nodes.Method])
+    new NodeSteps(wrapped.raw.out(EdgeTypes.REF).cast[nodes.Method])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRef.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRef.scala
@@ -10,6 +10,6 @@ class MethodRef(raw: GremlinScala[nodes.MethodRef]) extends NodeSteps[nodes.Meth
   /**
     * Traverse to referenced method.
     * */
-  def referencedMethod: Method =
-    new Method(raw.out(EdgeTypes.REF).cast[nodes.Method])
+  def referencedMethod: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.out(EdgeTypes.REF).cast[nodes.Method])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -93,8 +93,8 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
   /**
     * Traverse only to those AST nodes that are blocks
     * */
-  def isBlock: Block =
-    new Block(raw.hasLabel(NodeTypes.BLOCK).cast[nodes.Block])
+  def isBlock: NodeSteps[nodes.Block] =
+    new NodeSteps(raw.hasLabel(NodeTypes.BLOCK).cast[nodes.Block])
 
   /**
     * Traverse only to those AST nodes that are control structures

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -1,25 +1,22 @@
 package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
-import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.NodeSteps
-import io.shiftleft.semanticcpg.language.types.structure.Block
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions._
 
-class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw) {
+class AstNode[A <: nodes.AstNode](val wrapped: NodeSteps[A]) extends AnyVal {
 
   /**
     * Nodes of the AST rooted in this node, including the node itself.
     * */
   def ast: NodeSteps[nodes.AstNode] =
-    new NodeSteps(raw.emit.repeat(_.out(EdgeTypes.AST)).cast[nodes.AstNode])
+    new NodeSteps(wrapped.raw.emit.repeat(_.out(EdgeTypes.AST)).cast[nodes.AstNode])
 
   def containsCallTo(regex: String): NodeSteps[A] =
-    where(_.ast.isCall.name(regex).size > 0)
+    wrapped.where(_.ast.isCall.name(regex).size > 0)
 
   def depth(p: nodes.AstNode => Boolean): Steps[Int] =
-    map(_.depth(p))
+    wrapped.map(_.depth(p))
 
   def isCallTo(regex: String): NodeSteps[nodes.Call] =
     isCall.name(regex)
@@ -28,19 +25,19 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
     * Nodes of the AST rooted in this node, minus the node itself
     * */
   def astMinusRoot: NodeSteps[nodes.AstNode] =
-    new NodeSteps(raw.repeat(_.out(EdgeTypes.AST)).emit.cast[nodes.AstNode])
+    new NodeSteps(wrapped.raw.repeat(_.out(EdgeTypes.AST)).emit.cast[nodes.AstNode])
 
   /**
     * Direct children of node in the AST
     * */
   def astChildren: NodeSteps[nodes.AstNode] =
-    new NodeSteps(raw.out(EdgeTypes.AST).cast[nodes.AstNode])
+    new NodeSteps(wrapped.raw.out(EdgeTypes.AST).cast[nodes.AstNode])
 
   /**
     * Parent AST node
     * */
   def astParent: NodeSteps[nodes.AstNode] =
-    new NodeSteps(raw.in(EdgeTypes.AST).cast[nodes.AstNode])
+    new NodeSteps(wrapped.raw.in(EdgeTypes.AST).cast[nodes.AstNode])
 
   /**
     * Nodes of the AST obtained by expanding AST edges backwards until the method root is reached
@@ -59,7 +56,7 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
     * */
   def inAst(root: nodes.AstNode): NodeSteps[nodes.AstNode] =
     new NodeSteps(
-      raw.emit
+      wrapped.raw.emit
         .until(_.or(_.hasLabel(NodeTypes.METHOD), _.filterOnEnd(n => root != null && root == n)))
         .repeat(_.in(EdgeTypes.AST))
         .cast[nodes.AstNode])
@@ -70,7 +67,7 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
     * */
   def inAstMinusLeaf(root: nodes.AstNode): NodeSteps[nodes.AstNode] =
     new NodeSteps(
-      raw
+      wrapped.raw
         .until(_.or(_.hasLabel(NodeTypes.METHOD), _.filterOnEnd(n => root != null && root == n)))
         .repeat(_.in(EdgeTypes.AST))
         .emit
@@ -82,37 +79,37 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
     * "member access operation", e.g., "<operator>.memberAccess".
     * */
   def parentExpression: NodeSteps[nodes.Expression] =
-    new NodeSteps(raw.map(_.parentExpression))
+    new NodeSteps(wrapped.raw.map(_.parentExpression))
 
   /**
     * Traverse only to those AST nodes that are also control flow graph nodes
     * */
   def isCfgNode: NodeSteps[nodes.CfgNode] =
-    new NodeSteps(raw.filterOnEnd(_.isInstanceOf[nodes.CfgNode]).cast[nodes.CfgNode])
+    new NodeSteps(wrapped.raw.filterOnEnd(_.isInstanceOf[nodes.CfgNode]).cast[nodes.CfgNode])
 
   /**
     * Traverse only to those AST nodes that are blocks
     * */
   def isBlock: NodeSteps[nodes.Block] =
-    new NodeSteps(raw.hasLabel(NodeTypes.BLOCK).cast[nodes.Block])
+    new NodeSteps(wrapped.raw.hasLabel(NodeTypes.BLOCK).cast[nodes.Block])
 
   /**
     * Traverse only to those AST nodes that are control structures
     * */
   def isControlStructure: NodeSteps[nodes.ControlStructure] =
-    new NodeSteps(raw.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
+    new NodeSteps(wrapped.raw.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
 
   /**
     * Traverse only to AST nodes that are expressions
     * */
   def isExpression: NodeSteps[nodes.Expression] =
-    new NodeSteps(raw.filterOnEnd(_.isInstanceOf[nodes.Expression]).cast[nodes.Expression])
+    new NodeSteps(wrapped.raw.filterOnEnd(_.isInstanceOf[nodes.Expression]).cast[nodes.Expression])
 
   /**
     * Traverse only to AST nodes that are calls
     * */
   def isCall: NodeSteps[nodes.Call] =
-    new NodeSteps(raw.hasLabel(NodeTypes.CALL).cast[nodes.Call])
+    new NodeSteps(wrapped.raw.hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**
   Cast to call if applicable and filter on call code `calleeRegex`
@@ -124,29 +121,29 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
     * Traverse only to AST nodes that are literals
     * */
   def isLiteral: NodeSteps[nodes.Literal] =
-    new NodeSteps(raw.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
+    new NodeSteps(wrapped.raw.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
   /**
     * Traverse only to AST nodes that are identifier
     * */
   def isIdentifier: NodeSteps[nodes.Identifier] =
-    new NodeSteps(raw.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+    new NodeSteps(wrapped.raw.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * Traverse only to AST nodes that are return nodes
     * */
   def isReturn: NodeSteps[nodes.Return] =
-    new NodeSteps(raw.hasLabel(NodeTypes.RETURN).cast[nodes.Return])
+    new NodeSteps(wrapped.raw.hasLabel(NodeTypes.RETURN).cast[nodes.Return])
 
   /**
     * Traverse only to AST nodes that are method reference nodes.
     */
   def isMethodRef: NodeSteps[nodes.MethodRef] =
-    new NodeSteps(raw.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
+    new NodeSteps(wrapped.raw.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
 
   def walkAstUntilReaching(labels: List[String]): NodeSteps[nodes.StoredNode] =
     new NodeSteps[nodes.StoredNode](
-      raw
+      wrapped.raw
         .repeat(_.out(EdgeTypes.AST))
         .until(_.hasLabel(labels.head, labels.tail: _*))
         .emit

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -21,7 +21,7 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
   def depth(p: nodes.AstNode => Boolean): Steps[Int] =
     map(_.depth(p))
 
-  def isCallTo(regex: String): Call =
+  def isCallTo(regex: String): NodeSteps[nodes.Call] =
     isCall.name(regex)
 
   /**
@@ -81,14 +81,14 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
     * It's continuing it's walk until it hits an expression that's not a generic
     * "member access operation", e.g., "<operator>.memberAccess".
     * */
-  def parentExpression: Expression[nodes.Expression] =
-    new Expression(raw.map(_.parentExpression))
+  def parentExpression: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.map(_.parentExpression))
 
   /**
     * Traverse only to those AST nodes that are also control flow graph nodes
     * */
-  def isCfgNode: CfgNode[nodes.CfgNode] =
-    new CfgNode(raw.filterOnEnd(_.isInstanceOf[nodes.CfgNode]).cast[nodes.CfgNode])
+  def isCfgNode: NodeSteps[nodes.CfgNode] =
+    new NodeSteps(raw.filterOnEnd(_.isInstanceOf[nodes.CfgNode]).cast[nodes.CfgNode])
 
   /**
     * Traverse only to those AST nodes that are blocks
@@ -99,38 +99,38 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
   /**
     * Traverse only to those AST nodes that are control structures
     * */
-  def isControlStructure: ControlStructure =
-    new ControlStructure(raw.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
+  def isControlStructure: NodeSteps[nodes.ControlStructure] =
+    new NodeSteps(raw.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
 
   /**
     * Traverse only to AST nodes that are expressions
     * */
-  def isExpression: Expression[nodes.Expression] =
-    new Expression(raw.filterOnEnd(_.isInstanceOf[nodes.Expression]).cast[nodes.Expression])
+  def isExpression: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.filterOnEnd(_.isInstanceOf[nodes.Expression]).cast[nodes.Expression])
 
   /**
     * Traverse only to AST nodes that are calls
     * */
-  def isCall: Call =
-    new Call(raw.hasLabel(NodeTypes.CALL).cast[nodes.Call])
+  def isCall: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**
   Cast to call if applicable and filter on call code `calleeRegex`
     */
-  def isCall(calleeRegex: String): Call =
+  def isCall(calleeRegex: String): NodeSteps[nodes.Call] =
     isCall.filter(_.code(calleeRegex))
 
   /**
     * Traverse only to AST nodes that are literals
     * */
-  def isLiteral: Literal =
-    new Literal(raw.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
+  def isLiteral: NodeSteps[nodes.Literal] =
+    new NodeSteps(raw.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
   /**
     * Traverse only to AST nodes that are identifier
     * */
-  def isIdentifier: IdentifierTrav =
-    new IdentifierTrav(raw.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def isIdentifier: NodeSteps[nodes.Identifier] =
+    new NodeSteps(raw.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * Traverse only to AST nodes that are return nodes
@@ -141,8 +141,8 @@ class AstNode[A <: nodes.AstNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
   /**
     * Traverse only to AST nodes that are method reference nodes.
     */
-  def isMethodRef: MethodRef =
-    new MethodRef(raw.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
+  def isMethodRef: NodeSteps[nodes.MethodRef] =
+    new NodeSteps(raw.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
 
   def walkAstUntilReaching(labels: List[String]): NodeSteps[nodes.StoredNode] =
     new NodeSteps[nodes.StoredNode](

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -11,8 +11,8 @@ class CfgNode[A <: nodes.CfgNode](raw: GremlinScala[A]) extends NodeSteps[A](raw
   /**
   Traverse to enclosing method
     */
-  def method: Method = {
-    new Method(
+  def method: NodeSteps[nodes.Method] = {
+    new NodeSteps(
       raw
         .map {
           case method: nodes.Method =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -1,19 +1,17 @@
 package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
-import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.structure.Method
 import io.shiftleft.semanticcpg.utils.ExpandTo
 
-class CfgNode[A <: nodes.CfgNode](raw: GremlinScala[A]) extends NodeSteps[A](raw) {
+class CfgNode[A <: nodes.CfgNode](val wrapped: NodeSteps[A]) extends AnyVal {
 
   /**
   Traverse to enclosing method
     */
   def method: NodeSteps[nodes.Method] = {
     new NodeSteps(
-      raw
+      wrapped.raw
         .map {
           case method: nodes.Method =>
             method

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -11,10 +11,9 @@ import io.shiftleft.semanticcpg.language.types.structure.{Method, MethodParamete
 /**
   An expression (base type)
   */
-class Expression[A <: nodes.Expression](raw: GremlinScala[A])
-    extends NodeSteps[A](raw)
-    with ArgumentIndexAccessors[A]
-    with EvalTypeAccessors[A] {
+class Expression[A <: nodes.Expression](val wrapped: NodeSteps[A])
+    extends ArgumentIndexAccessors[A] with EvalTypeAccessors[A] {
+  override val raw: GremlinScala[A] = wrapped.raw
 
   /**
     Traverse to enclosing expression
@@ -108,4 +107,5 @@ class Expression[A <: nodes.Expression](raw: GremlinScala[A])
     * */
   def typ: NodeSteps[nodes.Type] =
     new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -12,7 +12,8 @@ import io.shiftleft.semanticcpg.language.types.structure.{Method, MethodParamete
   An expression (base type)
   */
 class Expression[A <: nodes.Expression](val wrapped: NodeSteps[A])
-    extends ArgumentIndexAccessors[A] with EvalTypeAccessors[A] {
+    extends ArgumentIndexAccessors[A]
+    with EvalTypeAccessors[A] {
   override val raw: GremlinScala[A] = wrapped.raw
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -19,14 +19,14 @@ class Expression[A <: nodes.Expression](raw: GremlinScala[A])
   /**
     Traverse to enclosing expression
     */
-  def expressionUp: Expression[nodes.Expression] =
-    new Expression(raw.in(EdgeTypes.AST).not(_.hasLabel(NodeTypes.LOCAL)).cast[nodes.Expression])
+  def expressionUp: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.in(EdgeTypes.AST).not(_.hasLabel(NodeTypes.LOCAL)).cast[nodes.Expression])
 
   /**
     Traverse to sub expressions
     */
-  def expressionDown: Expression[nodes.Expression] =
-    new Expression(
+  def expressionDown: NodeSteps[nodes.Expression] =
+    new NodeSteps(
       raw
         .out(EdgeTypes.AST)
         .not(_.hasLabel(NodeTypes.LOCAL))
@@ -35,33 +35,33 @@ class Expression[A <: nodes.Expression](raw: GremlinScala[A])
   /**
     If the expression is used as receiver for a call, this traverses to the call.
     */
-  def receivedCall: Call =
-    new Call(raw.in(EdgeTypes.RECEIVER).cast[nodes.Call])
+  def receivedCall: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.in(EdgeTypes.RECEIVER).cast[nodes.Call])
 
   /**
     * Only those expressions which are (direct) arguments of a call
     * */
-  def isArgument: Expression[nodes.Expression] =
-    new Expression(raw.filter(_.in(EdgeTypes.ARGUMENT)).cast[nodes.Expression])
+  def isArgument: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.filter(_.in(EdgeTypes.ARGUMENT)).cast[nodes.Expression])
 
   /**
     * Traverse to surrounding call
     * */
-  def call: Call =
-    new Call(raw.repeat(_.in(EdgeTypes.ARGUMENT)).until(_.hasLabel(NodeTypes.CALL)).cast[nodes.Call])
+  def call: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.repeat(_.in(EdgeTypes.ARGUMENT)).until(_.hasLabel(NodeTypes.CALL)).cast[nodes.Call])
 
   /**
   Traverse to related parameter
     */
   @deprecated("", "October 2019")
-  def toParameter: MethodParameter = parameter
+  def toParameter: NodeSteps[nodes.MethodParameterIn] = parameter
 
   /**
     Traverse to related parameter, if the expression is an argument to a call and the call
     can be resolved.
     */
-  def parameter: MethodParameter = {
-    new MethodParameter(
+  def parameter: NodeSteps[nodes.MethodParameterIn] =
+    new NodeSteps(
       raw
         .sack((sack: Integer, node: nodes.Expression) => node.value2(NodeKeys.ARGUMENT_INDEX))
         .in(EdgeTypes.ARGUMENT)
@@ -74,19 +74,18 @@ class Expression[A <: nodes.Expression](raw: GremlinScala[A])
         }
         .cast[nodes.MethodParameterIn]
     )
-  }
 
   /**
     Traverse to enclosing method
     */
-  def method: Method =
-    new Method(raw.in(EdgeTypes.CONTAINS).cast[nodes.Method])
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.in(EdgeTypes.CONTAINS).cast[nodes.Method])
 
   /**
     * Traverse to next expression in CFG.
     */
-  def cfgNext: Expression[nodes.Expression] =
-    new Expression(
+  def cfgNext: NodeSteps[nodes.Expression] =
+    new NodeSteps(
       raw
         .out(EdgeTypes.CFG)
         .filterNot(_.hasLabel(NodeTypes.METHOD_RETURN))
@@ -96,8 +95,8 @@ class Expression[A <: nodes.Expression](raw: GremlinScala[A])
   /**
     * Traverse to previous expression in CFG.
     */
-  def cfgPrev: Expression[nodes.Expression] =
-    new Expression(
+  def cfgPrev: NodeSteps[nodes.Expression] =
+    new NodeSteps(
       raw
         .in(EdgeTypes.CFG)
         .filterNot(_.hasLabel(NodeTypes.METHOD))
@@ -107,6 +106,6 @@ class Expression[A <: nodes.Expression](raw: GremlinScala[A])
   /**
     * Traverse to expression evaluation type
     * */
-  def typ: Type =
-    new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+  def typ: NodeSteps[nodes.Type] =
+    new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Binding.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Binding.scala
@@ -1,20 +1,19 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
 
-class Binding(raw: GremlinScala[nodes.Binding]) extends NodeSteps[nodes.Binding](raw) {
+class Binding(val wrapped: NodeSteps[nodes.Binding]) extends AnyVal {
 
   /**
     * Traverse to the method bound by this method binding.
     */
   def boundMethod: Method =
-    new Method(raw.out(EdgeTypes.REF).cast[nodes.Method])
+    new Method(wrapped.raw.out(EdgeTypes.REF).cast[nodes.Method])
 
   /**
     * Traverse to the method bound by this method binding.
     */
   def bindingTypeDecl: TypeDecl =
-    new TypeDecl(raw.in(EdgeTypes.BINDS).cast[nodes.TypeDecl])
+    new TypeDecl(wrapped.raw.in(EdgeTypes.BINDS).cast[nodes.TypeDecl])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Binding.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Binding.scala
@@ -8,12 +8,12 @@ class Binding(val wrapped: NodeSteps[nodes.Binding]) extends AnyVal {
   /**
     * Traverse to the method bound by this method binding.
     */
-  def boundMethod: Method =
-    new Method(wrapped.raw.out(EdgeTypes.REF).cast[nodes.Method])
+  def boundMethod: NodeSteps[nodes.Method] =
+    new NodeSteps(wrapped.raw.out(EdgeTypes.REF).cast[nodes.Method])
 
   /**
     * Traverse to the method bound by this method binding.
     */
-  def bindingTypeDecl: TypeDecl =
-    new TypeDecl(wrapped.raw.in(EdgeTypes.BINDS).cast[nodes.TypeDecl])
+  def bindingTypeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(wrapped.raw.in(EdgeTypes.BINDS).cast[nodes.TypeDecl])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Block.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Block.scala
@@ -1,15 +1,14 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language._
 
-class Block(raw: GremlinScala[nodes.Block]) extends NodeSteps[nodes.Block](raw) {
+class Block(val wrapped: NodeSteps[nodes.Block]) extends AnyVal {
 
   /**
     * Traverse to locals of this block.
     */
-  def local: Local =
-    new Local(raw.out(EdgeTypes.AST).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
+  def local: NodeSteps[nodes.Local] =
+    new NodeSteps(wrapped.raw.out(EdgeTypes.AST).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/File.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/File.scala
@@ -1,30 +1,28 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
-import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language._
 
 /**
   * A compilation unit
   * */
-class File(raw: GremlinScala[nodes.File]) extends NodeSteps[nodes.File](raw) {
+class File(val wrapped: NodeSteps[nodes.File]) extends AnyVal {
 
-  def typeDecl: TypeDecl =
-    new TypeDecl(
-      raw
+  def typeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(
+      wrapped.raw
         .out(EdgeTypes.AST)
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.TYPE_DECL)
         .cast[nodes.TypeDecl])
 
-  def namespace: Namespace =
-    new Namespace(raw.out(EdgeTypes.AST).out(EdgeTypes.REF).cast[nodes.Namespace])
+  def namespace: NodeSteps[nodes.Namespace] =
+    new NodeSteps(wrapped.raw.out(EdgeTypes.AST).out(EdgeTypes.REF).cast[nodes.Namespace])
 
-  def namespaceBlock: NamespaceBlock =
-    new NamespaceBlock(raw.out(EdgeTypes.AST).hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
+  def namespaceBlock: NodeSteps[nodes.NamespaceBlock] =
+    new NodeSteps(wrapped.raw.out(EdgeTypes.AST).hasLabel(NodeTypes.NAMESPACE_BLOCK).cast[nodes.NamespaceBlock])
 
   def comment: NodeSteps[nodes.Comment] =
-    new NodeSteps(raw.out(EdgeTypes.AST).hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
+    new NodeSteps(wrapped.raw.out(EdgeTypes.AST).hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -1,12 +1,15 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.propertyaccessors.EvalTypeAccessors
 
 /**
   * A local variable
   * */
-class Local(val wrapped: NodeSteps[nodes.Local]) extends AnyVal {
+class Local(val wrapped: NodeSteps[nodes.Local]) extends EvalTypeAccessors[nodes.Local] {
+  override val raw: GremlinScala[nodes.Local] = wrapped.raw
 
   /**
     * The method hosting this local variable

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -8,7 +8,7 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 /**
   * A local variable
   * */
-class Local(raw: GremlinScala[nodes.Local]) extends NodeSteps[nodes.Local](raw) with EvalTypeAccessors[nodes.Local] {
+class Local(val wrapped: NodeSteps[nodes.Local]) extends AnyVal {
 
   /**
     * The method hosting this local variable
@@ -16,7 +16,7 @@ class Local(raw: GremlinScala[nodes.Local]) extends NodeSteps[nodes.Local](raw) 
   def method: NodeSteps[nodes.Method] = {
     // TODO The following line of code is here for backwards compatibility.
     // Use the lower commented out line once not required anymore.
-    new Method(raw.repeat(_.in(EdgeTypes.AST)).until(_.hasLabel(NodeTypes.METHOD)).cast[nodes.Method])
+    new NodeSteps(wrapped.raw.repeat(_.in(EdgeTypes.AST)).until(_.hasLabel(NodeTypes.METHOD)).cast[nodes.Method])
     //definingBlock.method
   }
 
@@ -24,13 +24,13 @@ class Local(raw: GremlinScala[nodes.Local]) extends NodeSteps[nodes.Local](raw) 
     * The block in which local is declared.
     */
   def definingBlock: NodeSteps[nodes.Block] =
-    new NodeSteps(raw.in(EdgeTypes.AST).cast[nodes.Block])
+    new NodeSteps(wrapped.raw.in(EdgeTypes.AST).cast[nodes.Block])
 
   /**
     * Places (identifier) where this local is being referenced
     * */
   def referencingIdentifiers: NodeSteps[nodes.Identifier] =
-    new NodeSteps(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+    new NodeSteps(wrapped.raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * The type of the local.
@@ -38,5 +38,5 @@ class Local(raw: GremlinScala[nodes.Local]) extends NodeSteps[nodes.Local](raw) 
     * Unfortunately, `type` is a keyword, so we use `typ` here.
     * */
   def typ: NodeSteps[nodes.Type] =
-    new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+    new NodeSteps(wrapped.raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -3,7 +3,6 @@ package io.shiftleft.semanticcpg.language.types.structure
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions.IdentifierTrav
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
 /**
@@ -24,20 +23,20 @@ class Local(raw: GremlinScala[nodes.Local]) extends NodeSteps[nodes.Local](raw) 
   /**
     * The block in which local is declared.
     */
-  def definingBlock: Block =
-    new Block(raw.in(EdgeTypes.AST).cast[nodes.Block])
+  def definingBlock: NodeSteps[nodes.Block] =
+    new NodeSteps(raw.in(EdgeTypes.AST).cast[nodes.Block])
 
   /**
     * Places (identifier) where this local is being referenced
     * */
-  def referencingIdentifiers: IdentifierTrav =
-    new IdentifierTrav(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def referencingIdentifiers: NodeSteps[nodes.Identifier] =
+    new NodeSteps(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * The type of the local.
     *
     * Unfortunately, `type` is a keyword, so we use `typ` here.
     * */
-  def typ: Type =
-    new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+  def typ: NodeSteps[nodes.Type] =
+    new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Local.scala
@@ -1,9 +1,7 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
 /**
   * A local variable

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
@@ -9,7 +9,9 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors.{EvalTypeAccess
 /**
   * A member variable of a class/type.
   * */
-class Member(val wrapped: NodeSteps[nodes.Member]) extends EvalTypeAccessors[nodes.Member] with ModifierAccessors[nodes.Member] {
+class Member(val wrapped: NodeSteps[nodes.Member])
+    extends EvalTypeAccessors[nodes.Member]
+    with ModifierAccessors[nodes.Member] {
   override val raw: GremlinScala[nodes.Member] = wrapped.raw
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Member.scala
@@ -1,59 +1,57 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import gremlin.scala._
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions.Call
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.{EvalTypeAccessors, ModifierAccessors}
 
 /**
   * A member variable of a class/type.
   * */
-class Member(raw: GremlinScala[nodes.Member])
-    extends NodeSteps[nodes.Member](raw)
-    with EvalTypeAccessors[nodes.Member]
-    with ModifierAccessors[nodes.Member] {
+class Member(val wrapped: NodeSteps[nodes.Member]) extends EvalTypeAccessors[nodes.Member] with ModifierAccessors[nodes.Member] {
+  override val raw: GremlinScala[nodes.Member] = wrapped.raw
 
   /**
     * The type declaration this member is defined in
     * */
-  def typeDecl: TypeDecl =
-    new TypeDecl(raw.in(EdgeTypes.AST).cast[nodes.TypeDecl])
+  def typeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(raw.in(EdgeTypes.AST).cast[nodes.TypeDecl])
 
   /**
     * Places where
     * */
-  def ref: Call =
-    new Call(raw.in(EdgeTypes.REF).cast[nodes.Call])
+  def ref: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.in(EdgeTypes.REF).cast[nodes.Call])
 
   /**
     * Public members
     * */
-  def isPublic: Member =
+  def isPublic: NodeSteps[nodes.Member] =
     hasModifier(ModifierTypes.PUBLIC)
 
   /**
     * Private members
     * */
-  def isPrivate: Member =
+  def isPrivate: NodeSteps[nodes.Member] =
     hasModifier(ModifierTypes.PRIVATE)
 
   /**
     * Protected members
     * */
-  def isProtected: Member =
+  def isProtected: NodeSteps[nodes.Member] =
     hasModifier(ModifierTypes.PROTECTED)
 
   /**
     * Static members
     * */
-  def isStatic: Member =
+  def isStatic: NodeSteps[nodes.Member] =
     hasModifier(ModifierTypes.STATIC)
 
   /**
     * Traverse to member type
     * */
-  def typ: Type =
-    new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+  def typ: NodeSteps[nodes.Type] =
+    new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MetaData.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MetaData.scala
@@ -7,12 +7,12 @@ import io.shiftleft.semanticcpg.language.NodeSteps
 /**
   * A meta data entry
   * */
-class MetaData(raw: GremlinScala[nodes.MetaData]) extends NodeSteps[nodes.MetaData](raw) {
+class MetaData(val wrapped: NodeSteps[nodes.MetaData]) extends AnyVal {
 
   /**
     * Returns the programming language of the code for which this CPG was
     * generated from.
     * */
-  def language: GremlinScala[String] = raw.map(_.language)
+  def language: GremlinScala[String] = wrapped.raw.map(_.language)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -19,8 +19,8 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse to parameters of the method
     * */
-  def parameter: MethodParameter =
-    new MethodParameter(
+  def parameter: NodeSteps[nodes.MethodParameterIn] =
+    new NodeSteps(
       raw
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
@@ -29,13 +29,13 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse to formal return parameter
     * */
-  def methodReturn: MethodReturn =
-    new MethodReturn(raw.map(_.methodReturn))
+  def methodReturn: NodeSteps[nodes.MethodReturn] =
+    new NodeSteps(raw.map(_.methodReturn))
 
   /**
     * Traverse to type decl which have this method bound to it.
     */
-  def bindingTypeDecl: TypeDecl =
+  def bindingTypeDecl: NodeSteps[nodes.TypeDecl] =
     referencingBinding.bindingTypeDecl
 
   /**
@@ -47,26 +47,26 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * All control structures of this method
     * */
-  def controlStructure: ControlStructure =
+  def controlStructure: NodeSteps[nodes.ControlStructure] =
     this.ast.isControlStructure
 
   /**
     * Shorthand to traverse to control structures where condition matches `regex`
     * */
-  def controlStructure(regex: String): ControlStructure =
+  def controlStructure(regex: String): NodeSteps[nodes.ControlStructure] =
     this.ast.isControlStructure.code(regex)
 
   /**
     * Outgoing call sites
     * */
-  def callOut: Call =
-    new Call(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call])
+  def callOut: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**
     * The type declaration associated with this method, e.g., the class it is defined in.
     * */
-  def definingTypeDecl: TypeDecl =
-    new TypeDecl(
+  def definingTypeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(
       raw
         .cast[nodes.StoredNode]
         .repeat(_.in(EdgeTypes.AST).cast[nodes.StoredNode])
@@ -76,8 +76,8 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * The method in which this method is defined
     * */
-  def definingMethod: Method =
-    new Method(
+  def definingMethod: NodeSteps[nodes.Method] =
+    new NodeSteps(
       raw
         .cast[nodes.StoredNode]
         .repeat(_.in(EdgeTypes.AST).cast[nodes.StoredNode])
@@ -87,76 +87,76 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse only to methods that are stubs, e.g., their code is not available
     * */
-  def isStub: Method =
-    new Method(raw.filter(_.not(_.out(EdgeTypes.CFG))))
+  def isStub: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.filter(_.not(_.out(EdgeTypes.CFG))))
 
   /**
     * Traverse only to methods that are not stubs.
     * */
-  def isNotStub: Method =
-    new Method(raw.filter(_.out(EdgeTypes.CFG)))
+  def isNotStub: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.filter(_.out(EdgeTypes.CFG)))
 
   /**
     * Traverse to public methods
     * */
-  def isPublic: Method =
+  def isPublic: NodeSteps[nodes.Method] =
     hasModifier(ModifierTypes.PUBLIC)
 
   /**
     * Traverse to private methods
     * */
-  def isPrivate: Method =
+  def isPrivate: NodeSteps[nodes.Method] =
     hasModifier(ModifierTypes.PRIVATE)
 
   /**
     * Traverse to protected methods
     * */
-  def isProtected: Method =
+  def isProtected: NodeSteps[nodes.Method] =
     hasModifier(ModifierTypes.PROTECTED)
 
   /**
     * Traverse to abstract methods
     * */
-  def isAbstract: Method =
+  def isAbstract: NodeSteps[nodes.Method] =
     hasModifier(ModifierTypes.ABSTRACT)
 
   /**
     * Traverse to static methods
     * */
-  def isStatic: Method =
+  def isStatic: NodeSteps[nodes.Method] =
     hasModifier(ModifierTypes.STATIC)
 
   /**
     * Traverse to native methods
     * */
-  def isNative: Method =
+  def isNative: NodeSteps[nodes.Method] =
     hasModifier(ModifierTypes.NATIVE)
 
   /**
     * Traverse to constructors, that is, keep methods that are constructors
     * */
-  def isConstructor: Method =
+  def isConstructor: NodeSteps[nodes.Method] =
     hasModifier(ModifierTypes.CONSTRUCTOR)
 
   /**
     * Traverse to virtual method
     * */
-  def isVirtual: Method =
+  def isVirtual: NodeSteps[nodes.Method] =
     hasModifier(ModifierTypes.VIRTUAL)
 
   /**
     * Traverse to external methods, that is, methods not present
     * but only referenced in the CPG.
     * */
-  def external: Method =
-    new Method(raw.has(NodeKeys.IS_EXTERNAL -> true))
+  def external: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.has(NodeKeys.IS_EXTERNAL -> true))
 
   /**
     * Traverse to internal methods, that is, methods for which
     * code is included in this CPG.
     * */
-  def internal: Method =
-    new Method(raw.has(NodeKeys.IS_EXTERNAL -> false))
+  def internal: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.has(NodeKeys.IS_EXTERNAL -> false))
 
   /**
     * Traverse to the methods local variables
@@ -173,11 +173,11 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse to literals of method
     * */
-  def literal: Literal =
-    new Literal(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
+  def literal: NodeSteps[nodes.Literal] =
+    new NodeSteps(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
-  def topLevelExpressions: Expression[nodes.Expression] =
-    new Expression(
+  def topLevelExpressions: NodeSteps[nodes.Expression] =
+    new NodeSteps(
       raw
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.BLOCK)
@@ -185,8 +185,8 @@ class Method(override val raw: GremlinScala[nodes.Method])
         .not(_.hasLabel(NodeTypes.LOCAL))
         .cast[nodes.Expression])
 
-  def cfgNode: CfgNode[nodes.CfgNode] =
-    new CfgNode(raw.flatMap { method =>
+  def cfgNode: NodeSteps[nodes.CfgNode] =
+    new NodeSteps(raw.flatMap { method =>
       __(method.cfgNode.to(Seq): _*)
     })
 
@@ -194,14 +194,14 @@ class Method(override val raw: GremlinScala[nodes.Method])
     *  Traverse to first expressions in CFG.
     *  Can be multiple.
     */
-  def cfgFirst: Expression[nodes.Expression] =
-    new Expression(raw.out(EdgeTypes.CFG).cast[nodes.Expression])
+  def cfgFirst: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.out(EdgeTypes.CFG).cast[nodes.Expression])
 
   /**
     *  Traverse to last expressions in CFG.
     *  Can be multiple.
     */
-  def cfgLast: Expression[nodes.Expression] =
+  def cfgLast: NodeSteps[nodes.Expression] =
     methodReturn.cfgLast
 
   /**
@@ -218,8 +218,8 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse to namespace
     * */
-  def namespace: Namespace =
-    new Namespace(definingTypeDecl.namespace.raw)
+  def namespace: NodeSteps[nodes.Namespace] =
+    new NodeSteps(definingTypeDecl.namespace.raw)
 
   def numberOfLines: Steps[Int] = map(_.numberOfLines)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -41,8 +41,8 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse to bindings which reference to this method.
     */
-  def referencingBinding: Binding =
-    new Binding(raw.in(EdgeTypes.REF).filter(_.hasLabel(NodeTypes.BINDING)).cast[nodes.Binding])
+  def referencingBinding: NodeSteps[nodes.Binding] =
+    new NodeSteps(raw.in(EdgeTypes.REF).filter(_.hasLabel(NodeTypes.BINDING)).cast[nodes.Binding])
 
   /**
     * All control structures of this method

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -207,13 +207,13 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse to block
     * */
-  def block: Block =
-    new Block(raw.out(EdgeTypes.AST).hasLabel(NodeTypes.BLOCK).cast[nodes.Block])
+  def block: NodeSteps[nodes.Block] =
+    new NodeSteps(raw.out(EdgeTypes.AST).hasLabel(NodeTypes.BLOCK).cast[nodes.Block])
 
   /**
     * Traverse to method body (alias for `block`)
     * */
-  def body: Block = block
+  def body: NodeSteps[nodes.Block] = block
 
   /**
     * Traverse to namespace

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -161,8 +161,8 @@ class Method(override val raw: GremlinScala[nodes.Method])
   /**
     * Traverse to the methods local variables
     * */
-  def local: Local =
-    new Local(
+  def local: NodeSteps[nodes.Local] =
+    new NodeSteps(
       raw
         .out(EdgeTypes.CONTAINS)
         .hasLabel(NodeTypes.BLOCK)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -4,17 +4,15 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{CfgNode, Expression}
-import io.shiftleft.semanticcpg.language.types.expressions.{Call, ControlStructure, Literal}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
 /**
   * A method, function, or procedure
   * */
-class Method(override val raw: GremlinScala[nodes.Method])
-    extends NodeSteps[nodes.Method](raw)
-    with EvalTypeAccessors[nodes.Method]
+class Method(val wrapped: NodeSteps[nodes.Method])
+    extends EvalTypeAccessors[nodes.Method]
     with ModifierAccessors[nodes.Method] {
+  override val raw: GremlinScala[nodes.Method] = wrapped.raw
 
   /**
     * Traverse to parameters of the method
@@ -48,13 +46,13 @@ class Method(override val raw: GremlinScala[nodes.Method])
     * All control structures of this method
     * */
   def controlStructure: NodeSteps[nodes.ControlStructure] =
-    this.ast.isControlStructure
+    wrapped.ast.isControlStructure
 
   /**
     * Shorthand to traverse to control structures where condition matches `regex`
     * */
   def controlStructure(regex: String): NodeSteps[nodes.ControlStructure] =
-    this.ast.isControlStructure.code(regex)
+    wrapped.ast.isControlStructure.code(regex)
 
   /**
     * Outgoing call sites
@@ -221,6 +219,6 @@ class Method(override val raw: GremlinScala[nodes.Method])
   def namespace: NodeSteps[nodes.Namespace] =
     new NodeSteps(definingTypeDecl.namespace.raw)
 
-  def numberOfLines: Steps[Int] = map(_.numberOfLines)
+  def numberOfLines: Steps[Int] = wrapped.map(_.numberOfLines)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -10,15 +10,15 @@ import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 /**
   * Formal method input parameter
   * */
-class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
-    extends NodeSteps[nodes.MethodParameterIn](raw)
-    with EvalTypeAccessors[nodes.MethodParameterIn] {
+class MethodParameter(val wrapped: NodeSteps[nodes.MethodParameterIn])
+    extends EvalTypeAccessors[nodes.MethodParameterIn] {
+  override def raw: GremlinScala[nodes.MethodParameterIn] = wrapped.raw
 
   /**
     * Traverse to all `num`th parameters
     * */
   def index(num: Int): NodeSteps[nodes.MethodParameterIn] =
-    this.order(num)
+    wrapped.order(num)
 
   /**
     * Traverse to all parameters with index greater or equal than `num`

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -17,32 +17,32 @@ class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
   /**
     * Traverse to all `num`th parameters
     * */
-  def index(num: Int): MethodParameter =
+  def index(num: Int): NodeSteps[nodes.MethodParameterIn] =
     this.order(num)
 
   /**
     * Traverse to all parameters with index greater or equal than `num`
     * */
-  def indexFrom(num: Int): MethodParameter =
-    new MethodParameter(raw.has(NodeKeys.METHOD_PARAMETER_IN.ORDER, P.gte(num: Integer)))
+  def indexFrom(num: Int): NodeSteps[nodes.MethodParameterIn] =
+    new NodeSteps(raw.has(NodeKeys.METHOD_PARAMETER_IN.ORDER, P.gte(num: Integer)))
 
   /**
     * Traverse to all parameters with index smaller or equal than `num`
     * */
-  def indexTo(num: Int): MethodParameter =
-    new MethodParameter(raw.has(NodeKeys.METHOD_PARAMETER_IN.ORDER, P.lte(num: Integer)))
+  def indexTo(num: Int): NodeSteps[nodes.MethodParameterIn] =
+    new NodeSteps(raw.has(NodeKeys.METHOD_PARAMETER_IN.ORDER, P.lte(num: Integer)))
 
   /**
     * Traverse to method associated with this formal parameter
     * */
-  def method: Method =
-    new Method(raw.in(EdgeTypes.AST).cast[nodes.Method])
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.in(EdgeTypes.AST).cast[nodes.Method])
 
   /**
     * Traverse to arguments (actual parameters) associated with this formal parameter
     * */
-  def argument(): Expression[nodes.Expression] = {
-    new Expression(
+  def argument(): NodeSteps[nodes.Expression] = {
+    new NodeSteps(
       raw
         .sack((_: Integer, node: nodes.MethodParameterIn) => node.value2(NodeKeys.ORDER))
         .in(EdgeTypes.AST)
@@ -59,19 +59,19 @@ class MethodParameter(raw: GremlinScala[nodes.MethodParameterIn])
   /**
     * Traverse to corresponding formal output parameter
     * */
-  def asOutput: MethodParameterOut =
-    new MethodParameterOut(raw.out(EdgeTypes.PARAMETER_LINK).cast[nodes.MethodParameterOut])
+  def asOutput: NodeSteps[nodes.MethodParameterOut] =
+    new NodeSteps(raw.out(EdgeTypes.PARAMETER_LINK).cast[nodes.MethodParameterOut])
 
   /**
     * Places (identifier) where this parameter is being referenced
     * */
-  def referencingIdentifiers: IdentifierTrav =
-    new IdentifierTrav(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
+  def referencingIdentifiers: NodeSteps[nodes.Identifier] =
+    new NodeSteps(raw.in(EdgeTypes.REF).hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
   /**
     * Traverse to parameter type
     * */
-  def typ: Type =
-    new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+  def typ: NodeSteps[nodes.Type] =
+    new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -7,13 +7,12 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
-class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
-    extends NodeSteps[nodes.MethodParameterOut](raw)
-    with EvalTypeAccessors[nodes.MethodParameterOut] {
+class MethodParameterOut(val wrapped: NodeSteps[nodes.MethodParameterOut]) extends EvalTypeAccessors[nodes.MethodParameterOut] {
+  override def raw: GremlinScala[nodes.MethodParameterOut] = wrapped.raw
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
   def index(num: Int): NodeSteps[nodes.MethodParameterOut] =
-    this.order(num)
+    wrapped.order(num)
 
   /* get all parameters from (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
@@ -51,4 +50,5 @@ class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
     * */
   def typ: NodeSteps[nodes.Type] =
     new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -7,7 +7,8 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 
-class MethodParameterOut(val wrapped: NodeSteps[nodes.MethodParameterOut]) extends EvalTypeAccessors[nodes.MethodParameterOut] {
+class MethodParameterOut(val wrapped: NodeSteps[nodes.MethodParameterOut])
+    extends EvalTypeAccessors[nodes.MethodParameterOut] {
   override def raw: GremlinScala[nodes.MethodParameterOut] = wrapped.raw
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -12,24 +12,24 @@ class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
     with EvalTypeAccessors[nodes.MethodParameterOut] {
 
   /* method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def index(num: Int): MethodParameterOut =
+  def index(num: Int): NodeSteps[nodes.MethodParameterOut] =
     this.order(num)
 
   /* get all parameters from (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def indexFrom(num: Int): MethodParameterOut =
-    new MethodParameterOut(raw.has(NodeKeys.METHOD_PARAMETER_OUT.ORDER, P.gte(num: Integer)))
+  def indexFrom(num: Int): NodeSteps[nodes.MethodParameterOut] =
+    new NodeSteps(raw.has(NodeKeys.METHOD_PARAMETER_OUT.ORDER, P.gte(num: Integer)))
 
   /* get all parameters up to (and including)
    * method parameter indexes are  based, i.e. first parameter has index  (that's how java2cpg generates it) */
-  def indexTo[Out](num: Int): MethodParameterOut =
-    new MethodParameterOut(raw.has(NodeKeys.METHOD_PARAMETER_OUT.ORDER, P.lte(num: Integer)))
+  def indexTo[Out](num: Int): NodeSteps[nodes.MethodParameterOut] =
+    new NodeSteps(raw.has(NodeKeys.METHOD_PARAMETER_OUT.ORDER, P.lte(num: Integer)))
 
-  def method: Method =
-    new Method(raw.in(EdgeTypes.AST).cast[nodes.Method])
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.in(EdgeTypes.AST).cast[nodes.Method])
 
-  def argument: Expression[nodes.Expression] = {
-    new Expression(
+  def argument: NodeSteps[nodes.Expression] = {
+    new NodeSteps(
       raw
         .sack((_: Integer, node: nodes.MethodParameterOut) => node.value2(NodeKeys.ORDER))
         .in(EdgeTypes.AST)
@@ -43,12 +43,12 @@ class MethodParameterOut(raw: GremlinScala[nodes.MethodParameterOut])
     )
   }
 
-  def asInput: MethodParameter =
-    new MethodParameter(raw.in(EdgeTypes.PARAMETER_LINK).cast[nodes.MethodParameterIn])
+  def asInput: NodeSteps[nodes.MethodParameterIn] =
+    new NodeSteps(raw.in(EdgeTypes.PARAMETER_LINK).cast[nodes.MethodParameterIn])
 
   /**
     * Traverse to parameter type
     * */
-  def typ: Type =
-    new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+  def typ: NodeSteps[nodes.Type] =
+    new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
@@ -8,9 +8,8 @@ import io.shiftleft.semanticcpg.language.types.expressions.Call
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 import io.shiftleft.semanticcpg.language.types.propertyaccessors.EvalTypeAccessors
 
-class MethodReturn(raw: GremlinScala[nodes.MethodReturn])
-    extends NodeSteps[nodes.MethodReturn](raw)
-    with EvalTypeAccessors[nodes.MethodReturn] {
+class MethodReturn(val wrapped: NodeSteps[nodes.MethodReturn]) extends EvalTypeAccessors[nodes.MethodReturn] {
+  override val raw: GremlinScala[nodes.MethodReturn] = wrapped.raw
 
   def method: NodeSteps[nodes.Method] =
     new NodeSteps(raw.in(EdgeTypes.AST).cast[nodes.Method])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
@@ -12,24 +12,24 @@ class MethodReturn(raw: GremlinScala[nodes.MethodReturn])
     extends NodeSteps[nodes.MethodReturn](raw)
     with EvalTypeAccessors[nodes.MethodReturn] {
 
-  def method: Method =
-    new Method(raw.in(EdgeTypes.AST).cast[nodes.Method])
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(raw.in(EdgeTypes.AST).cast[nodes.Method])
 
-  def returnUser: Call =
-    new Call(raw.in(EdgeTypes.AST).in(EdgeTypes.CALL).cast[nodes.Call])
+  def returnUser: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.in(EdgeTypes.AST).in(EdgeTypes.CALL).cast[nodes.Call])
 
   /**
     *  Traverse to last expressions in CFG.
     *  Can be multiple.
     */
-  def cfgLast: Expression[nodes.Expression] =
-    new Expression(raw.in(EdgeTypes.CFG).cast[nodes.Expression])
+  def cfgLast: NodeSteps[nodes.Expression] =
+    new NodeSteps(raw.in(EdgeTypes.CFG).cast[nodes.Expression])
 
   /**
     * Traverse to return type
     * */
-  def typ: Type =
-    new Type(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
+  def typ: NodeSteps[nodes.Type] =
+    new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 
   def toReturn: NodeSteps[nodes.Return] =
     new NodeSteps(raw.flatMap { mr =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Namespace.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Namespace.scala
@@ -8,14 +8,14 @@ import io.shiftleft.semanticcpg.language._
 /**
   * A namespace, e.g., Java package or C# namespace
   * */
-class Namespace(raw: GremlinScala[nodes.Namespace]) extends NodeSteps[nodes.Namespace](raw) {
+class Namespace(val wrapped: NodeSteps[nodes.Namespace]) extends AnyVal {
 
   /**
     * The type declarations defined in this namespace
     * */
   def typeDecl: NodeSteps[nodes.TypeDecl] =
     new NodeSteps(
-      raw
+      wrapped.raw
         .in(EdgeTypes.REF)
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.TYPE_DECL)
@@ -26,7 +26,7 @@ class Namespace(raw: GremlinScala[nodes.Namespace]) extends NodeSteps[nodes.Name
     * */
   def method: NodeSteps[nodes.Method] =
     new NodeSteps(
-      raw
+      wrapped.raw
         .in(EdgeTypes.REF)
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.METHOD)
@@ -37,13 +37,13 @@ class Namespace(raw: GremlinScala[nodes.Namespace]) extends NodeSteps[nodes.Name
     * which contain one or more external type.
     * */
   def external: NodeSteps[nodes.Namespace] =
-    new NodeSteps(filter(_.typeDecl.external).raw)
+    wrapped.filter(_.typeDecl.external)
 
   /**
     * Internal namespaces - any namespaces
     * which contain one or more internal type
     * */
   def internal: NodeSteps[nodes.Namespace] =
-    new NodeSteps(filter(_.typeDecl.internal).raw)
+    wrapped.filter(_.typeDecl.internal)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Namespace.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Namespace.scala
@@ -13,8 +13,8 @@ class Namespace(raw: GremlinScala[nodes.Namespace]) extends NodeSteps[nodes.Name
   /**
     * The type declarations defined in this namespace
     * */
-  def typeDecl: TypeDecl =
-    new TypeDecl(
+  def typeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(
       raw
         .in(EdgeTypes.REF)
         .out(EdgeTypes.AST)
@@ -24,8 +24,8 @@ class Namespace(raw: GremlinScala[nodes.Namespace]) extends NodeSteps[nodes.Name
   /**
     * Methods defined in this namespace
     * */
-  def method: Method =
-    new Method(
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(
       raw
         .in(EdgeTypes.REF)
         .out(EdgeTypes.AST)
@@ -36,14 +36,14 @@ class Namespace(raw: GremlinScala[nodes.Namespace]) extends NodeSteps[nodes.Name
     * External namespaces - any namespaces
     * which contain one or more external type.
     * */
-  def external: Namespace =
-    new Namespace(filter(_.typeDecl.external).raw)
+  def external: NodeSteps[nodes.Namespace] =
+    new NodeSteps(filter(_.typeDecl.external).raw)
 
   /**
     * Internal namespaces - any namespaces
     * which contain one or more internal type
     * */
-  def internal: Namespace =
-    new Namespace(filter(_.typeDecl.internal).raw)
+  def internal: NodeSteps[nodes.Namespace] =
+    new NodeSteps(filter(_.typeDecl.internal).raw)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
@@ -4,20 +4,20 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
 
-class NamespaceBlock(raw: GremlinScala[nodes.NamespaceBlock]) extends NodeSteps[nodes.NamespaceBlock](raw) {
+class NamespaceBlock(val wrapped: NodeSteps[nodes.NamespaceBlock]) extends AnyVal {
 
   /**
     * Namespaces for namespace blocks.
     * */
   def namespaces: NodeSteps[nodes.Namespace] =
-    new NodeSteps(raw.out(EdgeTypes.REF).cast[nodes.Namespace])
+    new NodeSteps(wrapped.raw.out(EdgeTypes.REF).cast[nodes.Namespace])
 
   /**
     * The type declarations defined in this namespace
     * */
   def typeDecl: NodeSteps[nodes.TypeDecl] =
     new NodeSteps(
-      raw
+      wrapped.raw
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.TYPE_DECL)
         .cast[nodes.TypeDecl])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
@@ -9,14 +9,14 @@ class NamespaceBlock(raw: GremlinScala[nodes.NamespaceBlock]) extends NodeSteps[
   /**
     * Namespaces for namespace blocks.
     * */
-  def namespaces: Namespace =
-    new Namespace(raw.out(EdgeTypes.REF).cast[nodes.Namespace])
+  def namespaces: NodeSteps[nodes.Namespace] =
+    new NodeSteps(raw.out(EdgeTypes.REF).cast[nodes.Namespace])
 
   /**
     * The type declarations defined in this namespace
     * */
-  def typeDecl: TypeDecl =
-    new TypeDecl(
+  def typeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(
       raw
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.TYPE_DECL)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -11,25 +11,25 @@ class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
   /**
     * Namespaces in which the corresponding type declaration is defined.
     * */
-  def namespace: Namespace =
+  def namespace: NodeSteps[nodes.Namespace] =
     referencedTypeDecl.namespace
 
   /**
     * Methods defined on the corresponding type declaration.
     * */
-  def method: Method =
+  def method: NodeSteps[nodes.Method] =
     referencedTypeDecl.method
 
   /**
     * Filter for types whos corresponding type declaration is in the analyzed jar.
     * */
-  def internal: Type =
+  def internal: NodeSteps[nodes.Type] =
     filter(_.referencedTypeDecl.internal)
 
   /**
     * Filter for types whos corresponding type declaration is not in the analyzed jar.
     * */
-  def external: Type =
+  def external: NodeSteps[nodes.Type] =
     filter(_.referencedTypeDecl.external)
 
   /**
@@ -41,66 +41,62 @@ class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
   /**
     * Direct base types of the corresponding type declaration in the inheritance graph.
     * */
-  def baseType: Type =
+  def baseType: NodeSteps[nodes.Type] =
     referencedTypeDecl.baseType
 
   /**
     * Direct and transitive base types of the corresponding type declaration.
     * */
-  def baseTypeTransitive: Type = {
+  def baseTypeTransitive: NodeSteps[nodes.Type] =
     repeat(_.baseType).emit()
-  }
 
   /**
     * Direct derived types.
     * */
-  def derivedType: Type =
+  def derivedType: NodeSteps[nodes.Type] =
     derivedTypeDecl.referencingType
 
   /**
     * Direct and transitive derived types.
     * */
-  def derivedTypeTransitive: Type =
+  def derivedTypeTransitive: NodeSteps[nodes.Type] =
     repeat(_.derivedType).emit()
 
   /**
     * Type declaration which is referenced by this type.
     */
-  def referencedTypeDecl: TypeDecl =
-    new TypeDecl(raw.out(EdgeTypes.REF).cast[nodes.TypeDecl])
+  def referencedTypeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(raw.out(EdgeTypes.REF).cast[nodes.TypeDecl])
 
   /**
     * Type declarations which derive from this type.
     */
-  def derivedTypeDecl: TypeDecl =
-    new TypeDecl(raw.in(EdgeTypes.INHERITS_FROM).cast[nodes.TypeDecl])
+  def derivedTypeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(raw.in(EdgeTypes.INHERITS_FROM).cast[nodes.TypeDecl])
 
   /**
     * Direct alias type declarations.
     */
-  def aliasTypeDecl: TypeDecl = {
-    new TypeDecl(raw.in(EdgeTypes.ALIAS_OF).cast[nodes.TypeDecl])
-  }
+  def aliasTypeDecl: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(raw.in(EdgeTypes.ALIAS_OF).cast[nodes.TypeDecl])
 
   /**
     * Direct alias types.
     */
-  def aliasType: Type = {
+  def aliasType: NodeSteps[nodes.Type] =
     aliasTypeDecl.referencingType
-  }
 
   /**
     * Direct and transitive alias types.
     */
-  def aliasTypeTransitive: Type = {
+  def aliasTypeTransitive: NodeSteps[nodes.Type] =
     repeat(_.aliasType).emit()
-  }
 
   def localsOfType: NodeSteps[nodes.Local] =
     new NodeSteps(raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
-  def expressionOfType: Expression[nodes.Expression] =
-    new Expression(
+  def expressionOfType: NodeSteps[nodes.Expression] =
+    new NodeSteps(
       raw
         .in(EdgeTypes.EVAL_TYPE)
         .hasLabel(NodeTypes.IDENTIFIER, NodeTypes.CALL, NodeTypes.LITERAL)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -96,8 +96,8 @@ class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
     repeat(_.aliasType).emit()
   }
 
-  def localsOfType: Local =
-    new Local(raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
+  def localsOfType: NodeSteps[nodes.Local] =
+    new NodeSteps(raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
   def expressionOfType: Expression[nodes.Expression] =
     new Expression(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -35,7 +35,7 @@ class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
   /**
     * Member variables of the corresponding type declaration.
     * */
-  def member: Member =
+  def member: NodeSteps[nodes.Member] =
     referencedTypeDecl.member
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -6,7 +6,7 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.Expression
 
-class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
+class Type(val wrapped: NodeSteps[nodes.Type]) extends AnyVal {
 
   /**
     * Namespaces in which the corresponding type declaration is defined.
@@ -24,13 +24,13 @@ class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
     * Filter for types whos corresponding type declaration is in the analyzed jar.
     * */
   def internal: NodeSteps[nodes.Type] =
-    filter(_.referencedTypeDecl.internal)
+    wrapped.filter(_.referencedTypeDecl.internal)
 
   /**
     * Filter for types whos corresponding type declaration is not in the analyzed jar.
     * */
   def external: NodeSteps[nodes.Type] =
-    filter(_.referencedTypeDecl.external)
+    wrapped.filter(_.referencedTypeDecl.external)
 
   /**
     * Member variables of the corresponding type declaration.
@@ -48,7 +48,7 @@ class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
     * Direct and transitive base types of the corresponding type declaration.
     * */
   def baseTypeTransitive: NodeSteps[nodes.Type] =
-    repeat(_.baseType).emit()
+    wrapped.repeat(_.baseType).emit()
 
   /**
     * Direct derived types.
@@ -60,25 +60,25 @@ class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
     * Direct and transitive derived types.
     * */
   def derivedTypeTransitive: NodeSteps[nodes.Type] =
-    repeat(_.derivedType).emit()
+    wrapped.repeat(_.derivedType).emit()
 
   /**
     * Type declaration which is referenced by this type.
     */
   def referencedTypeDecl: NodeSteps[nodes.TypeDecl] =
-    new NodeSteps(raw.out(EdgeTypes.REF).cast[nodes.TypeDecl])
+    new NodeSteps(wrapped.raw.out(EdgeTypes.REF).cast[nodes.TypeDecl])
 
   /**
     * Type declarations which derive from this type.
     */
   def derivedTypeDecl: NodeSteps[nodes.TypeDecl] =
-    new NodeSteps(raw.in(EdgeTypes.INHERITS_FROM).cast[nodes.TypeDecl])
+    new NodeSteps(wrapped.raw.in(EdgeTypes.INHERITS_FROM).cast[nodes.TypeDecl])
 
   /**
     * Direct alias type declarations.
     */
   def aliasTypeDecl: NodeSteps[nodes.TypeDecl] =
-    new NodeSteps(raw.in(EdgeTypes.ALIAS_OF).cast[nodes.TypeDecl])
+    new NodeSteps(wrapped.raw.in(EdgeTypes.ALIAS_OF).cast[nodes.TypeDecl])
 
   /**
     * Direct alias types.
@@ -90,14 +90,14 @@ class Type(raw: GremlinScala[nodes.Type]) extends NodeSteps[nodes.Type](raw) {
     * Direct and transitive alias types.
     */
   def aliasTypeTransitive: NodeSteps[nodes.Type] =
-    repeat(_.aliasType).emit()
+    wrapped.repeat(_.aliasType).emit()
 
   def localsOfType: NodeSteps[nodes.Local] =
-    new NodeSteps(raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
+    new NodeSteps(wrapped.raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
   def expressionOfType: NodeSteps[nodes.Expression] =
     new NodeSteps(
-      raw
+      wrapped.raw
         .in(EdgeTypes.EVAL_TYPE)
         .hasLabel(NodeTypes.IDENTIFIER, NodeTypes.CALL, NodeTypes.LITERAL)
         .cast[nodes.Expression])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -53,8 +53,8 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
   /**
     * Member variables
     * */
-  def member: Member =
-    new Member(canonicalType.raw.out().hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
+  def member: NodeSteps[nodes.Member] =
+    new NodeSteps(canonicalType.raw.out().hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
 
   /**
     * Direct base types in the inheritance graph.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -10,10 +10,9 @@ import org.apache.tinkerpop.gremlin.structure.Direction
 /**
   * Type declaration - possibly a template that requires instantiation
   * */
-class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
-    extends NodeSteps[nodes.TypeDecl](raw)
-    with ModifierAccessors[nodes.TypeDecl] {
+class TypeDecl(val wrapped: NodeSteps[nodes.TypeDecl]) extends ModifierAccessors[nodes.TypeDecl] {
   import TypeDecl._
+  override val raw: GremlinScala[nodes.TypeDecl] = wrapped.raw
 
   /**
     * Types referencing to this type declaration.
@@ -72,19 +71,19 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
     * Direct and transitive base type declaration.
     * */
   def derivedTypeDeclTransitive: NodeSteps[nodes.TypeDecl] =
-    repeat(_.derivedTypeDecl).emit()
+    wrapped.repeat(_.derivedTypeDecl).emit()
 
   /**
     * Direct base type declaration.
     */
   def baseTypeDecl: NodeSteps[nodes.TypeDecl] =
-    baseType.referencedTypeDecl
+    wrapped.baseType.referencedTypeDecl
 
   /**
     * Direct and transitive base type declaration.
     */
   def baseTypeDeclTransitive: NodeSteps[nodes.TypeDecl] =
-    repeat(_.baseTypeDecl).emit()
+    wrapped.repeat(_.baseTypeDecl).emit()
 
   /**
     * Traverse to methods bound to this type decl.
@@ -167,7 +166,7 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
     *  Direct and transitive alias type declarations.
     */
   def aliasTypeDeclTransitive: NodeSteps[nodes.TypeDecl] =
-    repeat(_.aliasTypeDecl).emit()
+    wrapped.repeat(_.aliasTypeDecl).emit()
 
 }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -95,8 +95,8 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
   /**
     * Traverse to the method bindings of this type declaration.
     */
-  def methodBinding: Binding =
-    new Binding(canonicalType.raw.out(EdgeTypes.BINDS).cast[nodes.Binding])
+  def methodBinding: NodeSteps[nodes.Binding] =
+    new NodeSteps(canonicalType.raw.out(EdgeTypes.BINDS).cast[nodes.Binding])
 
   /**
     * Traverse to alias type declarations.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -18,14 +18,14 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
   /**
     * Types referencing to this type declaration.
     * */
-  def referencingType: Type =
-    new Type(raw.in(EdgeTypes.REF).cast[nodes.Type])
+  def referencingType: NodeSteps[nodes.Type] =
+    new NodeSteps(raw.in(EdgeTypes.REF).cast[nodes.Type])
 
   /**
     * Namespace in which this type declaration is defined
     * */
-  def namespace: Namespace =
-    new Namespace(
+  def namespace: NodeSteps[nodes.Namespace] =
+    new NodeSteps(
       raw
         .in(EdgeTypes.AST)
         .hasLabel(NodeTypes.NAMESPACE_BLOCK)
@@ -35,20 +35,20 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
   /**
     * Methods defined as part of this type
     * */
-  def method: Method =
-    new Method(canonicalType.raw.out(EdgeTypes.AST).hasLabel(NodeTypes.METHOD).cast[nodes.Method])
+  def method: NodeSteps[nodes.Method] =
+    new NodeSteps(canonicalType.raw.out(EdgeTypes.AST).hasLabel(NodeTypes.METHOD).cast[nodes.Method])
 
   /**
     * Filter for type declarations contained in the analyzed code.
     * */
-  def internal: TypeDecl =
-    new TypeDecl(canonicalType.raw.has(NodeKeys.IS_EXTERNAL -> false))
+  def internal: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(canonicalType.raw.has(NodeKeys.IS_EXTERNAL -> false))
 
   /**
     * Filter for type declarations not contained in the analyzed code.
     * */
-  def external: TypeDecl =
-    new TypeDecl(canonicalType.raw.has(NodeKeys.IS_EXTERNAL -> true))
+  def external: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(canonicalType.raw.has(NodeKeys.IS_EXTERNAL -> true))
 
   /**
     * Member variables
@@ -59,37 +59,37 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
   /**
     * Direct base types in the inheritance graph.
     * */
-  def baseType: Type =
-    new Type(canonicalType.raw.out(EdgeTypes.INHERITS_FROM).cast[nodes.Type])
+  def baseType: NodeSteps[nodes.Type] =
+    new NodeSteps(canonicalType.raw.out(EdgeTypes.INHERITS_FROM).cast[nodes.Type])
 
   /**
     * Direct base type declaration.
     * */
-  def derivedTypeDecl: TypeDecl =
+  def derivedTypeDecl: NodeSteps[nodes.TypeDecl] =
     referencingType.derivedTypeDecl
 
   /**
     * Direct and transitive base type declaration.
     * */
-  def derivedTypeDeclTransitive: TypeDecl =
+  def derivedTypeDeclTransitive: NodeSteps[nodes.TypeDecl] =
     repeat(_.derivedTypeDecl).emit()
 
   /**
     * Direct base type declaration.
     */
-  def baseTypeDecl: TypeDecl =
+  def baseTypeDecl: NodeSteps[nodes.TypeDecl] =
     baseType.referencedTypeDecl
 
   /**
     * Direct and transitive base type declaration.
     */
-  def baseTypeDeclTransitive: TypeDecl =
+  def baseTypeDeclTransitive: NodeSteps[nodes.TypeDecl] =
     repeat(_.baseTypeDecl).emit()
 
   /**
     * Traverse to methods bound to this type decl.
     */
-  def boundMethod: Method =
+  def boundMethod: NodeSteps[nodes.Method] =
     methodBinding.boundMethod
 
   /**
@@ -101,21 +101,21 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
   /**
     * Traverse to alias type declarations.
     */
-  def isAlias: TypeDecl =
-    new TypeDecl(raw.filterOnEnd(_.aliasTypeFullName.isDefined))
+  def isAlias: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(raw.filterOnEnd(_.aliasTypeFullName.isDefined))
 
   /**
     * Traverse to canonical type declarations.
     */
-  def isCanonical: TypeDecl =
-    new TypeDecl(raw.filterOnEnd(_.aliasTypeFullName.isEmpty))
+  def isCanonical: NodeSteps[nodes.TypeDecl] =
+    new NodeSteps(raw.filterOnEnd(_.aliasTypeFullName.isEmpty))
 
   /**
     * If this is an alias type declaration, go to its underlying type declaration
     * else unchanged.
     */
-  def unravelAlias: TypeDecl = {
-    new TypeDecl(raw.map { typeDecl =>
+  def unravelAlias: NodeSteps[nodes.TypeDecl] = {
+    new NodeSteps(raw.map { typeDecl =>
       if (typeDecl.aliasTypeFullName.isDefined) {
         typeDecl
           .vertices(Direction.OUT, EdgeTypes.ALIAS_OF)
@@ -134,13 +134,13 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
     * Traverse to canonical type which means unravel aliases until we find
     * a non alias type declaration.
     */
-  def canonicalType: TypeDecl = {
+  def canonicalType: NodeSteps[nodes.TypeDecl] = {
     // We cannot use this compact form because the gremlin implementation at least
     // in some case seems to have problems with nested "repeat" steps. Since this
     // step is used in other repeat steps we do not use it here.
     //until(_.isCanonical).repeat(_.unravelAlias)
 
-    new TypeDecl(raw.map { typeDecl =>
+    new NodeSteps(raw.map { typeDecl =>
       var currentTypeDecl = typeDecl
       var aliasExpansionCounter = 0
       while (currentTypeDecl.aliasTypeFullName.isDefined && aliasExpansionCounter < maxAliasExpansions) {
@@ -160,13 +160,13 @@ class TypeDecl(raw: GremlinScala[nodes.TypeDecl])
   /**
     *  Direct alias type declarations.
     */
-  def aliasTypeDecl: TypeDecl =
+  def aliasTypeDecl: NodeSteps[nodes.TypeDecl] =
     referencingType.aliasTypeDecl
 
   /**
     *  Direct and transitive alias type declarations.
     */
-  def aliasTypeDeclTransitive: TypeDecl =
+  def aliasTypeDeclTransitive: NodeSteps[nodes.TypeDecl] =
     repeat(_.aliasTypeDecl).emit()
 
 }


### PR DESCRIPTION
use AnyVal instead

as discussed in https://github.com/ShiftLeftSecurity/codescience/pull/3377#issuecomment-585432344
part of https://github.com/ShiftLeftSecurity/product/issues/3526

this isn't yet complete, but it doesn't harm if we do it in multiple steps