### PR TITLE
CfgDominator: replace tinkerpop api

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
@@ -1,6 +1,8 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
-class CfgDominator[Node](adapter: CfgAdapter[Node]) {
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+
+class CfgDominator[Node <: StoredNode](adapter: CfgAdapter[Node]) {
 
   /**
     * Calculates the immediate dominators of all CFG nodes reachable from cfgEntry.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorFrontier.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorFrontier.scala
@@ -1,8 +1,9 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import scala.collection.mutable
 
-class CfgDominatorFrontier[Node](cfgAdapter: CfgAdapter[Node], domTreeAdapter: DomTreeAdapter[Node]) {
+class CfgDominatorFrontier[Node <: StoredNode](cfgAdapter: CfgAdapter[Node], domTreeAdapter: DomTreeAdapter[Node]) {
 
   /**
     * Calculates a the dominator frontier for a set of CFG nodes.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
@@ -17,7 +17,7 @@ class CfgDominatorPass(cpg: Cpg) extends CpgPass(cpg) {
     new ParallelIteratorExecutor(methodsIterator).map(perMethod)
   }
 
-  private def perMethod(method: Vertex): DiffGraph = {
+  private def perMethod(method: StoredNode): DiffGraph = {
     val cfgAdapter = new CpgCfgAdapter()
     val dominatorCalculator = new CfgDominator(cfgAdapter)
 
@@ -36,7 +36,8 @@ class CfgDominatorPass(cpg: Cpg) extends CpgPass(cpg) {
     dstGraph.build()
   }
 
-  private def addDomTreeEdges(dstGraph: DiffGraph.Builder, cfgNodeToImmediateDominator: Map[Vertex, Vertex]): Unit = {
+  private def addDomTreeEdges(dstGraph: DiffGraph.Builder,
+                              cfgNodeToImmediateDominator: Map[StoredNode, StoredNode]): Unit = {
     // TODO do not iterate over potential hash map to ensure same interation order for
     // edge creation.
     cfgNodeToImmediateDominator.foreach {
@@ -48,7 +49,7 @@ class CfgDominatorPass(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   private def addPostDomTreeEdges(dstGraph: DiffGraph.Builder,
-                                  cfgNodeToPostImmediateDominator: Map[Vertex, Vertex]): Unit = {
+                                  cfgNodeToPostImmediateDominator: Map[StoredNode, StoredNode]): Unit = {
     // TODO do not iterate over potential hash map to ensure same interation order for
     // edge creation.
     cfgNodeToPostImmediateDominator.foreach {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CpgCfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CpgCfgAdapter.scala
@@ -1,17 +1,12 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
-import gremlin.scala.Vertex
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import org.apache.tinkerpop.gremlin.structure.Direction
-
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import scala.jdk.CollectionConverters._
 
-class CpgCfgAdapter extends CfgAdapter[Vertex] {
-  override def successors(node: Vertex): IterableOnce[Vertex] = {
-    node.vertices(Direction.OUT, EdgeTypes.CFG).asScala
-  }
+class CpgCfgAdapter extends CfgAdapter[StoredNode] {
+  override def successors(node: StoredNode): IterableOnce[StoredNode] =
+    node._cfgOut.asScala
 
-  override def predecessors(node: Vertex): IterableOnce[Vertex] = {
-    node.vertices(Direction.IN, EdgeTypes.CFG).asScala
-  }
+  override def predecessors(node: StoredNode): IterableOnce[StoredNode] =
+    node._cfgIn.asScala
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/ReverseCpgCfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/ReverseCpgCfgAdapter.scala
@@ -1,17 +1,12 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
-import gremlin.scala.Vertex
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import org.apache.tinkerpop.gremlin.structure.Direction
-
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import scala.jdk.CollectionConverters._
 
-class ReverseCpgCfgAdapter extends CfgAdapter[Vertex] {
-  override def successors(node: Vertex): IterableOnce[Vertex] = {
-    node.vertices(Direction.IN, EdgeTypes.CFG).asScala
-  }
+class ReverseCpgCfgAdapter extends CfgAdapter[StoredNode] {
+  override def successors(node: StoredNode): IterableOnce[StoredNode] =
+    node._cfgIn.asScala
 
-  override def predecessors(node: Vertex): IterableOnce[Vertex] = {
-    node.vertices(Direction.OUT, EdgeTypes.CFG).asScala
-  }
+  override def predecessors(node: StoredNode): IterableOnce[StoredNode] =
+    node._cfgOut.asScala
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CpgPostDomTreeAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CpgPostDomTreeAdapter.scala
@@ -1,18 +1,12 @@
 package io.shiftleft.semanticcpg.passes.codepencegraph
 
-import gremlin.scala.Vertex
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.passes.cfgdominator.DomTreeAdapter
-import org.apache.tinkerpop.gremlin.structure.Direction
+import scala.jdk.CollectionConverters._
 
-class CpgPostDomTreeAdapter extends DomTreeAdapter[Vertex] {
+class CpgPostDomTreeAdapter extends DomTreeAdapter[StoredNode] {
 
-  override def immediateDominator(cfgNode: Vertex): Option[Vertex] = {
-    val iterator = cfgNode.vertices(Direction.IN, EdgeTypes.POST_DOMINATE)
-    if (iterator.hasNext) {
-      Some(iterator.next)
-    } else {
-      None
-    }
-  }
+  override def immediateDominator(cfgNode: StoredNode): Option[StoredNode] =
+    cfgNode._postDominateIn.asScala.nextOption
+
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
@@ -2,39 +2,40 @@ package io.shiftleft.semanticcpg.passes
 
 import gremlin.scala._
 import io.shiftleft.OverflowDbTestInstance
-import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominator, CfgDominatorFrontier, DomTreeAdapter, CfgAdapter}
-import org.apache.tinkerpop.gremlin.structure.Direction
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgAdapter, CfgDominator, CfgDominatorFrontier, DomTreeAdapter}
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.jdk.CollectionConverters._
 
 class CfgDominatorFrontierTests extends WordSpec with Matchers {
 
-  private class TestCfgAdapter extends CfgAdapter[Vertex] {
-    override def successors(node: Vertex): IterableOnce[Vertex] = {
-      node.vertices(Direction.OUT, "CFG").asScala
-    }
-    override def predecessors(node: Vertex): IterableOnce[Vertex] = {
-      node.vertices(Direction.IN, "CFG").asScala
-    }
+  private class TestCfgAdapter extends CfgAdapter[StoredNode] {
+    override def successors(node: StoredNode): IterableOnce[StoredNode] =
+      node._cfgOut.asScala
+
+    override def predecessors(node: StoredNode): IterableOnce[StoredNode] =
+      node._cfgIn.asScala
   }
 
-  private class TestDomTreeAdapter(immediateDominators: Map[Vertex, Vertex]) extends DomTreeAdapter[Vertex] {
-    override def immediateDominator(cfgNode: Vertex): Option[Vertex] = {
+  private class TestDomTreeAdapter(immediateDominators: Map[StoredNode, StoredNode])
+      extends DomTreeAdapter[StoredNode] {
+    override def immediateDominator(cfgNode: StoredNode): Option[StoredNode] = {
       immediateDominators.get(cfgNode)
     }
   }
 
   "Cfg dominance frontier test" in {
     implicit val graph: ScalaGraph = OverflowDbTestInstance.create
+    def addNode: StoredNode = (graph + "UNKNOWN").asInstanceOf[StoredNode]
 
-    val v0 = graph + "UNKNOWN"
-    val v1 = graph + "UNKNOWN"
-    val v2 = graph + "UNKNOWN"
-    val v3 = graph + "UNKNOWN"
-    val v4 = graph + "UNKNOWN"
-    val v5 = graph + "UNKNOWN"
-    val v6 = graph + "UNKNOWN"
+    val v0 = addNode
+    val v1 = addNode
+    val v2 = addNode
+    val v3 = addNode
+    val v4 = addNode
+    val v5 = addNode
+    val v6 = addNode
 
     v0 --- "CFG" --> v1
     v1 --- "CFG" --> v2
@@ -51,7 +52,7 @@ class CfgDominatorFrontierTests extends WordSpec with Matchers {
 
     val domTreeAdapter = new TestDomTreeAdapter(immediateDominators)
     val cfgDominatorFrontier = new CfgDominatorFrontier(cfgAdapter, domTreeAdapter)
-    val dominanceFrontier = cfgDominatorFrontier.calculate(graph.V.l())
+    val dominanceFrontier = cfgDominatorFrontier.calculate(graph.V.l.asInstanceOf[List[StoredNode]])
 
     dominanceFrontier.get(v0) shouldBe Set.empty
     dominanceFrontier.get(v1) shouldBe Set.empty
@@ -64,10 +65,11 @@ class CfgDominatorFrontierTests extends WordSpec with Matchers {
 
   "Cfg domiance frontier with dead code test" in {
     implicit val graph: ScalaGraph = OverflowDbTestInstance.create
+    def addNode: StoredNode = (graph + "UNKNOWN").asInstanceOf[StoredNode]
 
-    val v0 = graph + "UNKNOWN"
-    val v1 = graph + "UNKNOWN" // This node simulates dead code as it is not reachable from the entry v0.
-    val v2 = graph + "UNKNOWN"
+    val v0 = addNode
+    val v1 = addNode // This node simulates dead code as it is not reachable from the entry v0.
+    val v2 = addNode
 
     v0 --- "CFG" --> v2
     v1 --- "CFG" --> v2
@@ -78,7 +80,7 @@ class CfgDominatorFrontierTests extends WordSpec with Matchers {
 
     val domTreeAdapter = new TestDomTreeAdapter(immediateDominators)
     val cfgDominatorFrontier = new CfgDominatorFrontier(cfgAdapter, domTreeAdapter)
-    val dominanceFrontier = cfgDominatorFrontier.calculate(graph.V.l())
+    val dominanceFrontier = cfgDominatorFrontier.calculate(graph.V.l.asInstanceOf[List[StoredNode]])
 
     dominanceFrontier.get(v0) shouldBe Set.empty
     dominanceFrontier.get(v1) shouldBe Set(v2)


### PR DESCRIPTION
This defines in a base type of StoredNode for all cfgdominator classes.