### PR TITLE
Fix CPG validator expectaions.

### DIFF
--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/SuperTypes.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/SuperTypes.scala
@@ -7,6 +7,7 @@ object SuperTypes {
     NodeTypes.BLOCK,
     NodeTypes.CALL,
     NodeTypes.IDENTIFIER,
+    NodeTypes.FIELD_IDENTIFIER,
     NodeTypes.LITERAL,
     NodeTypes.METHOD_REF,
     NodeTypes.RETURN,

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/InFactsImporter.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/InFactsImporter.scala
@@ -52,7 +52,8 @@ class InFactsImporter extends FactsImporter {
       NodeTypes.METHOD_REF has 0 to 1 incoming EdgeTypes.ARGUMENT from NodeTypes.CALL or NodeTypes.RETURN,
       NodeTypes.BINDING has 1 incoming EdgeTypes.BINDS from NodeTypes.TYPE_DECL,
       NodeTypes.FIELD_IDENTIFIER has 1 incoming EdgeTypes.ARGUMENT from NodeTypes.CALL,
-      NodeTypes.FIELD_IDENTIFIER has 1 incoming EdgeTypes.AST from NodeTypes.CALL
+      NodeTypes.FIELD_IDENTIFIER has 1 incoming EdgeTypes.AST from NodeTypes.CALL,
+      NodeTypes.FIELD_IDENTIFIER has 1 incoming EdgeTypes.CFG from SuperTypes.Expression,
     )
 
 }

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/OutFactsImporter.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/OutFactsImporter.scala
@@ -18,7 +18,7 @@ class OutFactsImporter extends FactsImporter {
       NodeTypes.METHOD has 1 outgoing EdgeTypes.AST to NodeTypes.BLOCK,
       NodeTypes.METHOD has 0 to N outgoing EdgeTypes.AST to NodeTypes.TYPE_PARAMETER,
       NodeTypes.METHOD has 0 to N outgoing EdgeTypes.AST to NodeTypes.ANNOTATION,
-      NodeTypes.METHOD has 0 to N outgoing EdgeTypes.CFG to SuperTypes.Expression or NodeTypes.METHOD_RETURN,
+      NodeTypes.METHOD has 0 to 1 outgoing EdgeTypes.CFG to SuperTypes.Expression or NodeTypes.METHOD_RETURN,
       NodeTypes.METHOD_PARAMETER_IN has 0 to N outgoing EdgeTypes.AST to NodeTypes.ANNOTATION,
       NodeTypes.TYPE has 0 to N outgoing EdgeTypes.AST to NodeTypes.TYPE_ARGUMENT,
       NodeTypes.TYPE_DECL has 0 to N outgoing EdgeTypes.AST to NodeTypes.TYPE_PARAMETER,
@@ -34,8 +34,7 @@ class OutFactsImporter extends FactsImporter {
       NodeTypes.CALL has 1 to N outgoing EdgeTypes.CFG to SuperTypes.Expression or NodeTypes.METHOD_RETURN,
       NodeTypes.CALL has 0 to 1 outgoing EdgeTypes.RECEIVER to
         NodeTypes.CALL or NodeTypes.IDENTIFIER or NodeTypes.LITERAL or NodeTypes.METHOD_REF or NodeTypes.BLOCK,
-      NodeTypes.CALL has 0 to N outgoing EdgeTypes.ARGUMENT to
-        NodeTypes.CALL or NodeTypes.IDENTIFIER or NodeTypes.LITERAL or NodeTypes.METHOD_REF or NodeTypes.BLOCK,
+      NodeTypes.CALL has 0 to N outgoing EdgeTypes.ARGUMENT to SuperTypes.Expression,
       NodeTypes.IDENTIFIER has 1 to N outgoing EdgeTypes.CFG to SuperTypes.Expression or NodeTypes.METHOD_RETURN,
       NodeTypes.IDENTIFIER has 0 to 1 outgoing EdgeTypes.REF to NodeTypes.LOCAL or NodeTypes.METHOD_PARAMETER_IN,
       NodeTypes.RETURN has 0 to 1 outgoing EdgeTypes.AST to SuperTypes.Expression or NodeTypes.CONTROL_STRUCTURE,
@@ -49,6 +48,7 @@ class OutFactsImporter extends FactsImporter {
       NodeTypes.CLOSURE_BINDING has 1 outgoing EdgeTypes.REF to NodeTypes.LOCAL or NodeTypes.METHOD_PARAMETER_IN,
       NodeTypes.BINDING has 1 outgoing EdgeTypes.REF to NodeTypes.METHOD,
       NodeTypes.METHOD_RETURN has 0 to 1 outgoing EdgeTypes.CFG to NodeTypes.METHOD,
+      NodeTypes.FIELD_IDENTIFIER has 1 outgoing EdgeTypes.CFG to NodeTypes.CALL,
     )
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -138,15 +138,13 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     })
 
   /**
-    *  Traverse to first expressions in CFG.
-    *  Can be multiple.
+    *  Traverse to first expression in CFG.
     */
   def cfgFirst: NodeSteps[nodes.Expression] =
     new NodeSteps(raw.out(EdgeTypes.CFG).cast[nodes.Expression])
 
   /**
-    *  Traverse to last expressions in CFG.
-    *  Can be multiple.
+    *  Traverse to last expression in CFG.
     */
   def cfgLast: NodeSteps[nodes.Expression] =
     methodReturn.cfgLast


### PR DESCRIPTION
- From a METHOD node we only allow one CFG successor.
- Added FIELD_IDENTIFIER at places where it was missing.