### PR TITLE
minor cleanup for nodemethods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,14 +46,6 @@ before_cache:
 - find $HOME/.sbt -name "*.lock" -type f -delete
 - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
 - rm -rf $HOME/.ivy2/local
-cache:
-  directories:
-    - $HOME/.sbt/1.0/dependency
-    - $HOME/.sbt/boot/scala*
-    - $HOME/.sbt/launchers
-    - $HOME/.ivy2/cache
-    - $HOME/.cache/coursier
-    - $HOME/.coursier
 notifications:
   slack:
     secure: HAZWVXDtRQiqSl0BiskghiLRMzi9+6q7DYhgBSmXTth8Ljex2n6ehsmxN7DdnL+OX8RqKWCIzSCURbPmVxJG77g4vQOi5a4FG//2NUAWMNBciLSwAJfyn6eC7tn4+iA9B1SKOSwdz7SCshnOL/9XupojYAwApjZgjvAFDGYOfFk9gv4Ezjrx3mX6Ge+VrkBVLIyFxTeBcMCsLYi/zsZWnzWpl7+ymqQIxhiburOU1ePDq/lHcFdvQSks3YWb1TlfsdNRt7hwkNrb60nfsZBxyt7pDk+GV4rdpgtZgolcZImqrVarnz7/UchOLn6Hl/bmkqFr3a+Aiaank7oph/fIWGBKqbTzoD8nY6mp1sLYtMbk8BZgKjr+DuqyIoJawMl7RvffJA2L149QPNdaR9uIkx+a2P5Wgs/DFiASOnyiX87S1Hfwok6ediO+NSrQJhGMyk87dRycDHywDaG0VuppHiFrDrqEo9kE/2iEL3/10xqVuoU1Yp/aLmeXSs2b0P7VZTLy23w8aCn6EEdyTgLkc0xRHPkA/c04UZ6vuQCK3JsBpEtT95Sot0y58vgbh1Er5DOlDXccOXL9qooBe9e84uJFj4qJx+/bIRBPKC0em1Dd3qtPP4MCfxY9+75r03ruwi1PPR/ifAjXbiBp9qfWu2XHXDmyHfoI73UJyClYLxI=

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -25,21 +25,23 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
     * Indicate whether the AST node represents a control structure,
     * e.g., `if`, `for`, `while`.
     * */
-  def isControlStructure: Boolean = node.start.isControlStructure.size == 1
+  def isControlStructure: Boolean = node.isInstanceOf[nodes.ControlStructure]
 
-  def isIdentifier: Boolean = node.start.isIdentifier.size == 1
+  def isIdentifier: Boolean = node.isInstanceOf[nodes.Identifier]
 
-  def isReturn: Boolean = node.start.isReturn.size == 1
+  def isFieldIdentifier: Boolean = node.isInstanceOf[nodes.FieldIdentifier]
 
-  def isLiteral: Boolean = node.start.isLiteral.size == 1
+  def isReturn: Boolean = node.isInstanceOf[nodes.Return]
 
-  def isCall: Boolean = node.start.isCall.size == 1
+  def isLiteral: Boolean = node.isInstanceOf[nodes.Literal]
 
-  def isExpression: Boolean = node.start.isExpression.size == 1
+  def isCall: Boolean = node.isInstanceOf[nodes.Call]
 
-  def isMethodRef: Boolean = node.start.isMethodRef.size == 1
+  def isExpression: Boolean = node.isInstanceOf[nodes.Expression]
 
-  def isBlock: Boolean = node.start.isBlock.size == 1
+  def isMethodRef: Boolean = node.isInstanceOf[nodes.MethodRef]
+
+  def isBlock: Boolean = node.isInstanceOf[nodes.Block]
 
   /**
     * The depth of the AST rooted in this node. Upon walking
@@ -67,7 +69,7 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
 
   @tailrec
   final def _parentExpression(argument: nodes.AstNode): nodes.Expression = {
-    val parent = argument.asInstanceOf[nodes.StoredNode]._astIn.nextChecked
+    val parent = argument._astIn.nextChecked
     parent match {
       case call: nodes.Call if MemberAccess.isGenericMemberAccessName(call.name) =>
         _parentExpression(call)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
@@ -16,9 +16,9 @@ class WithinMethodMethods(val node: nodes.WithinMethod) extends AnyVal {
   }
 
   private def walkUpAst(node: nodes.WithinMethod): nodes.Method =
-    node.vertices(Direction.IN, EdgeTypes.AST).nextChecked.asInstanceOf[nodes.Method]
+    node._astIn.nextChecked.asInstanceOf[nodes.Method]
 
   private def walkUpContainsEdges(node: nodes.WithinMethod): nodes.Method =
-    node.vertices(Direction.IN, EdgeTypes.CONTAINS).nextChecked.asInstanceOf[nodes.Method]
+    node._containsIn.nextChecked.asInstanceOf[nodes.Method]
 
 }


### PR DESCRIPTION
Relevant if we use the nice methods in the dataflow tracker (don't start gremlin traversals unless absolutely required).