### PR TITLE
Generalize Findings node

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/securityprofile.json
+++ b/codepropertygraph/src/main/resources/schemas/securityprofile.json
@@ -92,7 +92,7 @@
    ]
    },
       {"id" : 214, "name" : "FINDING", "comment" : "", "keys" : [], "outEdges" : [], "containedNodes" : [
-	  {"localName" : "ioflows", "nodeType" : "IOFLOW", "cardinality" : "list"},
+	  {"localName" : "evidence", "nodeType" : "NODE", "cardinality" : "list"},
 	  {"localName" : "keyValuePairs", "nodeType" : "KEY_VALUE_PAIR", "cardinality" : "list"}
    ]
    },

--- a/codepropertygraph/src/main/resources/schemas/securityprofile.json
+++ b/codepropertygraph/src/main/resources/schemas/securityprofile.json
@@ -93,8 +93,6 @@
    },
       {"id" : 214, "name" : "FINDING", "comment" : "", "keys" : [], "outEdges" : [], "containedNodes" : [
 	  {"localName" : "ioflows", "nodeType" : "IOFLOW", "cardinality" : "list"},
-	  {"localName" : "methods", "nodeType" : "METHOD", "cardinality" : "list"},
-	  {"localName" : "flows", "nodeType" : "FLOW", "cardinality" : "list"},
 	  {"localName" : "keyValuePairs", "nodeType" : "KEY_VALUE_PAIR", "cardinality" : "list"}
    ]
    },


### PR DESCRIPTION
* Removed the fields `flows` and `methods` from the findings node as they are no longer used
* Changed the type of `ioFlows` to the more generic type `Node` and renamed to `evidence`