### PR TITLE
Use iterators on passes as opposed to lists

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/DataFlowRunner.scala
@@ -9,7 +9,7 @@ import io.shiftleft.dataflowengine.semanticsloader.Semantics
 class DataFlowRunner(semantics: Semantics) {
 
   def run(cpg: Cpg, serializedCpg: SerializedCpg): Unit = {
-    val enhancementExecList = List(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
+    val enhancementExecList = Iterator(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
     enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -25,10 +25,10 @@ import io.shiftleft.semanticcpg.passes.receiveredges.ReceiverEdgePass
 class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedCpg) {
   private val enhancementExecList = createEnhancementExecList(language)
 
-  private def createEnhancementExecList(language: String): List[CpgPass] = {
+  private def createEnhancementExecList(language: String): Iterator[CpgPass] = {
     language match {
       case Languages.JAVA =>
-        List(
+        Iterator(
           new ArgumentCompat(cpg),
           new MethodInstCompat(cpg),
           new ReceiverEdgePass(cpg),
@@ -47,7 +47,7 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
           new TrimPass(cpg),
         )
       case Languages.C =>
-        List(
+        Iterator(
           new TypeDeclStubCreator(cpg),
           new MethodStubCreator(cpg),
           new MethodDecoratorPass(cpg),


### PR DESCRIPTION
Some of our passes keep tables for fast lookup, and so, if we keep a list of all passes, these tables need to remain in memory until all passes have run, despite the fact that they are not required anymore. By using an iterator on passes instead, we can free up memory used by previous passes.