### PR TITLE
Do not run trim pass by default.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -62,7 +62,6 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
           new NamespaceCreator(cpg),
           new CfgDominatorPass(cpg),
           new CdgPass(cpg),
-          new TrimPass(cpg),
         )
     }
   }


### PR DESCRIPTION
Bringing in #589 in stages: do not run trim pass as it touches all nodes which stands somewhat in contrast with lazy loading.