### PR TITLE
Downgrade warn to info for number of meta data blocks

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -96,7 +96,8 @@ abstract class CpgPass(cpg: Cpg, outputName: String = getClass.getSimpleName) {
       case (metaData: nodes.MetaData) :: Nil =>
         metaData.property(NodeKeys.OVERLAYS.toString, metaData.overlays ++ List(outputName))
       case _ =>
-        logger.warn("Invalid CPG: exactly 1 meta data block required")
+        // TODO: make this a warning once all frontends are caught up.
+        logger.info("Invalid CPG: exactly 1 meta data block required")
     }
   }
 


### PR DESCRIPTION
Some of our frontends only pass builds on Jenkins when no warnings are generated, and not all frontends currently have only one meta data block. I'm therefore downgrading a recently introduced warning about multiple meta data blocks to info for now.