### PR TITLE
Skip edge creation if destination full name cannot be determined

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -253,9 +253,11 @@ object Linker {
           }
         }
       } else {
-        val dstFullName =
-          srcNode.vertices(Direction.OUT, edgeType).nextChecked.value2(NodeKeys.FULL_NAME)
-        srcNode.property(dstFullNameKey, dstFullName)
+        val maybeDstFullName = srcNode.vertices(Direction.OUT, edgeType).nextOption.map(_.value2(NodeKeys.FULL_NAME))
+        maybeDstFullName match {
+          case Some(dstFullName) => srcNode.property(dstFullNameKey, dstFullName)
+          case None              => logger.error(s"Missing outgoing edge of type ${edgeType} from node ${srcNode}")
+        }
         if (!loggedDeprecationWarning) {
           logger.warn(
             s"Using deprecated CPG format with already existing $edgeType edge between" +


### PR DESCRIPTION
As discussed over the weekend and in yesterday's call, components that process the CPG shall be a bit more liberal about slight deviations from the spec, and when possible, return results even for slightly broken CPGs, ensuring that these results are in themselves consistent so as to not cause crashes further downstream.

This PR: the linker can potentially hard-fail when the destination full name cannot be looked up due to a missing edge. This is then clearly an error in the CPG, however, it only means that a single link will be missing. Instead of crashing, I'm therefore logging an error in this situation and skipping creation of the affected edge.