### PR TITLE
Add parameterOfType step for TYPE nodes.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -96,14 +96,17 @@ class Type(val wrapped: NodeSteps[nodes.Type]) extends AnyVal {
   def localsOfType: NodeSteps[nodes.Local] =
     new NodeSteps(raw.in(EdgeTypes.EVAL_TYPE).hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
-  def expressionOfType: NodeSteps[nodes.Expression] =
+  @deprecated("Use expression step instead.")
+  def expressionOfType: NodeSteps[nodes.Expression] = expression
+
+  def expression: NodeSteps[nodes.Expression] =
     new NodeSteps(
       raw
         .in(EdgeTypes.EVAL_TYPE)
         .filterOnEnd(_.isInstanceOf[nodes.Expression])
         .cast[nodes.Expression])
 
-  def parameterOfType: NodeSteps[nodes.MethodParameterIn] =
+  def parameter: NodeSteps[nodes.MethodParameterIn] =
     new NodeSteps(
       raw
         .in(EdgeTypes.EVAL_TYPE)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -100,6 +100,13 @@ class Type(val wrapped: NodeSteps[nodes.Type]) extends AnyVal {
     new NodeSteps(
       raw
         .in(EdgeTypes.EVAL_TYPE)
-        .hasLabel(NodeTypes.IDENTIFIER, NodeTypes.CALL, NodeTypes.LITERAL)
+        .filterOnEnd(_.isInstanceOf[nodes.Expression])
         .cast[nodes.Expression])
+
+  def parameterOfType: NodeSteps[nodes.MethodParameterIn] =
+    new NodeSteps(
+      raw
+        .in(EdgeTypes.EVAL_TYPE)
+        .filterOnEnd(_.isInstanceOf[nodes.MethodParameterIn])
+        .cast[nodes.MethodParameterIn])
 }


### PR DESCRIPTION
Also changes expressionOfType to work on class hierarchy instead of
labels so that it now really returns all expressions of a type and not
just IDENTIFIER, CALL and LITERAL.