### PR TITLE
Register `semanticcpg` in MetaData's `overlays` field

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -1,0 +1,28 @@
+package io.shiftleft.semanticcpg
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.MetaData
+import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
+import io.shiftleft.semanticcpg.language._
+
+object Overlays {
+
+  def appendOverlayName(cpg: Cpg, name: String): Unit = {
+    cpg.metaData.l.headOption match {
+      case Some(metaData) =>
+        metaData.property(Cardinality.list, MetaData.PropertyNames.Overlays, name)
+      case None =>
+        System.err.println("Missing metaData block")
+    }
+  }
+
+  def appliedOverlays(cpg: Cpg): List[String] = {
+    cpg.metaData.l.headOption match {
+      case Some(metaData) => metaData.overlays
+      case None =>
+        System.err.println("Missing metaData block")
+        List()
+    }
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreator.scala
@@ -4,6 +4,7 @@ import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPass
+import io.shiftleft.semanticcpg.Overlays
 import io.shiftleft.semanticcpg.passes.BindingMethodOverridesPass
 import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
 import io.shiftleft.semanticcpg.passes.codepencegraph.CdgPass
@@ -73,5 +74,10 @@ class EnhancedBaseCreator(cpg: Cpg, language: String, serializedCpg: SerializedC
 
   def create(): Unit = {
     enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
+    Overlays.appendOverlayName(cpg, EnhancedBaseCreator.overlayName)
   }
+}
+
+object EnhancedBaseCreator {
+  val overlayName = "semanticcpg"
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
@@ -1,0 +1,27 @@
+package io.shiftleft.semanticcpg
+
+import io.shiftleft.semanticcpg.testing.MockCpg
+import org.scalatest.{Matchers, WordSpec}
+import io.shiftleft.semanticcpg.language._
+
+class OverlaysTests extends WordSpec with Matchers {
+
+  "Overlays" should {
+
+    "allow adding a name to the `overlays` list" in {
+      val cpg = MockCpg().withMetaData().cpg
+      Overlays.appendOverlayName(cpg, "foo")
+      Overlays.appendOverlayName(cpg, "bar")
+      cpg.metaData.head.overlays shouldBe List("foo", "bar")
+    }
+
+    "allow querying `overlays`" in {
+      val cpg = MockCpg().withMetaData().cpg
+      Overlays.appendOverlayName(cpg, "foo")
+      Overlays.appendOverlayName(cpg, "bar")
+      Overlays.appliedOverlays(cpg) shouldBe List("foo", "bar")
+    }
+
+  }
+
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreatorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreatorTests.scala
@@ -1,0 +1,21 @@
+package io.shiftleft.semanticcpg.layers
+
+import io.shiftleft.SerializedCpg
+import io.shiftleft.semanticcpg.Overlays
+import io.shiftleft.semanticcpg.testing.MockCpg
+import org.scalatest.{Matchers, WordSpec}
+
+class EnhancedBaseCreatorTests extends WordSpec with Matchers {
+
+  "EnhancedBaseCreator" should {
+
+    "add name of overlay to metadata field" in {
+      val cpg = MockCpg().withMetaData().cpg
+      val creator = new EnhancedBaseCreator(cpg, "C", new SerializedCpg())
+      creator.create()
+      Overlays.appliedOverlays(cpg) shouldBe List(EnhancedBaseCreator.overlayName)
+    }
+
+  }
+
+}


### PR DESCRIPTION
We now make use of the new `metaData.overlays` field to register overlay names in the CPG - allowing to determine which overlays have already been added to the CPG. In particular, the overlay name `semanticcpg` is appended to `metaData.overlays` after applying the semantic CPG layer by executing the `EnhancedBaseCreator`.