### PR TITLE
Optimize passes

### DIFF
--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -7,6 +7,7 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-native" % "3.6.7",
   "com.massisframework" % "j-text-utils" % "0.3.4",
   "org.scala-lang.modules" %% "scala-collection-contrib" % "0.2.1",
+  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test
 )

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -49,7 +49,6 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
         )
       case Languages.C =>
         List(
-          new ArgumentCompat(cpg),
           new MethodInstCompat(cpg),
           new TypeDeclStubCreator(cpg),
           new MethodStubCreator(cpg),

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -64,7 +64,6 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
           new NamespaceCreator(cpg),
           new CfgDominatorPass(cpg),
           new CdgPass(cpg),
-          new TrimPass(cpg),
         )
     }
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -21,15 +21,15 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
   // Since the method fullNames for fuzzyc are not unique, we do not have
   // a 1to1 relation and may overwrite some values. We deem this ok for now.
-  private var methodFullNameToNode = scala.collection.concurrent.TrieMap[String, nodes.MethodBase]()
-  private var methodToParameterCount = scala.collection.concurrent.TrieMap[NameAndSignature, Int]()
+  private var methodFullNameToNode = TrieMap[String, nodes.MethodBase]()
+  private var methodToParameterCount = TrieMap.empty[NameAndSignature, Int]
 
   override def run(): Iterator[DiffGraph] = {
 
     init()
 
-    val CHUNK_SIZE = 128
-    val chunks: Iterator[TrieMap[NameAndSignature, Int]] = methodToParameterCount.grouped(CHUNK_SIZE)
+    val chunkSize = 128
+    val chunks: Iterator[TrieMap[NameAndSignature, Int]] = methodToParameterCount.grouped(chunkSize)
     new ParallelIteratorExecutor[TrieMap[NameAndSignature, Int]](chunks).map { group =>
       implicit val dstGraph: DiffGraph.Builder = DiffGraph.newBuilder
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -3,44 +3,48 @@ package io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewMethodReturn}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, NodeTypes, nodes}
-import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.passes.{CpgPass, DiffGraph, ParallelIteratorExecutor}
 import org.apache.logging.log4j.{LogManager, Logger}
 import org.apache.tinkerpop.gremlin.structure.Direction
 import io.shiftleft.semanticcpg.language._
 
+import scala.collection.concurrent.TrieMap
 import scala.jdk.CollectionConverters._
+import scala.collection.parallel.CollectionConverters._
 
 /**
   * This pass has no other pass as prerequisite.
   */
 class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
-  import MethodStubCreator.logger
 
   private case class NameAndSignature(name: String, signature: String)
 
   // Since the method fullNames for fuzzyc are not unique, we do not have
   // a 1to1 relation and may overwrite some values. We deem this ok for now.
-  private var methodFullNameToNode = Map[String, nodes.MethodBase]()
-  private var methodToParameterCount = Map[NameAndSignature, Int]()
+  private var methodFullNameToNode = scala.collection.concurrent.TrieMap[String, nodes.MethodBase]()
+  private var methodToParameterCount = scala.collection.concurrent.TrieMap[NameAndSignature, Int]()
 
   override def run(): Iterator[DiffGraph] = {
-    val dstGraph = DiffGraph.newBuilder
 
     init()
 
-    // TODO bring in Receiver type. Just working on name and comparing to full name
-    // will only work for C because in C, name always equals full name.
-    methodToParameterCount.foreach {
-      case (NameAndSignature(name, signature), parameterCount) =>
-        methodFullNameToNode.get(name) match {
-          case None =>
-            createMethodStub(name, name, signature, parameterCount, dstGraph)
-          case _ =>
-        }
+    val CHUNK_SIZE = 128
+    val chunks: Iterator[TrieMap[NameAndSignature, Int]] = methodToParameterCount.grouped(CHUNK_SIZE)
+    new ParallelIteratorExecutor[TrieMap[NameAndSignature, Int]](chunks).map { group =>
+      implicit val dstGraph: DiffGraph.Builder = DiffGraph.newBuilder
 
+      // TODO bring in Receiver type. Just working on name and comparing to full name
+      // will only work for C because in C, name always equals full name.
+      group.foreach {
+        case (NameAndSignature(name, signature), parameterCount) =>
+          methodFullNameToNode.get(name) match {
+            case None =>
+              createMethodStub(name, name, signature, parameterCount, dstGraph)
+            case _ =>
+          }
+      }
+      dstGraph.build()
     }
-
-    Iterator(dstGraph.build())
   }
 
   private def createMethodStub(name: String,
@@ -101,18 +105,16 @@ class MethodStubCreator(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   private def init(): Unit = {
-    cpg.method
-      .sideEffect { method =>
+    cpg.method.l.par
+      .foreach { method =>
         methodFullNameToNode += method.fullName -> method
       }
-      .exec()
 
-    cpg.call
-      .sideEffect { call =>
+    cpg.call.l.par
+      .foreach { call =>
         methodToParameterCount +=
           NameAndSignature(call.name, call.signature) -> call.vertices(Direction.OUT, EdgeTypes.AST).asScala.size
       }
-      .exec()
   }
 }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
@@ -3,8 +3,10 @@ package io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
-import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.passes.{CpgPass, DiffGraph, ParallelIteratorExecutor}
 import io.shiftleft.semanticcpg.language._
+
+import scala.collection.parallel.CollectionConverters._
 
 /**
   * This pass has no other pass as prerequisite.
@@ -14,17 +16,22 @@ import io.shiftleft.semanticcpg.language._
   */
 class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
-  private var typeDeclFullNameToNode = Map[String, nodes.TypeDeclBase]()
+  private var typeDeclFullNameToNode =
+    scala.collection.concurrent.TrieMap[String, nodes.TypeDeclBase]()
 
   override def run(): Iterator[DiffGraph] = {
-    val dstGraph = DiffGraph.newBuilder
 
     init()
 
-    cpg.graph.V
-      .hasLabel(NodeTypes.TYPE)
-      .sideEffectWithTraverser { traverser =>
-        val typ = traverser.get.asInstanceOf[nodes.Type]
+    val CHUNK_SIZE = 128
+    new ParallelIteratorExecutor[List[Vertex]](
+      cpg.graph.V
+        .hasLabel(NodeTypes.TYPE)
+        .l
+        .grouped(CHUNK_SIZE)).map { group =>
+      implicit val dstGraph: DiffGraph.Builder = DiffGraph.newBuilder
+      group.foreach { vertex =>
+        val typ = vertex.asInstanceOf[nodes.Type]
         typeDeclFullNameToNode.get(typ.fullName) match {
           case Some(_) =>
           case None =>
@@ -33,9 +40,8 @@ class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
             dstGraph.addNode(newTypeDecl)
         }
       }
-      .iterate()
-
-    Iterator(dstGraph.build())
+      dstGraph.build()
+    }
   }
 
   private def createTypeDeclStub(name: String, fullName: String): nodes.NewTypeDecl = {
@@ -50,8 +56,8 @@ class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   private def init(): Unit = {
-    cpg.typeDecl.sideEffect { typeDecl =>
+    cpg.typeDecl.l.par.foreach { typeDecl =>
       typeDeclFullNameToNode += typeDecl.fullName -> typeDecl
-    }.exec
+    }
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
@@ -25,11 +25,11 @@ class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
 
   override def run(): Iterator[DiffGraph] = {
 
-    val CHUNK_SIZE = 128
+    val chunkSize = 128
     val chunks: Iterator[List[Vertex]] = cpg.graph.V
       .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
       .l
-      .grouped(CHUNK_SIZE)
+      .grouped(chunkSize)
 
     new ParallelIteratorExecutor[List[Vertex]](chunks).map { group =>
       implicit val dstGraph: DiffGraph.Builder = DiffGraph.newBuilder

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/trim/TrimPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/trim/TrimPass.scala
@@ -5,6 +5,12 @@ import io.shiftleft.passes.{CpgPass, DiffGraph}
 import org.apache.logging.log4j.{LogManager, Logger}
 import io.shiftleft.semanticcpg.language._
 
+// TODO this pass is problematic for two reasons: first, it writes into
+// the graph directly without going via the DiffGraph, and it seems there
+// is no other way of doing this. Second, it iterates over all nodes and
+// processes them in a single thread. On Linux kernel drivers, the pass
+// takes about 5 minutes to execute on an Intel i9-7900X CPU @ 3.30GHz.
+
 class TrimPass(cpg: Cpg) extends CpgPass(cpg) {
   override def run(): Iterator[DiffGraph] = {
     val reduction = cpg.all


### PR DESCRIPTION
There are currently several passes which construct potentially large diff graphs in a single thread. In this PR we optimize these passes to make use of all cores and chunk results into smaller DiffGraphs. The primary player in this change is `ParallelIteratorExecutor`.
