### PR TITLE
Route all call site to method expansions via ICallResolver interface.

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
@@ -209,8 +209,8 @@ class ReachingDefPass(cpg: Cpg) extends CpgPass(cpg) {
 class DataFlowFrameworkHelper(graph: ScalaGraph) {
 
   private def callToMethodParamOut(call: nodes.StoredNode): Iterable[nodes.StoredNode] = {
-    ExpandTo
-      .callToCalledMethod(call.asInstanceOf[nodes.Call], NoResolve)
+    NoResolve
+      .getCalledMethods(call.asInstanceOf[nodes.Call])
       .flatMap(method => ExpandTo.methodToOutParameters(method))
   }
 

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/passes/reachingdef/ReachingDefPass.scala
@@ -208,12 +208,15 @@ class ReachingDefPass(cpg: Cpg) extends CpgPass(cpg) {
 /** Common functionalities needed for data flow frameworks */
 class DataFlowFrameworkHelper(graph: ScalaGraph) {
 
-  private def callToMethodParamOut(call: nodes.StoredNode): Seq[nodes.StoredNode] = {
-    ExpandTo.callToCalledMethod(call).flatMap(method => ExpandTo.methodToOutParameters(method))
+  private def callToMethodParamOut(call: nodes.StoredNode): Iterable[nodes.StoredNode] = {
+    ExpandTo
+      .callToCalledMethod(call.asInstanceOf[nodes.Call], NoResolve)
+      .flatMap(method => ExpandTo.methodToOutParameters(method))
   }
 
-  private def filterArgumentIndex(vertexList: List[nodes.StoredNode], orderSeq: Seq[Int]): List[nodes.StoredNode] = {
-    vertexList.filter(v => orderSeq.contains(v.asInstanceOf[nodes.HasArgumentIndex].argumentIndex.toInt))
+  private def filterArgumentIndex(vertexList: List[nodes.StoredNode],
+                                  orderSeq: Iterable[Int]): List[nodes.StoredNode] = {
+    vertexList.filter(v => orderSeq.exists(_ == v.asInstanceOf[nodes.HasArgumentIndex].argumentIndex.toInt))
   }
 
   def getExpressions(method: nodes.Method): List[nodes.Call] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
@@ -8,38 +8,84 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 trait ICallResolver {
-  def resolveDynamicCallSite(callsite: nodes.Call): Unit
-  def resolveDynamicMethodCallSites(method: nodes.Method): Unit
-  def getResolvedCalledMethods(callsite: nodes.CallRepr): Iterable[nodes.Method]
-  def getResolvedCallsites(method: nodes.Method): Iterable[nodes.CallRepr]
 
-  def getCalledMethods(callsite: nodes.CallRepr): GremlinScala[nodes.Method] = {
+  /**
+    * Get methods called at the given callsite.
+    * This internally calls triggerCallsiteResolution.
+    */
+  def getCalledMethods(callsite: nodes.CallRepr): Iterable[nodes.Method] = {
+    triggerCallsiteResolution(callsite)
     val combined = mutable.ArrayBuffer.empty[nodes.Method]
     callsite._callOut.asScala.foreach(method => combined.append(method.asInstanceOf[nodes.Method]))
     combined.appendAll(getResolvedCalledMethods(callsite))
 
-    gremlin.scala.__(combined.toSeq: _*)
+    combined
   }
 
-  def getCallsites(method: nodes.Method): GremlinScala[nodes.CallRepr] = {
+  /**
+    * Same as getCalledMethods but with traversal return type.
+    */
+  def getCalledMethodsAsTraversal(callsite: nodes.CallRepr): GremlinScala[nodes.Method] = {
+    val calledMethods = getCalledMethods(callsite)
+
+    gremlin.scala.__(calledMethods.toSeq: _*)
+  }
+
+  /**
+    * Get callsites of the given method.
+    * This internally calls triggerMethodResolution.
+    */
+  def getMethodCallsites(method: nodes.Method): Iterable[nodes.CallRepr] = {
+    triggerMethodCallsiteResolution(method)
     val combined = mutable.ArrayBuffer.empty[nodes.CallRepr]
     method._callIn.asScala.foreach(call => combined.append(call.asInstanceOf[nodes.CallRepr]))
-    combined.appendAll(getResolvedCallsites(method))
+    combined.appendAll(getResolvedMethodCallsites(method))
 
-    gremlin.scala.__(combined.toSeq: _*)
+    combined
   }
+
+  /**
+    * Same as getMethodCallsites but with traversal return type.
+    */
+  def getMethodCallsitesAsTraversal(method: nodes.Method): GremlinScala[nodes.CallRepr] = {
+    val methodCallsites = getMethodCallsites(method)
+
+    gremlin.scala.__(methodCallsites.toSeq: _*)
+  }
+
+  /**
+    * Starts data flow tracking to find all method which could be called at the given callsite.
+    * The result is stored in the resolver internal cache.
+    */
+  def triggerCallsiteResolution(callsite: nodes.CallRepr): Unit
+
+  /**
+    * Starts data flow tracking to find all callsites which could call the given method.
+    * The result is stored in the resolver internal cache.
+    */
+  def triggerMethodCallsiteResolution(method: nodes.Method): Unit
+
+  /**
+    * Retrieve results of triggerCallsiteResolution.
+    */
+  def getResolvedCalledMethods(callsite: nodes.CallRepr): Iterable[nodes.Method]
+
+  /**
+    * Retrieve results of triggerMethodResolution.
+    */
+  def getResolvedMethodCallsites(method: nodes.Method): Iterable[nodes.CallRepr]
 }
 
 object NoResolve extends ICallResolver {
-  def resolveDynamicCallSite(callsite: nodes.Call): Unit = {}
+  def triggerCallsiteResolution(callsite: nodes.CallRepr): Unit = {}
 
-  def resolveDynamicMethodCallSites(method: nodes.Method): Unit = {}
+  def triggerMethodCallsiteResolution(method: nodes.Method): Unit = {}
 
   override def getResolvedCalledMethods(callsite: nodes.CallRepr): Iterable[Method] = {
     Iterable.empty
   }
 
-  override def getResolvedCallsites(method: Method): Iterable[CallRepr] = {
+  override def getResolvedMethodCallsites(method: Method): Iterable[CallRepr] = {
     Iterable.empty
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
@@ -1,14 +1,45 @@
 package io.shiftleft.semanticcpg.language
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.{CallRepr, Method}
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 trait ICallResolver {
   def resolveDynamicCallSite(callsite: nodes.Call): Unit
   def resolveDynamicMethodCallSites(method: nodes.Method): Unit
+  def getResolvedCalledMethods(callsite: nodes.CallRepr): Iterable[nodes.Method]
+  def getResolvedCallsites(method: nodes.Method): Iterable[nodes.CallRepr]
+
+  def getCalledMethods(callsite: nodes.CallRepr): GremlinScala[nodes.Method] = {
+    val combined = mutable.ArrayBuffer.empty[nodes.Method]
+    callsite._callOut.asScala.foreach(method => combined.append(method.asInstanceOf[nodes.Method]))
+    combined.appendAll(getResolvedCalledMethods(callsite))
+
+    gremlin.scala.__(combined.toSeq: _*)
+  }
+
+  def getCallsites(method: nodes.Method): GremlinScala[nodes.CallRepr] = {
+    val combined = mutable.ArrayBuffer.empty[nodes.CallRepr]
+    method._callIn.asScala.foreach(call => combined.append(call.asInstanceOf[nodes.CallRepr]))
+    combined.appendAll(getResolvedCallsites(method))
+
+    gremlin.scala.__(combined.toSeq: _*)
+  }
 }
 
 object NoResolve extends ICallResolver {
   def resolveDynamicCallSite(callsite: nodes.Call): Unit = {}
 
   def resolveDynamicMethodCallSites(method: nodes.Method): Unit = {}
+
+  override def getResolvedCalledMethods(callsite: nodes.CallRepr): Iterable[Method] = {
+    Iterable.empty
+  }
+
+  override def getResolvedCallsites(method: Method): Iterable[CallRepr] = {
+    Iterable.empty
+  }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
@@ -10,8 +10,7 @@ class Call(val wrapped: NodeSteps[nodes.Call]) extends AnyVal {
   /** The callee method */
   def calledMethod(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] = {
     new NodeSteps(wrapped.raw.flatMap { call =>
-      callResolver.resolveDynamicCallSite(call)
-      callResolver.getCalledMethods(call)
+      callResolver.getCalledMethodsAsTraversal(call)
     })
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language.callgraphextension
 
 import gremlin.scala.GremlinScala
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 
 class Call(val wrapped: NodeSteps[nodes.Call]) extends AnyVal {
@@ -9,12 +9,10 @@ class Call(val wrapped: NodeSteps[nodes.Call]) extends AnyVal {
 
   /** The callee method */
   def calledMethod(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] = {
-    new NodeSteps(
-      wrapped
-        .sideEffect(callResolver.resolveDynamicCallSite)
-        .raw
-        .out(EdgeTypes.CALL)
-        .cast[nodes.Method])
+    new NodeSteps(wrapped.raw.flatMap { call =>
+      callResolver.resolveDynamicCallSite(call)
+      callResolver.getCalledMethods(call)
+    })
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -54,10 +54,10 @@ class Call(val wrapped: NodeSteps[nodes.Call]) extends AnyVal {
   /**
     To formal method return parameter
     */
-  def toMethodReturn: NodeSteps[nodes.MethodReturn] =
+  def toMethodReturn(implicit callResolver: ICallResolver): NodeSteps[nodes.MethodReturn] =
     new NodeSteps(
       raw
-        .out(EdgeTypes.CALL)
+        .flatMap(callResolver.getCalledMethods)
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.METHOD_RETURN)
         .cast[nodes.MethodReturn])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -57,7 +57,7 @@ class Call(val wrapped: NodeSteps[nodes.Call]) extends AnyVal {
   def toMethodReturn(implicit callResolver: ICallResolver): NodeSteps[nodes.MethodReturn] =
     new NodeSteps(
       raw
-        .flatMap(callResolver.getCalledMethods)
+        .flatMap(callResolver.getCalledMethodsAsTraversal)
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.METHOD_RETURN)
         .cast[nodes.MethodReturn])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -52,18 +52,18 @@ class Expression[NodeType <: nodes.Expression](val wrapped: NodeSteps[NodeType])
   Traverse to related parameter
     */
   @deprecated("", "October 2019")
-  def toParameter: NodeSteps[nodes.MethodParameterIn] = parameter
+  def toParameter(implicit callResolver: ICallResolver): NodeSteps[nodes.MethodParameterIn] = parameter
 
   /**
     Traverse to related parameter, if the expression is an argument to a call and the call
     can be resolved.
     */
-  def parameter: NodeSteps[nodes.MethodParameterIn] =
+  def parameter(implicit callResolver: ICallResolver): NodeSteps[nodes.MethodParameterIn] =
     new NodeSteps(
       raw
         .sack((sack: Integer, node: nodes.Expression) => node.value2(NodeKeys.ARGUMENT_INDEX))
         .in(EdgeTypes.ARGUMENT)
-        .out(EdgeTypes.CALL)
+        .flatMap(call => callResolver.getCalledMethods(call.asInstanceOf[nodes.CallRepr]))
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
         .filterWithTraverser { traverser =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -63,7 +63,7 @@ class Expression[NodeType <: nodes.Expression](val wrapped: NodeSteps[NodeType])
       raw
         .sack((sack: Integer, node: nodes.Expression) => node.value2(NodeKeys.ARGUMENT_INDEX))
         .in(EdgeTypes.ARGUMENT)
-        .flatMap(call => callResolver.getCalledMethods(call.asInstanceOf[nodes.CallRepr]))
+        .flatMap(call => callResolver.getCalledMethodsAsTraversal(call.asInstanceOf[nodes.CallRepr]))
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
         .filterWithTraverser { traverser =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -73,14 +73,6 @@ object ExpandTo {
         astChild.isInstanceOf[nodes.Modifier] &&
           astChild.asInstanceOf[nodes.Modifier].modifierType == modifierType)
 
-  def callToCalledMethod(call: nodes.Call, callResolver: ICallResolver): Iterable[nodes.Method] = {
-    val combined = mutable.ArrayBuffer.empty[nodes.Method]
-    call._callOut.asScala.foreach(method => combined.append(method.asInstanceOf[nodes.Method]))
-    combined.appendAll(callResolver.getResolvedCalledMethods(call))
-
-    combined
-  }
-
   def methodToTypeDecl(method: nodes.Method): Option[nodes.TypeDecl] =
     findVertex(method, _.isInstanceOf[nodes.TypeDecl]).map(_.asInstanceOf[nodes.TypeDecl])
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -4,9 +4,11 @@ import io.shiftleft.codepropertygraph.generated._
 import org.apache.tinkerpop.gremlin.structure.{Direction, Vertex}
 import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.passes.DiffGraph.getClass
+import io.shiftleft.semanticcpg.language.ICallResolver
 import org.apache.logging.log4j.LogManager
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 // TODO This object is problematic. While it offers a few utility methods
@@ -71,13 +73,13 @@ object ExpandTo {
         astChild.isInstanceOf[nodes.Modifier] &&
           astChild.asInstanceOf[nodes.Modifier].modifierType == modifierType)
 
-  def callToCalledMethod(call: Vertex): Seq[nodes.Method] =
-    call
-      .asInstanceOf[nodes.StoredNode]
-      ._callOut
-      .asScala
-      .map(_.asInstanceOf[nodes.Method])
-      .toSeq
+  def callToCalledMethod(call: nodes.Call, callResolver: ICallResolver): Iterable[nodes.Method] = {
+    val combined = mutable.ArrayBuffer.empty[nodes.Method]
+    call._callOut.asScala.foreach(method => combined.append(method.asInstanceOf[nodes.Method]))
+    combined.appendAll(callResolver.getResolvedCalledMethods(call))
+
+    combined
+  }
 
   def methodToTypeDecl(method: nodes.Method): Option[nodes.TypeDecl] =
     findVertex(method, _.isInstanceOf[nodes.TypeDecl]).map(_.asInstanceOf[nodes.TypeDecl])


### PR DESCRIPTION
This enables us to not write call resolution results directly into the
graph. Instead those results will be provided by the new ICallResolver
method getResolvedCalledMethods and getResolvedCallsites.

From now on all call site to method expansion HAVE TO go via ICallResolver.