### PR TITLE
Add TYPE_FULL_NAME property to METHOD_REF node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ cpg.method.name("getAccountList").definingTypeDecl.toList.head
 # References
 
 [1]  Rodriguez and Neubauer - The Graph Traversal Pattern:
-   https://pdfs.semanticscholar.org/ae6d/dcba8c848dd0a30a30c5a895cbb491c9e445.pdf
+    https://pdfs.semanticscholar.org/ae6d/dcba8c848dd0a30a30c5a895cbb491c9e445.pdf
 
 [2] Yamaguchi et al. - Modeling and Discovering Vulnerabilities with Code Property Graphs
     https://www.sec.cs.tu-bs.de/pubs/2014-ieeesp.pdf

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -244,7 +244,7 @@
         },
 
         {"id":333, "name":"METHOD_REF",
-          "keys": ["CODE", "ORDER", "ARGUMENT_INDEX", "METHOD_INST_FULL_NAME", "METHOD_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+          "keys": ["CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "METHOD_INST_FULL_NAME", "METHOD_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
           "comment":"Reference to a method instance",
          "is": ["EXPRESSION"],
           "outEdges": [

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -57,6 +57,7 @@ class Linker(cpg: Cpg) extends CpgPass(cpg) {
         NodeTypes.LOCAL,
         NodeTypes.IDENTIFIER,
         NodeTypes.BLOCK,
+        NodeTypes.METHOD_REF,
         NodeTypes.UNKNOWN
       ),
       dstNodeLabel = NodeTypes.TYPE,


### PR DESCRIPTION
This was long overdue since METHOD_REF is a EXPRESSION and thus
has to have a type associated.