### PR TITLE
implicit conversion: lift to NewNodeSteps for nodes.NewNode extensions

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -218,8 +218,11 @@ package object language extends operatorextension.Implicits {
   implicit def toCallForCallGraph(steps: Steps[nodes.Call]): Call = new Call(steps)
   // / Call graph extension
 
-  implicit def toNodeStepsTag[NodeType <: nodes.StoredNode](original: Steps[NodeType]): NodeSteps[NodeType] =
+  implicit def toNodeSteps[NodeType <: nodes.StoredNode](original: Steps[NodeType]): NodeSteps[NodeType] =
     new NodeSteps[NodeType](original.raw)
+
+  implicit def toNewNodeSteps[NodeType <: nodes.NewNode](original: Steps[NodeType]): NewNodeSteps[NodeType] =
+    new NewNodeSteps[NodeType](original.raw)
 
   implicit def toNodeTypeStarters(cpg: Cpg): NodeTypeStarters = new NodeTypeStarters(cpg)
   implicit def toTagTraversal(steps: Steps[nodes.Tag]): Tag = new Tag(steps)


### PR DESCRIPTION
Allows us to call `steps.store` directly for a given `steps: Steps[nodes.NewNode]`
Before, we had to call e.g. `steps.toList.start.store`.

re https://github.com/ShiftLeftSecurity/codescience/pull/3486