### PR TITLE
use new typesafe neighbor accessors

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.semanticcpg.utils.{ExpandTo, MemberAccess}
-import org.apache.tinkerpop.gremlin.structure.Vertex
 import scala.jdk.CollectionConverters._
 
 /**
@@ -99,9 +98,7 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
 
   private def indirectAccess(node: nodes.StoredNode): Boolean =
     node match {
-      case call: nodes.Call =>
-        val callName = call.value2(NodeKeys.NAME)
-        MemberAccess.isGenericMemberAccessName(callName)
+      case call: nodes.Call => MemberAccess.isGenericMemberAccessName(call.name)
       case _ => false
     }
 

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -99,7 +99,7 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
   private def indirectAccess(node: nodes.StoredNode): Boolean =
     node match {
       case call: nodes.Call => MemberAccess.isGenericMemberAccessName(call.name)
-      case _ => false
+      case _                => false
     }
 
 }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -94,7 +94,7 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
         case NodeTypes.METHOD_PARAMETER_OUT =>
           ExpandTo.parameterInToMethod(dataFlowObject)
         case NodeTypes.LITERAL | NodeTypes.CALL | NodeTypes.IDENTIFIER | NodeTypes.RETURN | NodeTypes.UNKNOWN =>
-          ExpandTo.expressionToMethod(dataFlowObject)
+          ExpandTo.expressionToMethod(dataFlowObject.asInstanceOf[nodes.Expression])
       }
     method.asInstanceOf[nodes.Method]
   }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -83,17 +83,14 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
       case _                                      => None
     }
 
-  // TODO match on type rather than label: depends on https://github.com/ShiftLeftSecurity/codepropertygraph/issues/610
   private def methodFast(dataFlowObject: nodes.TrackingPoint): nodes.Method =
-    dataFlowObject.label match {
-      case NodeTypes.METHOD_RETURN =>
-        ExpandTo.methodReturnToMethod(dataFlowObject.asInstanceOf[nodes.MethodReturn])
-      case NodeTypes.METHOD_PARAMETER_IN =>
-        ExpandTo.parameterInToMethod(dataFlowObject.asInstanceOf[nodes.MethodParameterIn])
-      case NodeTypes.METHOD_PARAMETER_OUT =>
-        ExpandTo.parameterOutToMethod(dataFlowObject.asInstanceOf[nodes.MethodParameterOut])
-      case NodeTypes.LITERAL | NodeTypes.CALL | NodeTypes.IDENTIFIER | NodeTypes.RETURN | NodeTypes.UNKNOWN =>
-        ExpandTo.expressionToMethod(dataFlowObject.asInstanceOf[nodes.Expression])
+    dataFlowObject match {
+      case methodReturn: nodes.MethodReturn             => ExpandTo.methodReturnToMethod(methodReturn)
+      case methodParameterIn: nodes.MethodParameterIn   => ExpandTo.parameterInToMethod(methodParameterIn)
+      case methodParameterOut: nodes.MethodParameterOut => ExpandTo.parameterOutToMethod(methodParameterOut)
+      case expression: nodes.Expression                 => ExpandTo.expressionToMethod(expression)
+      case other =>
+        throw new NotImplementedError(s".method not implemented for ${other.label}: $other") //e.g. free tracking point
     }
 
   private def indirectAccess(node: nodes.StoredNode): Boolean =

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -84,20 +84,18 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
       case _                                      => None
     }
 
-  private def methodFast(dataFlowObject: Vertex): nodes.Method = {
-    val method =
-      dataFlowObject.label match {
-        case NodeTypes.METHOD_RETURN =>
-          ExpandTo.methodReturnToMethod(dataFlowObject)
-        case NodeTypes.METHOD_PARAMETER_IN =>
-          ExpandTo.parameterInToMethod(dataFlowObject)
-        case NodeTypes.METHOD_PARAMETER_OUT =>
-          ExpandTo.parameterInToMethod(dataFlowObject)
-        case NodeTypes.LITERAL | NodeTypes.CALL | NodeTypes.IDENTIFIER | NodeTypes.RETURN | NodeTypes.UNKNOWN =>
-          ExpandTo.expressionToMethod(dataFlowObject.asInstanceOf[nodes.Expression])
-      }
-    method.asInstanceOf[nodes.Method]
-  }
+  // TODO match on type rather than label: depends on https://github.com/ShiftLeftSecurity/codepropertygraph/issues/610
+  private def methodFast(dataFlowObject: nodes.TrackingPoint): nodes.Method =
+    dataFlowObject.label match {
+      case NodeTypes.METHOD_RETURN =>
+        ExpandTo.methodReturnToMethod(dataFlowObject.asInstanceOf[nodes.MethodReturn])
+      case NodeTypes.METHOD_PARAMETER_IN =>
+        ExpandTo.parameterInToMethod(dataFlowObject.asInstanceOf[nodes.MethodParameterIn])
+      case NodeTypes.METHOD_PARAMETER_OUT =>
+        ExpandTo.parameterOutToMethod(dataFlowObject.asInstanceOf[nodes.MethodParameterOut])
+      case NodeTypes.LITERAL | NodeTypes.CALL | NodeTypes.IDENTIFIER | NodeTypes.RETURN | NodeTypes.UNKNOWN =>
+        ExpandTo.expressionToMethod(dataFlowObject.asInstanceOf[nodes.Expression])
+    }
 
   private def indirectAccess(node: nodes.StoredNode): Boolean =
     node match {

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/propagateedges/PropagateEdgePass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/propagateedges/PropagateEdgePass.scala
@@ -6,7 +6,6 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.dataflowengine.semanticsloader.Semantics
 import org.apache.logging.log4j.{LogManager, Logger}
-import org.apache.tinkerpop.gremlin.structure.Direction
 
 import scala.jdk.CollectionConverters._
 

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
@@ -166,8 +166,8 @@ class ReachingDefPass(cpg: Cpg) extends CpgPass(cpg) {
   /** For debug purposes */
   def vertexToStr(vertex: Vertex): String = {
     try {
-      val methodVertex = ExpandTo.expressionToMethod(vertex)
-      val fileName = ExpandTo.methodToFile(methodVertex) match {
+      val method = ExpandTo.expressionToMethod(vertex.asInstanceOf[nodes.Expression])
+      val fileName = ExpandTo.methodToFile(method) match {
         case Some(objFile) => objFile.value2(NodeKeys.NAME)
         case None          => "NA"
       }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.semanticcpg.language
 
 import gremlin.scala.Vertex
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.utils.ExpandTo
-import org.apache.tinkerpop.gremlin.structure.Direction
 
 import scala.jdk.CollectionConverters._
 
@@ -18,7 +17,7 @@ object LocationCreator {
           paramIn.name,
           paramIn.label,
           paramIn.lineNumber,
-          ExpandTo.parameterInToMethod(paramIn).asInstanceOf[nodes.Method]
+          ExpandTo.parameterInToMethod(paramIn)
         )
       case paramOut: nodes.MethodParameterOut =>
         apply(
@@ -26,7 +25,7 @@ object LocationCreator {
           paramOut.name,
           paramOut.label,
           paramOut.lineNumber,
-          ExpandTo.parameterInToMethod(paramOut).asInstanceOf[nodes.Method]
+          ExpandTo.parameterOutToMethod(paramOut)
         )
       case methodReturn: nodes.MethodReturn =>
         apply(
@@ -34,7 +33,7 @@ object LocationCreator {
           "$ret",
           methodReturn.label,
           methodReturn.lineNumber,
-          ExpandTo.methodReturnToMethod(methodReturn).asInstanceOf[nodes.Method]
+          ExpandTo.methodReturnToMethod(methodReturn)
         )
       case call: nodes.Call =>
         apply(
@@ -42,7 +41,7 @@ object LocationCreator {
           call.code,
           call.label,
           call.lineNumber,
-          ExpandTo.expressionToMethod(call).asInstanceOf[nodes.Method]
+          ExpandTo.expressionToMethod(call)
         )
       case implicitCall: nodes.ImplicitCall =>
         apply(
@@ -66,7 +65,7 @@ object LocationCreator {
           identifier.name,
           identifier.label,
           identifier.lineNumber,
-          ExpandTo.expressionToMethod(identifier).asInstanceOf[nodes.Method]
+          ExpandTo.expressionToMethod(identifier)
         )
       case literal: nodes.Literal =>
         apply(
@@ -120,7 +119,7 @@ object LocationCreator {
       )
 
       val namespaceName = namespaceOption.map(_.name).getOrElse("")
-      val fileOption = ExpandTo.methodToFile(method).map(_.asInstanceOf[nodes.File])
+      val fileOption = ExpandTo.methodToFile(method)
       val fileName = fileOption.map(_.name).getOrElse("N/A")
 
       nodes.NewLocation(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -74,14 +74,7 @@ object LocationCreator {
           literal.code,
           literal.label,
           literal.lineNumber,
-          ExpandTo.expressionToMethod(literal) match {
-            case method: nodes.Method =>
-              method
-            case _: nodes.TypeDecl =>
-              // TODO - there are csharp CPGs that have
-              // typedecls here, which is invalid.
-              null
-          }
+          ExpandTo.expressionToMethod(literal)
         )
       case local: nodes.Local =>
         apply(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -113,34 +113,24 @@ object LocationCreator {
             method: nodes.Method): nodes.NewLocation = {
 
     if (method == null) {
-      new nodes.NewLocation("", "", "", "", None, "", "", "", "", Some(node))
+      nodes.NewLocation("", "", "", "", None, "", "", "", "", Some(node))
     } else {
       val typeOption = ExpandTo.methodToTypeDecl(method).map(_.asInstanceOf[nodes.TypeDecl])
       val typeName = typeOption.map(_.fullName).getOrElse("")
       val typeShortName = typeOption.map(_.name).getOrElse("")
 
-      val namespaceOptionVertex = typeOption.flatMap(
-        _.vertices(Direction.IN, EdgeTypes.AST).asScala
-          .filter(_.label == NodeTypes.NAMESPACE_BLOCK)
-          .flatMap(_.vertices(Direction.OUT, EdgeTypes.REF).asScala)
-          .toList
-          .headOption
-      )
-      val namespaceOptionVertex2 = typeOption.flatMap(
-          _.astIn.asScala
-//          .filter(_.label == NodeTypes.NAMESPACE_BLOCK)
+      val namespaceOption = typeOption.flatMap(
+        _.astIn.asScala
           .collect { case nb: nodes.NamespaceBlock => nb }
           .flatMap(_.refOut.asScala)
-//          .flatMap(_._refOut.asScala)
-          .toList
-          .headOption
+          .nextOption
       )
-      val namespaceOption = namespaceOptionVertex.map(_.asInstanceOf[nodes.Namespace])
+
       val namespaceName = namespaceOption.map(_.name).getOrElse("")
       val fileOption = ExpandTo.methodToFile(method).map(_.asInstanceOf[nodes.File])
       val fileName = fileOption.map(_.name).getOrElse("N/A")
 
-      new nodes.NewLocation(
+      nodes.NewLocation(
         symbol = symbol,
         methodFullName = method.fullName,
         methodShortName = method.name,
@@ -155,7 +145,6 @@ object LocationCreator {
     }
   }
 
-  def emptyLocation(label: String, node: Option[nodes.Node]): nodes.NewLocation = {
-    new nodes.NewLocation("", "", "", "", None, "", "", label, "", node)
-  }
+  def emptyLocation(label: String, node: Option[nodes.Node]): nodes.NewLocation =
+    nodes.NewLocation("", "", "", "", None, "", "", label, "", node)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -126,6 +126,15 @@ object LocationCreator {
           .toList
           .headOption
       )
+      val namespaceOptionVertex2 = typeOption.flatMap(
+          _.astIn.asScala
+//          .filter(_.label == NodeTypes.NAMESPACE_BLOCK)
+          .collect { case nb: nodes.NamespaceBlock => nb }
+          .flatMap(_.refOut.asScala)
+//          .flatMap(_._refOut.asScala)
+          .toList
+          .headOption
+      )
       val namespaceOption = namespaceOptionVertex.map(_.asInstanceOf[nodes.Namespace])
       val namespaceName = namespaceOption.map(_.name).getOrElse("")
       val fileOption = ExpandTo.methodToFile(method).map(_.asInstanceOf[nodes.File])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointToCfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointToCfgNode.scala
@@ -12,11 +12,10 @@ object TrackingPointToCfgNode {
       case node: nodes.Literal    => node.parentExpression
 
       case node: nodes.MethodParameterIn =>
-        ExpandTo.parameterInToMethod(node).asInstanceOf[nodes.CfgNode]
+        ExpandTo.parameterInToMethod(node)
 
       case node: nodes.MethodParameterOut =>
-        val method = ExpandTo.parameterInToMethod(node)
-        method.asInstanceOf[nodes.Method].methodReturn
+        ExpandTo.parameterOutToMethod(node).methodReturn
 
       case node: nodes.Call if MemberAccess.isGenericMemberAccessName(node.name) =>
         node.parentExpression

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -19,7 +19,7 @@ class CfgNode[A <: nodes.CfgNode](val wrapped: NodeSteps[A]) extends AnyVal {
             method
           case methodReturn: nodes.MethodReturn =>
             ExpandTo.methodReturnToMethod(methodReturn)
-          case expression =>
+          case expression: nodes.Expression =>
             ExpandTo.expressionToMethod(expression)
         }
         .cast[nodes.Method])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -4,7 +4,6 @@ import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes}
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import org.apache.tinkerpop.gremlin.structure.Direction
 
 /**
   * Type declaration - possibly a template that requires instantiation
@@ -112,21 +111,12 @@ class TypeDecl(val wrapped: NodeSteps[nodes.TypeDecl]) extends AnyVal {
     * If this is an alias type declaration, go to its underlying type declaration
     * else unchanged.
     */
-  def unravelAlias: NodeSteps[nodes.TypeDecl] = {
-    new NodeSteps(raw.map { typeDecl =>
+  def unravelAlias: NodeSteps[nodes.TypeDecl] =
+    wrapped.map { typeDecl =>
       if (typeDecl.aliasTypeFullName.isDefined) {
-        typeDecl
-          .vertices(Direction.OUT, EdgeTypes.ALIAS_OF)
-          .next
-          .asInstanceOf[nodes.Type]
-          .vertices(Direction.OUT, EdgeTypes.REF)
-          .next
-          .asInstanceOf[nodes.TypeDecl]
-      } else {
-        typeDecl
-      }
-    })
-  }
+        typeDecl.aliasOfOut.next.refOut.next
+      } else typeDecl
+    }
 
   /**
     * Traverse to canonical type which means unravel aliases until we find
@@ -138,21 +128,15 @@ class TypeDecl(val wrapped: NodeSteps[nodes.TypeDecl]) extends AnyVal {
     // step is used in other repeat steps we do not use it here.
     //until(_.isCanonical).repeat(_.unravelAlias)
 
-    new NodeSteps(raw.map { typeDecl =>
+    wrapped.map { typeDecl =>
       var currentTypeDecl = typeDecl
       var aliasExpansionCounter = 0
       while (currentTypeDecl.aliasTypeFullName.isDefined && aliasExpansionCounter < maxAliasExpansions) {
-        currentTypeDecl = currentTypeDecl
-          .vertices(Direction.OUT, EdgeTypes.ALIAS_OF)
-          .next
-          .asInstanceOf[nodes.Type]
-          .vertices(Direction.OUT, EdgeTypes.REF)
-          .next
-          .asInstanceOf[nodes.TypeDecl]
+        currentTypeDecl = currentTypeDecl.aliasOfOut.next.refOut.next
         aliasExpansionCounter += 1
       }
       currentTypeDecl
-    })
+    }
   }
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDecl.scala
@@ -113,9 +113,10 @@ class TypeDecl(val wrapped: NodeSteps[nodes.TypeDecl]) extends AnyVal {
     */
   def unravelAlias: NodeSteps[nodes.TypeDecl] =
     wrapped.map { typeDecl =>
-      if (typeDecl.aliasTypeFullName.isDefined) {
+      if (typeDecl.aliasTypeFullName.isDefined)
         typeDecl.aliasOfOut.next.refOut.next
-      } else typeDecl
+      else
+        typeDecl
     }
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -24,8 +24,8 @@ object ExpandTo {
     callReceiverOption(callNode).get
 
   // TODO move into traversal dsl - used in codescience
-  def callArguments(callNode: nodes.Call): Iterator[nodes.Expression] =
-    callNode.argumentOut.asScala.map(_.asInstanceOf[nodes.Expression])
+  def callArguments(callNode: nodes.CallRepr): Iterator[nodes.Expression] =
+    callNode._argumentOut.asScala.map(_.asInstanceOf[nodes.Expression])
 
   def typeCarrierToType(parameterNode: nodes.StoredNode): nodes.Type =
     parameterNode._evalTypeOut.nextChecked.asInstanceOf[nodes.Type]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -32,10 +32,10 @@ object ExpandTo {
 
   def parameterInToMethod(parameterIn: nodes.MethodParameterIn): nodes.Method =
     parameterIn.astIn.nextChecked
-  
+
   def parameterOutToMethod(parameterOut: nodes.MethodParameterOut): nodes.Method =
     parameterOut.astIn.nextChecked
-  
+
   def methodReturnToMethod(formalReturnNode: nodes.MethodReturn): nodes.Method =
     formalReturnNode.astIn.nextChecked
 
@@ -81,16 +81,10 @@ object ExpandTo {
       case None                              => None
     }
 
-  def methodToOutParameters(method: Vertex): Seq[nodes.StoredNode] = {
-    method
-      .asInstanceOf[nodes.StoredNode]
-      ._astOut
-      .asScala
-      .filter(_.isInstanceOf[nodes.MethodParameterOut])
-      .toSeq
-  }
+  def methodToOutParameters(method: nodes.Method): Iterator[nodes.MethodParameterOut] =
+    method.astOut.asScala.collect { case paramOut: nodes.MethodParameterOut => paramOut }
 
   def implicitCallToMethod(implicitCall: nodes.ImplicitCall): nodes.Method =
-    implicitCall.vertices(Direction.IN, EdgeTypes.AST).next.asInstanceOf[nodes.Method]
+    implicitCall.astIn.nextChecked
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -17,29 +17,30 @@ object ExpandTo {
   // For languages which make use of function pointers, this can also be the
   // pointer itself.
   // TODO move into traversal dsl - used in codescience
-  def callReceiverOption(callNode: Vertex): Option[nodes.StoredNode] =
-    callNode
-      .asInstanceOf[nodes.StoredNode]
-      ._receiverOut
-      .nextOption
+  def callReceiverOption(callNode: nodes.Call): Option[nodes.StoredNode] =
+    callNode.receiverOut.nextOption
 
-  def callReceiver(callNode: Vertex): nodes.StoredNode = callReceiverOption(callNode).get
+  def callReceiver(callNode: nodes.Call): nodes.StoredNode =
+    callReceiverOption(callNode).get
 
   // TODO move into traversal dsl - used in codescience
-  def callArguments(callNode: Vertex): Iterator[nodes.Expression] =
-    callNode.asInstanceOf[nodes.StoredNode]._argumentOut.asScala.map(_.asInstanceOf[nodes.Expression])
+  def callArguments(callNode: nodes.Call): Iterator[nodes.Expression] =
+    callNode.argumentOut.asScala.map(_.asInstanceOf[nodes.Expression])
 
-  def typeCarrierToType(parameterNode: Vertex): nodes.StoredNode =
-    parameterNode.asInstanceOf[nodes.StoredNode]._evalTypeOut.nextChecked
+  def typeCarrierToType(parameterNode: nodes.StoredNode): nodes.Type =
+    parameterNode._evalTypeOut.nextChecked.asInstanceOf[nodes.Type]
 
-  def parameterInToMethod(parameterNode: Vertex): nodes.StoredNode =
-    parameterNode.asInstanceOf[nodes.StoredNode]._astIn.nextChecked
+  def parameterInToMethod(parameterIn: nodes.MethodParameterIn): nodes.Method =
+    parameterIn.astIn.nextChecked
+  
+  def parameterOutToMethod(parameterOut: nodes.MethodParameterOut): nodes.Method =
+    parameterOut.astIn.nextChecked
+  
+  def methodReturnToMethod(formalReturnNode: nodes.MethodReturn): nodes.Method =
+    formalReturnNode.astIn.nextChecked
 
-  def methodReturnToMethod(formalReturnNode: Vertex): nodes.StoredNode =
-    formalReturnNode.asInstanceOf[nodes.StoredNode]._astIn.nextChecked
-
-  def returnToReturnedExpression(returnExpression: Vertex): Option[nodes.Expression] =
-    returnExpression.asInstanceOf[nodes.StoredNode]._astOut.nextOption.map(_.asInstanceOf[nodes.Expression])
+  def returnToReturnedExpression(returnExpression: nodes.Return): Option[nodes.Expression] =
+    returnExpression.astOut.nextOption.map(_.asInstanceOf[nodes.Expression])
 
   def expressionToMethod(expression: nodes.Expression): nodes.Method =
     expression._containsIn.nextChecked match {
@@ -89,8 +90,7 @@ object ExpandTo {
       .toSeq
   }
 
-  def implicitCallToMethod(implicitCall: nodes.ImplicitCall): nodes.Method = {
+  def implicitCallToMethod(implicitCall: nodes.ImplicitCall): nodes.Method =
     implicitCall.vertices(Direction.IN, EdgeTypes.AST).next.asInstanceOf[nodes.Method]
-  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -17,41 +17,39 @@ object ExpandTo {
   // For languages which make use of function pointers, this can also be the
   // pointer itself.
   // TODO move into traversal dsl - used in codescience
-  def callReceiverOption(callNode: Vertex): Option[nodes.StoredNode] = {
+  def callReceiverOption(callNode: Vertex): Option[nodes.StoredNode] =
     callNode
       .asInstanceOf[nodes.StoredNode]
       ._receiverOut
       .nextOption
-  }
 
   def callReceiver(callNode: Vertex): nodes.StoredNode = callReceiverOption(callNode).get
 
   // TODO move into traversal dsl - used in codescience
-  def callArguments(callNode: Vertex): Iterator[nodes.Expression] = {
+  def callArguments(callNode: Vertex): Iterator[nodes.Expression] =
     callNode.asInstanceOf[nodes.StoredNode]._argumentOut.asScala.map(_.asInstanceOf[nodes.Expression])
-  }
 
-  def typeCarrierToType(parameterNode: Vertex): nodes.StoredNode = {
+  def typeCarrierToType(parameterNode: Vertex): nodes.StoredNode =
     parameterNode.asInstanceOf[nodes.StoredNode]._evalTypeOut.nextChecked
-  }
 
-  def parameterInToMethod(parameterNode: Vertex): nodes.StoredNode = {
+  def parameterInToMethod(parameterNode: Vertex): nodes.StoredNode =
     parameterNode.asInstanceOf[nodes.StoredNode]._astIn.nextChecked
-  }
 
-  def methodReturnToMethod(formalReturnNode: Vertex): nodes.StoredNode = {
+  def methodReturnToMethod(formalReturnNode: Vertex): nodes.StoredNode =
     formalReturnNode.asInstanceOf[nodes.StoredNode]._astIn.nextChecked
-  }
 
-  def returnToReturnedExpression(returnExpression: Vertex): Option[nodes.Expression] = {
+  def returnToReturnedExpression(returnExpression: Vertex): Option[nodes.Expression] =
     returnExpression.asInstanceOf[nodes.StoredNode]._astOut.nextOption.map(_.asInstanceOf[nodes.Expression])
-  }
 
-  def expressionToMethod(expression: Vertex): nodes.StoredNode = {
-    expression.asInstanceOf[nodes.StoredNode]._containsIn.nextChecked
-  }
+  def expressionToMethod(expression: nodes.Expression): nodes.Method =
+    expression._containsIn.nextChecked match {
+      case method: nodes.Method => method
+      case _: nodes.TypeDecl    =>
+        // TODO - there are csharp CPGs that have typedecls here, which is invalid.
+        null
+    }
 
-  def hasModifier(methodNode: Vertex, modifierType: String): Boolean = {
+  def hasModifier(methodNode: Vertex, modifierType: String): Boolean =
     methodNode
       .asInstanceOf[nodes.StoredNode]
       ._astOut
@@ -59,37 +57,28 @@ object ExpandTo {
       .exists(astChild =>
         astChild.isInstanceOf[nodes.Modifier] &&
           astChild.asInstanceOf[nodes.Modifier].modifierType == modifierType)
-  }
 
-  def callToCalledMethod(call: Vertex): Seq[nodes.Method] = {
+  def callToCalledMethod(call: Vertex): Seq[nodes.Method] =
     call
       .asInstanceOf[nodes.StoredNode]
       ._callOut
       .asScala
       .map(_.asInstanceOf[nodes.Method])
       .toSeq
-  }
 
-  def methodToTypeDecl(vertex: Vertex): Option[nodes.StoredNode] = {
-    findVertex(vertex, _.isInstanceOf[nodes.TypeDecl])
-  }
+  def methodToTypeDecl(method: nodes.Method): Option[nodes.TypeDecl] =
+    findVertex(method, _.isInstanceOf[nodes.TypeDecl]).map(_.asInstanceOf[nodes.TypeDecl])
 
-  def methodToFile(vertex: Vertex): Option[Vertex] = {
-    findVertex(vertex, _.isInstanceOf[nodes.File])
-  }
+  def methodToFile(method: nodes.Method): Option[nodes.File] =
+    findVertex(method, _.isInstanceOf[nodes.File]).map(_.asInstanceOf[nodes.File])
 
   @tailrec
-  private def findVertex(vertex: Vertex, instanceCheck: Vertex => Boolean): Option[nodes.StoredNode] = {
-    val iterator = vertex.asInstanceOf[nodes.StoredNode]._astIn
-    if (iterator.hasNext) {
-      iterator.next() match {
-        case head if instanceCheck(head) => Some(head)
-        case head                        => findVertex(head, instanceCheck)
-      }
-    } else {
-      None
+  private def findVertex(node: nodes.StoredNode, instanceCheck: nodes.StoredNode => Boolean): Option[nodes.StoredNode] =
+    node._astIn.nextOption match {
+      case Some(head) if instanceCheck(head) => Some(head)
+      case Some(head)                        => findVertex(head, instanceCheck)
+      case None                              => None
     }
-  }
 
   def methodToOutParameters(method: Vertex): Seq[nodes.StoredNode] = {
     method


### PR DESCRIPTION
* part of migration to new DSL:
https://github.com/ShiftLeftSecurity/product/issues/3526
* faster than tinkerpop api
* more concise and readable
* (far) less casts