### PR TITLE
Introduce list of policies to load in metadata block

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -6,7 +6,7 @@
 
     "nodeKeys" : [
 
-        { "id": 19, "name" : "LANGUAGE", "comment" : "The programming language this graph originates from (deprecated)", "valueType" : "string", "cardinality" : "one"},
+        { "id": 19, "name" : "LANGUAGE", "comment" : "The programming language this graph originates from", "valueType" : "string", "cardinality" : "one"},
         { "id" : 13, "name": "VERSION", "comment" : "A version, given as a string", "valueType" : "string", "cardinality" : "one"},
 	{ "id" : 118, "name" : "OVERLAYS", "comment" : "Names of overlays applied to this graph, in order of application", "valueType" : "string", "cardinality" : "list"},
 	{ "id" : 119, "name" : "POLICY_DIRECTORIES", "comment": "Sub directories of the policy directory that should be loaded when processing the CPG", "valueType" : "string", "cardinality" : "list"},

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -6,9 +6,10 @@
 
     "nodeKeys" : [
 
-        { "id": 19, "name" : "LANGUAGE", "comment" : "The programming language this graph originates from", "valueType" : "string", "cardinality" : "one"},
+        { "id": 19, "name" : "LANGUAGE", "comment" : "The programming language this graph originates from (deprecated)", "valueType" : "string", "cardinality" : "one"},
         { "id" : 13, "name": "VERSION", "comment" : "A version, given as a string", "valueType" : "string", "cardinality" : "one"},
 	{ "id" : 118, "name" : "OVERLAYS", "comment" : "Names of overlays applied to this graph, in order of application", "valueType" : "string", "cardinality" : "list"},
+	{ "id" : 119, "name" : "POLICY_DIRECTORIES", "comment": "Sub directories of the policy directory that should be loaded when processing the CPG", "valueType" : "string", "cardinality" : "list"},
 
         // Properties that indicate where the code can be found
 
@@ -63,7 +64,7 @@
         {
             "id" : 39,
             "name" : "META_DATA",
-            "keys" : ["LANGUAGE", "VERSION", "OVERLAYS"],
+            "keys" : ["LANGUAGE", "VERSION", "OVERLAYS", "POLICY_DIRECTORIES"],
             "comment" : "Node to save meta data about the graph on its properties. Exactly one node of this type per graph",
             "outEdges" : []
         },


### PR DESCRIPTION
As per our discussion, @AlexDenisov, for LLVM bitcode, we may want to load policies of multiple programming languages, e.g., C++ and Objective C. To support this, the metadata block now contains a list of policy directories to load.

A follow-up PR in Ocular will ensure that this list is honored if it is non-empty. Otherwise, Ocular will use the old LANGUAGE field.

PS: in case you're wondering why I didn't call this field `LANGUAGES`: that identifier is actually taken already for the LANGUAGES array in base.json.