### PR TITLE
toJson now outputs embedded nodes as well

### DIFF
--- a/cpgclientlib/tests/test.py
+++ b/cpgclientlib/tests/test.py
@@ -73,7 +73,7 @@ class TestStringMethods(unittest.TestCase):
         self.client.create_cpg(filename)
         response = self.client.query("cpg.method.toJson")
         jsonResponse = json.loads(response)
-        self.assertEqual("main", jsonResponse[0]["NAME"])
+        self.assertEqual("main", jsonResponse[0]["name"])
 
     @classmethod
     def tearDownClass(self):

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -106,9 +106,16 @@ class Steps[A](val raw: GremlinScala[A]) {
   private lazy val nodeSerializer = new CustomSerializer[nodes.Node](
     implicit format =>
       (
-        { case _                => ??? }, {
-          case node: StoredNode => Extraction.decompose(node.toMap)
-          case node: NewNode    => Extraction.decompose(node.properties)
+        { case _ => ??? }, {
+          case node: StoredNode => {
+            val elementMap = (0 until node.productArity).map { i =>
+              val label = node.productElementLabel(i)
+              val element = node.productElement(i)
+              (label -> element)
+            }.toMap + ("_label" -> node.label)
+            Extraction.decompose(elementMap)
+          }
+          case node: NewNode => Extraction.decompose(node.properties)
         }
     ))
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -107,7 +107,7 @@ class Steps[A](val raw: GremlinScala[A]) {
     implicit format =>
       (
         { case _ => ??? }, {
-          case node: StoredNode => {
+          case node: Node => {
             val elementMap = (0 until node.productArity).map { i =>
               val label = node.productElementLabel(i)
               val element = node.productElement(i)
@@ -115,7 +115,6 @@ class Steps[A](val raw: GremlinScala[A]) {
             }.toMap + ("_label" -> node.label)
             Extraction.decompose(elementMap)
           }
-          case node: NewNode => Extraction.decompose(node.properties)
         }
     ))
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -112,15 +112,15 @@ class StepsTest extends WordSpec with Matchers {
       val json = fixture.cpg.namespace.nameExact("io.shiftleft.testcode.splitmeup").toJson
       val parsed = parse(json).children.head //exactly one result for the above query
       (parsed \ "_label") shouldBe JString("NAMESPACE")
-      (parsed \ "NAME") shouldBe JString("io.shiftleft.testcode.splitmeup")
+      (parsed \ "name") shouldBe JString("io.shiftleft.testcode.splitmeup")
     }
 
     "operating on NewNode" in {
       val json = fixture.cpg.method.name(".*manyArgs.*").location.toJson
       val parsed = parse(json).children.head //exactly one result for the above query
-      (parsed \ "SYMBOL") shouldBe JString("manyArgs")
-      (parsed \ "CLASS_NAME") shouldBe JString("io.shiftleft.testcode.splitmeup.TestGraph")
-      (parsed \ "FILENAME") shouldBe JString("io/shiftleft/testcode/splitmeup/TestGraph.java")
+      (parsed \ "symbol") shouldBe JString("manyArgs")
+      (parsed \ "className") shouldBe JString("io.shiftleft.testcode.splitmeup.TestGraph")
+      (parsed \ "filename") shouldBe JString("io/shiftleft/testcode/splitmeup/TestGraph.java")
     }
 
     "operating on primitive" in {


### PR DESCRIPTION
Fix https://github.com/ShiftLeftSecurity/codescience/issues/3552 - 
"""
Pretty printing of case classes obtained via .toList/.l now also unrolls and displays containedNodes, however, toJson does not. As toJson is essentially supposed to export what the user sees with toList, we should adapt it accordingly.
"""
This PR fixes toJson for both StoredNodes and NewNodes. Just as is the case in the `toList` output, keys are lowercase, camel case.
