### PR TITLE
onlyChecked

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
@@ -19,6 +19,14 @@ object Implicits {
       }
     }
 
+    def onlyChecked: T = {
+      if (iterator.hasNext) {
+        val res = iterator.next
+        assert(!iterator.hasNext)
+        res
+      } else { throw new NoSuchElementException() }
+    }
+
     def nextOption: Option[T] = {
       if (iterator.hasNext) {
         Some(iterator.next)

--- a/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
@@ -22,7 +22,7 @@ object Implicits {
     def onlyChecked: T = {
       if (iterator.hasNext) {
         val res = iterator.next
-        assert(!iterator.hasNext)
+        assert(!iterator.hasNext, "iterator was expected to have exactly one element, but it actually has more")
         res
       } else { throw new NoSuchElementException() }
     }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -75,12 +75,12 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
   private def getTrackingPoint(node: nodes.StoredNode): Option[nodes.TrackingPoint] =
     node match {
       case identifier: nodes.Identifier =>
-        getTrackingPoint(identifier._argumentIn().nextChecked)
+        getTrackingPoint(identifier._argumentIn().onlyChecked)
       case call: nodes.Call                       => Some(call)
       case ret: nodes.Return                      => Some(ret)
       case methodReturn: nodes.MethodReturn       => Some(methodReturn)
       case methodParamIn: nodes.MethodParameterIn => Some(methodParamIn)
-      case literal: nodes.Literal                 => getTrackingPoint(literal._argumentIn().nextChecked)
+      case literal: nodes.Literal                 => getTrackingPoint(literal._argumentIn().onlyChecked)
       case _                                      => None
     }
 

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
@@ -277,11 +277,7 @@ class DataFlowFrameworkHelper(graph: ScalaGraph) {
   def getOperation(node: nodes.StoredNode): Option[nodes.StoredNode] = {
     node match {
       case identifier: nodes.Identifier =>
-        if (identifier.argumentIn.hasNext) {
-          getOperation(identifier.argumentIn.nextChecked)
-        } else {
-          None
-        }
+        identifier.argumentIn.nextOption
       case _: nodes.Call   => Some(node)
       case _: nodes.Return => Some(node)
       case _               => None

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
@@ -277,12 +277,10 @@ class DataFlowFrameworkHelper(graph: ScalaGraph) {
 
   def getOperation(node: nodes.StoredNode): Option[nodes.StoredNode] = {
     node match {
-      case identifier: nodes.Identifier =>
-        identifier.argumentIn.nextOption.map(getOperation)
-        }
-      case _: nodes.Call   => Some(node)
-      case _: nodes.Return => Some(node)
-      case _               => None
+      case identifier: nodes.Identifier => identifier.argumentIn.nextOption.flatMap(getOperation)
+      case _: nodes.Call                => Some(node)
+      case _: nodes.Return              => Some(node)
+      case _                            => None
     }
   }
 }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
@@ -11,6 +11,7 @@ import io.shiftleft.passes.{CpgPass, DiffGraph, ParallelIteratorExecutor}
 import io.shiftleft.semanticcpg.utils.{ExpandTo, MemberAccess}
 import io.shiftleft.semanticcpg.language._
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
@@ -277,7 +278,10 @@ class DataFlowFrameworkHelper(graph: ScalaGraph) {
   def getOperation(node: nodes.StoredNode): Option[nodes.StoredNode] = {
     node match {
       case identifier: nodes.Identifier =>
-        identifier.argumentIn.nextOption
+        identifier.argumentIn.nextOption match {
+          case None       => None
+          case Some(user) => getOperation(user)
+        }
       case _: nodes.Call   => Some(node)
       case _: nodes.Return => Some(node)
       case _               => None

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
@@ -278,9 +278,7 @@ class DataFlowFrameworkHelper(graph: ScalaGraph) {
   def getOperation(node: nodes.StoredNode): Option[nodes.StoredNode] = {
     node match {
       case identifier: nodes.Identifier =>
-        identifier.argumentIn.nextOption match {
-          case None       => None
-          case Some(user) => getOperation(user)
+        identifier.argumentIn.nextOption.map(getOperation)
         }
       case _: nodes.Call   => Some(node)
       case _: nodes.Return => Some(node)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -69,7 +69,7 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
 
   @tailrec
   final def _parentExpression(argument: nodes.AstNode): nodes.Expression = {
-    val parent = argument._astIn.nextChecked
+    val parent = argument._astIn.onlyChecked
     parent match {
       case call: nodes.Call if MemberAccess.isGenericMemberAccessName(call.name) =>
         _parentExpression(call)
@@ -79,6 +79,6 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
   }
 
   def astParent: nodes.AstNode =
-    node._astIn.nextChecked.asInstanceOf[nodes.AstNode]
+    node._astIn.onlyChecked.asInstanceOf[nodes.AstNode]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -25,21 +25,23 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
     * Indicate whether the AST node represents a control structure,
     * e.g., `if`, `for`, `while`.
     * */
-  def isControlStructure: Boolean = node.start.isControlStructure.size == 1
+  def isControlStructure: Boolean = node.isInstanceOf[nodes.ControlStructure]
 
-  def isIdentifier: Boolean = node.start.isIdentifier.size == 1
+  def isIdentifier: Boolean = node.isInstanceOf[nodes.Identifier]
 
-  def isReturn: Boolean = node.start.isReturn.size == 1
+  def isFieldIdentifier: Boolean = node.isInstanceOf[nodes.FieldIdentifier]
 
-  def isLiteral: Boolean = node.start.isLiteral.size == 1
+  def isReturn: Boolean = node.isInstanceOf[nodes.Return]
 
-  def isCall: Boolean = node.start.isCall.size == 1
+  def isLiteral: Boolean = node.isInstanceOf[nodes.Literal]
 
-  def isExpression: Boolean = node.start.isExpression.size == 1
+  def isCall: Boolean = node.isInstanceOf[nodes.Call]
 
-  def isMethodRef: Boolean = node.start.isMethodRef.size == 1
+  def isExpression: Boolean = node.isInstanceOf[nodes.Expression]
 
-  def isBlock: Boolean = node.start.isBlock.size == 1
+  def isMethodRef: Boolean = node.isInstanceOf[nodes.MethodRef]
+
+  def isBlock: Boolean = node.isInstanceOf[nodes.Block]
 
   /**
     * The depth of the AST rooted in this node. Upon walking
@@ -67,7 +69,7 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
 
   @tailrec
   final def _parentExpression(argument: nodes.AstNode): nodes.Expression = {
-    val parent = argument.asInstanceOf[nodes.StoredNode]._astIn.nextChecked
+    val parent = argument._astIn.nextChecked
     parent match {
       case call: nodes.Call if MemberAccess.isGenericMemberAccessName(call.name) =>
         _parentExpression(call)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -14,7 +14,7 @@ class MethodMethods(val node: nodes.Method) extends AnyVal {
     node._astOut.asScala
       .collect { case mr: nodes.MethodReturn => mr }
       .asJava
-      .nextChecked
+      .onlyChecked
 
   def local: NodeSteps[nodes.Local] =
     node.start.local

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
@@ -16,9 +16,9 @@ class WithinMethodMethods(val node: nodes.WithinMethod) extends AnyVal {
   }
 
   private def walkUpAst(node: nodes.WithinMethod): nodes.Method =
-    node._astIn.nextChecked.asInstanceOf[nodes.Method]
+    node._astIn.onlyChecked.asInstanceOf[nodes.Method]
 
   private def walkUpContainsEdges(node: nodes.WithinMethod): nodes.Method =
-    node._containsIn.nextChecked.asInstanceOf[nodes.Method]
+    node._containsIn.onlyChecked.asInstanceOf[nodes.Method]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
@@ -16,9 +16,9 @@ class WithinMethodMethods(val node: nodes.WithinMethod) extends AnyVal {
   }
 
   private def walkUpAst(node: nodes.WithinMethod): nodes.Method =
-    node.vertices(Direction.IN, EdgeTypes.AST).nextChecked.asInstanceOf[nodes.Method]
+    node._astIn.nextChecked.asInstanceOf[nodes.Method]
 
   private def walkUpContainsEdges(node: nodes.WithinMethod): nodes.Method =
-    node.vertices(Direction.IN, EdgeTypes.CONTAINS).nextChecked.asInstanceOf[nodes.Method]
+    node._containsIn.nextChecked.asInstanceOf[nodes.Method]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -47,23 +47,23 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
       if (call.dispatchType == DispatchTypes.STATIC_DISPATCH) {
         methodFullNameToNode.get(call.methodFullName)
       } else {
-        val receiverIt = call.vertices(Direction.OUT, EdgeTypes.RECEIVER)
+        val receiverIt = call.receiverOut
         if (receiverIt.hasNext) {
           val receiver = receiverIt.next
 
           receiver match {
             case methodRefReceiver: nodes.MethodRef =>
-              Some(methodRefReceiver.vertices(Direction.OUT, EdgeTypes.REF).nextChecked.asInstanceOf[nodes.Method])
+              Some(methodRefReceiver._refOut.onlyChecked.asInstanceOf[nodes.Method])
             case _ =>
               val receiverTypeDecl = receiver
-                .vertices(Direction.OUT, EdgeTypes.EVAL_TYPE)
-                .nextChecked
-                .vertices(Direction.OUT, EdgeTypes.REF)
-                .nextChecked
+                ._evalTypeOut()
+                .onlyChecked
+                ._refOut
+                .onlyChecked
 
-              receiverTypeDecl.vertices(Direction.OUT, EdgeTypes.BINDS).asScala.collectFirst {
+              receiverTypeDecl._bindsOut.asScala.collectFirst {
                 case binding: nodes.Binding if binding.name == call.name && binding.signature == call.signature =>
-                  binding.vertices(Direction.OUT, EdgeTypes.REF).nextChecked.asInstanceOf[nodes.Method]
+                  binding._refOut.onlyChecked.asInstanceOf[nodes.Method]
               }
           }
         } else {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
@@ -30,7 +30,7 @@ class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
       .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
       .sideEffect {
         case parameterIn: nodes.MethodParameterIn =>
-          if (!parameterIn.vertices(Direction.OUT, EdgeTypes.PARAMETER_LINK).hasNext) {
+          if (!parameterIn._parameterLinkOut().hasNext) {
             val parameterOut = new nodes.NewMethodParameterOut(
               parameterIn.code,
               parameterIn.order,
@@ -42,11 +42,9 @@ class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
             )
 
             val method =
-              parameterIn.vertices(Direction.IN, EdgeTypes.AST).nextChecked.asInstanceOf[nodes.Method]
+              parameterIn._astIn.onlyChecked.asInstanceOf[nodes.Method]
             if (parameterIn.typeFullName == null) {
-              val evalType = parameterIn
-                .vertices(Direction.OUT, EdgeTypes.EVAL_TYPE)
-                .nextChecked
+              val evalType = parameterIn._evalTypeOut.onlyChecked
                 .asInstanceOf[nodes.Type]
               dstGraph.addEdgeToOriginal(parameterOut, evalType, EdgeTypes.EVAL_TYPE)
               if (!loggedMissingTypeFullName) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -32,15 +32,15 @@ object ExpandTo {
   }
 
   def typeCarrierToType(parameterNode: Vertex): nodes.StoredNode = {
-    parameterNode.asInstanceOf[nodes.StoredNode]._evalTypeOut.nextChecked
+    parameterNode.asInstanceOf[nodes.StoredNode]._evalTypeOut.onlyChecked
   }
 
   def parameterInToMethod(parameterNode: Vertex): nodes.StoredNode = {
-    parameterNode.asInstanceOf[nodes.StoredNode]._astIn.nextChecked
+    parameterNode.asInstanceOf[nodes.StoredNode]._astIn.onlyChecked
   }
 
   def methodReturnToMethod(formalReturnNode: Vertex): nodes.StoredNode = {
-    formalReturnNode.asInstanceOf[nodes.StoredNode]._astIn.nextChecked
+    formalReturnNode.asInstanceOf[nodes.StoredNode]._astIn.onlyChecked
   }
 
   def returnToReturnedExpression(returnExpression: Vertex): Option[nodes.Expression] = {
@@ -48,7 +48,7 @@ object ExpandTo {
   }
 
   def expressionToMethod(expression: Vertex): nodes.StoredNode = {
-    expression.asInstanceOf[nodes.StoredNode]._containsIn.nextChecked
+    expression.asInstanceOf[nodes.StoredNode]._containsIn.onlyChecked
   }
 
   def hasModifier(methodNode: Vertex, modifierType: String): Boolean = {


### PR DESCRIPTION
We use `nextChecked` in a lot of places where we actually insist on exactly one item existing. This introduces `onlyChecked` to also assert this fact.

Also make more use of the fast neighbor API. I skipped the `Linker` for now to avoid merge conflicts with https://github.com/ShiftLeftSecurity/codepropertygraph/pull/596 .