### PR TITLE
Make LocationCreator more resilient.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -18,14 +18,14 @@ object LocationCreator {
     try {
       location(vertex)
     } catch {
-      case exc @ (_ : NoSuchElementException | _ : ClassCastException) => {
+      case exc @ (_: NoSuchElementException | _: ClassCastException) => {
         logger.error(s"Cannot determine location for ${vertex.label} due to broken CPG", exc)
         emptyLocation(vertex.label, Some(vertex.asInstanceOf[nodes.Node]))
       }
     }
   }
 
-  private def location(vertex : Vertex): NewLocation = {
+  private def location(vertex: Vertex): NewLocation = {
     vertex match {
       case paramIn: nodes.MethodParameterIn =>
         apply(


### PR DESCRIPTION
Currently, the LocationCreator, when called on a vertex that does not support locations, returns an empty location. With this PR, we adapt the same behavior when a location cannot be created due to a broken CPG, and log an additional error.