### PR TITLE
better logging for enhancements

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -85,13 +85,13 @@ abstract class CpgPass(cpg: Cpg) {
     }
 
   private def withStartEndTimesLogged[A](fun: => A): A = {
-    logger.info(s"Start of enhancement: $name")
+    logger.debug(s"Start of enhancement: $name")
     val startTime = System.currentTimeMillis
     try {
       fun
     } finally {
       val endTime = System.currentTimeMillis
-      logger.info(s"End of enhancement: $name, after ${endTime - startTime}ms")
+      logger.info(s"Enhancement $name completed in ${endTime - startTime}ms")
     }
   }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -8,6 +8,7 @@ import java.util
 import java.lang.{Long => JLong}
 import org.apache.logging.log4j.{LogManager, Logger}
 import org.apache.tinkerpop.gremlin.structure.Vertex
+import scala.concurrent.duration.DurationLong
 
 /**
   * Base class for CPG pass - a program, which receives an input graph
@@ -90,8 +91,8 @@ abstract class CpgPass(cpg: Cpg) {
     try {
       fun
     } finally {
-      val endTime = System.currentTimeMillis
-      logger.info(s"Enhancement $name completed in ${endTime - startTime}ms")
+      val duration = (System.currentTimeMillis - startTime).millis.toCoarsest
+      logger.info(s"Enhancement $name completed in $duration")
     }
   }
 


### PR DESCRIPTION
* log cpgpass.start is now only on level DEBUG - finish is still INFO
* display coarsest time unit for enhancement duration
  before: Enhancement ABC completed in 3300000 milliseconds 
  now:    Enhancement ABC completed in 55 minutes