### PR TITLE
Replace `assert` with `log.error` in `onlyChecked`.

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
@@ -1,6 +1,10 @@
 package io.shiftleft
 
+import org.apache.logging.log4j.LogManager
+
 object Implicits {
+
+  private val logger = LogManager.getLogger(classOf[Implicits])
 
   /**
     * A wrapper around a Java iterator that throws a proper NoSuchElementException.
@@ -22,7 +26,9 @@ object Implicits {
     def onlyChecked: T = {
       if (iterator.hasNext) {
         val res = iterator.next
-        assert(!iterator.hasNext, "iterator was expected to have exactly one element, but it actually has more")
+        if (iterator.hasNext) {
+          logger.error("iterator was expected to have exactly one element, but it actually has more")
+        }
         res
       } else { throw new NoSuchElementException() }
     }
@@ -37,3 +43,5 @@ object Implicits {
   }
 
 }
+
+class Implicits {}

--- a/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
@@ -43,5 +43,3 @@ object Implicits {
   }
 
 }
-
-class Implicits {}

--- a/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
@@ -4,7 +4,7 @@ import org.apache.logging.log4j.LogManager
 
 object Implicits {
 
-  private val logger = LogManager.getLogger(classOf[Implicits])
+  private val logger = LogManager.getLogger(getClass)
 
   /**
     * A wrapper around a Java iterator that throws a proper NoSuchElementException.


### PR DESCRIPTION
As discussed over the weekend and in yesterday's call, components that process the CPG shall be a bit more liberal about slight deviations from the spec, and when possible, return results even for slightly broken CPGs, ensuring that these results are in themselves consistent so as to not cause crashes further downstream.

This PR: replacing `assert` with `log.error` in `onlyChecked` for two reasons:
1. if assertions do survive compilation, then they lead to a hard stop, which is not desired
2. whether or not assertions show up depend on the compiler settings, and I'm worried we won't even see them during development.

Overall, I'd propose to stay away from assertions and use the logger instead. In particular, utility methods such as `onlyChecked` should not decide to terminate the program.