### PR TITLE
support serializing (inverse) DiffGraphs

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "overflowdb-traversal" % "345fb76a700175e4636fa396ba6ec427fe42c6e1",
+  "io.shiftleft" %% "overflowdb-traversal" % "0.55",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "overflowdb-traversal" % "0.52",
+  "io.shiftleft" %% "overflowdb-traversal" % "345fb76a700175e4636fa396ba6ec427fe42c6e1",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
+++ b/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
@@ -123,14 +123,11 @@ message CpgStruct {
   repeated Edge edge = 2;
 }
 
-
-// only used inside CpgOverlay and should probably move in there, but this would be backwards incompatible :(
 message AdditionalNodeProperty {
   int64 node_id = 1;
   CpgStruct.Node.Property property = 2;
 }
 
-// only used inside CpgOverlay and should probably move in there, but this would be backwards incompatible :(
 message AdditionalEdgeProperty {
   int64 edge_id = 1;
   CpgStruct.Edge.Property property = 2;
@@ -139,7 +136,16 @@ message AdditionalEdgeProperty {
   CpgStruct.Edge.EdgeType edge_type = 5;
 }
 
+// Overlays can be stacked onto each other, therefor their node ids must be globally unique.
 message CpgOverlay {
+  repeated CpgStruct.Node node = 1;
+  repeated CpgStruct.Edge edge = 2;
+  repeated AdditionalNodeProperty node_property = 3;
+  repeated AdditionalEdgeProperty edge_property = 4;
+}
+
+// DiffGraphs can be created independently of each other and therefor each one has its own ID space
+message DiffGraph {
   message RemoveNode {
     int64 key = 1;
   }

--- a/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
+++ b/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
@@ -124,11 +124,13 @@ message CpgStruct {
 }
 
 
+// only used inside CpgOverlay and should probably move in there, but this would be backwards incompatible :(
 message AdditionalNodeProperty {
   int64 node_id = 1;
   CpgStruct.Node.Property property = 2;
 }
 
+// only used inside CpgOverlay and should probably move in there, but this would be backwards incompatible :(
 message AdditionalEdgeProperty {
   int64 edge_id = 1;
   CpgStruct.Edge.Property property = 2;
@@ -138,11 +140,6 @@ message AdditionalEdgeProperty {
 }
 
 message CpgOverlay {
-  repeated CpgStruct.Node node = 1;
-  repeated CpgStruct.Edge edge = 2;
-  repeated AdditionalNodeProperty node_property = 3;
-  repeated AdditionalEdgeProperty edge_property = 4;
-
   message RemoveNode {
     int64 key = 1;
   }
@@ -156,28 +153,23 @@ message CpgOverlay {
     int64 out_node_key = 1;
     int64 in_node_key = 2;
     CpgStruct.Edge.EdgeType edge_type = 3;
-    bytes propertiesHash = 4; // used to identify edges despite not having edge ids; only set if the edge does have properties
+    bytes propertiesHash = 4; // used to identify edges (since our edges don't have ids)
   }
 
   message RemoveEdgeProperty {
     int64 out_node_key = 1;
     int64 in_node_key = 2;
     CpgStruct.Edge.EdgeType edge_type = 3;
-    bytes propertiesHash = 4; // used to identify edges despite not having edge ids; only set if the edge does have properties
+    bytes propertiesHash = 4; // used to identify edges (since our edges don't have ids)
     EdgePropertyName property_name = 5;
   }
 
-  message InverseOverlay {
-      repeated CpgStruct.Node node = 1;
-      repeated CpgStruct.Edge edge = 2;
-      repeated AdditionalNodeProperty node_property = 3;
-      repeated AdditionalEdgeProperty edge_property = 4;
-      repeated RemoveNode remove_node = 5;
-      repeated RemoveNodeProperty remove_node_property = 6;
-      repeated RemoveEdge remove_edge = 7;
-      repeated RemoveEdgeProperty remove_edge_property = 8;
-  }
-
-
-  InverseOverlay inverse_overlay = 5;
+  repeated CpgStruct.Node node = 1;
+  repeated CpgStruct.Edge edge = 2;
+  repeated AdditionalNodeProperty node_property = 3;
+  repeated AdditionalEdgeProperty edge_property = 4;
+  repeated RemoveNode remove_node = 5;
+  repeated RemoveNodeProperty remove_node_property = 6;
+  repeated RemoveEdge remove_edge = 7;
+  repeated RemoveEdgeProperty remove_edge_property = 8;
 }

--- a/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
+++ b/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
@@ -132,6 +132,9 @@ message AdditionalNodeProperty {
 message AdditionalEdgeProperty {
   int64 edge_id = 1;
   CpgStruct.Edge.Property property = 2;
+  int64 out_node_key = 3;
+  int64 in_node_key = 4;
+  CpgStruct.Edge.EdgeType edge_type = 5;
 }
 
 message CpgOverlay {
@@ -139,4 +142,44 @@ message CpgOverlay {
   repeated CpgStruct.Edge edge = 2;
   repeated AdditionalNodeProperty node_property = 3;
   repeated AdditionalEdgeProperty edge_property = 4;
+
+  message RemoveNode {
+    int64 key = 1;
+  }
+
+  message RemoveNodeProperty {
+    int64 key = 1;
+    NodePropertyName name = 2;
+  }
+
+  message RemoveEdge {
+    int64 out_node_key = 1;
+    int64 in_node_key = 2;
+    CpgStruct.Edge.EdgeType edge_type = 3;
+    // TODO: There is a possibility of the more than one edge between two nodes
+    //       with the same label but different properties.
+  }
+
+  message RemoveEdgeProperty {
+    int64 out_node_key = 1;
+    int64 in_node_key = 2;
+    CpgStruct.Edge.EdgeType edge_type = 3;
+    EdgePropertyName property_name = 5;
+    // TODO: There is a possibility of the more than one edge between two nodes
+    //       with the same label but different properties.
+  }
+
+  message InverseOverlay {
+      repeated CpgStruct.Node node = 1;
+      repeated CpgStruct.Edge edge = 2;
+      repeated AdditionalNodeProperty node_property = 3;
+      repeated AdditionalEdgeProperty edge_property = 4;
+      repeated RemoveNode remove_node = 5;
+      repeated RemoveNodeProperty remove_node_property = 6;
+      repeated RemoveEdge remove_edge = 7;
+      repeated RemoveEdgeProperty remove_edge_property = 8;
+  }
+
+
+  InverseOverlay inverse_overlay = 5;
 }

--- a/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
+++ b/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
@@ -156,17 +156,15 @@ message CpgOverlay {
     int64 out_node_key = 1;
     int64 in_node_key = 2;
     CpgStruct.Edge.EdgeType edge_type = 3;
-    // note: we do not currently support removing an edge if another edge with the same label between those nodes exist
-    // context: our edges do not currently have ids
+    bytes propertiesHash = 4; // used to identify edges despite not having edge ids; only set if the edge does have properties
   }
 
   message RemoveEdgeProperty {
     int64 out_node_key = 1;
     int64 in_node_key = 2;
     CpgStruct.Edge.EdgeType edge_type = 3;
+    bytes propertiesHash = 4; // used to identify edges despite not having edge ids; only set if the edge does have properties
     EdgePropertyName property_name = 5;
-    // note: we do not currently support removing an edge property if another edge with the same label and property between those nodes exist
-    // context: our edges do not currently have ids
   }
 
   message InverseOverlay {

--- a/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
+++ b/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
@@ -156,8 +156,8 @@ message CpgOverlay {
     int64 out_node_key = 1;
     int64 in_node_key = 2;
     CpgStruct.Edge.EdgeType edge_type = 3;
-    // TODO: There is a possibility of the more than one edge between two nodes
-    //       with the same label but different properties.
+    // note: we do not currently support removing an edge if another edge with the same label between those nodes exist
+    // context: our edges do not currently have ids
   }
 
   message RemoveEdgeProperty {
@@ -165,8 +165,8 @@ message CpgOverlay {
     int64 in_node_key = 2;
     CpgStruct.Edge.EdgeType edge_type = 3;
     EdgePropertyName property_name = 5;
-    // TODO: There is a possibility of the more than one edge between two nodes
-    //       with the same label but different properties.
+    // note: we do not currently support removing an edge property if another edge with the same label and property between those nodes exist
+    // context: our edges do not currently have ids
   }
 
   message InverseOverlay {

--- a/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
+++ b/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
@@ -144,7 +144,9 @@ message CpgOverlay {
   repeated AdditionalEdgeProperty edge_property = 4;
 }
 
-// DiffGraphs can be created independently of each other and therefor each one has its own ID space
+// DiffGraphs can be created independently of each other and therefor when _adding_ nodes|edges,
+// each DiffGraph has its own ID space. However, when removing nodes|edges, the nodeIds refer to the
+// globally unique graph id space.
 message DiffGraph {
   message RemoveNode {
     int64 key = 1;

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -3,7 +3,7 @@ package io.shiftleft.passes
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.SerializedCpg
-import io.shiftleft.proto.cpg.Cpg._
+import io.shiftleft.proto.cpg.Cpg.CpgOverlay
 import java.util
 import java.lang.{Long => JLong}
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -81,7 +81,7 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") {
   def createApplyAndSerialize(): Iterator[CpgOverlay] =
     withStartEndTimesLogged {
       val overlays = run().map { diffGraph =>
-        val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, cpg)
+        val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, cpg, undoable = true)
         new DiffGraphProtoSerializer().serialize(appliedDiffGraph)
       }
       overlays

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -81,7 +81,7 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") {
   def createApplyAndSerialize(): Iterator[CpgOverlay] =
     withStartEndTimesLogged {
       val overlays = run().map { diffGraph =>
-        val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, cpg, undoable = true)
+        val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, cpg)
         new DiffGraphProtoSerializer().serialize(appliedDiffGraph)
       }
       overlays

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -148,8 +148,8 @@ object DiffGraph {
 
       // TODO check if that's the right way around...
       val edge = cpg.scalaGraph.V(outNodeId).outE(edgeLabel).toList.filter(_.inVertex.id == inNodeId) match {
-        case Nil => throw new AssertionError(s"unable to find edge that is supposed to be removed: $removeEdge")
-        case edge :: Nil => edge
+        case Nil           => throw new AssertionError(s"unable to find edge that is supposed to be removed: $removeEdge")
+        case edge :: Nil   => edge
         case multipleEdges => ??? //TODO
       }
 
@@ -303,7 +303,8 @@ object DiffGraph {
         case Change.RemoveEdge(edge)                      => edge.remove()
         case Change.RemoveEdgeProperty(edge, propertyKey) => edge.property(propertyKey).remove()
         case Change.RemoveNode(nodeId)                    => graph.vertices(nodeId).next().remove()
-        case Change.RemoveNodeProperty(nodeId, propertyKey) => graph.vertices(nodeId).next.property(propertyKey).remove()
+        case Change.RemoveNodeProperty(nodeId, propertyKey) =>
+          graph.vertices(nodeId).next.property(propertyKey).remove()
       }
 
     private def addEdgeProperty(edge: Edge, key: String, value: AnyRef, inverseBuilder: DiffGraph.InverseBuilder) = {

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -106,7 +106,7 @@ object DiffGraph {
       case object Existing extends NodeKind
     }
 
-    final case class RemoveNode(node: StoredNode) extends Change
+    final case class RemoveNode(nodeId: Long) extends Change
     final case class RemoveNodeProperty(node: StoredNode, propertyKey: String) extends Change
     final case class RemoveEdge(edge: Edge) extends Change
     final case class RemoveEdgeProperty(edge: Edge, propertyKey: String) extends Change
@@ -189,7 +189,8 @@ object DiffGraph {
       buffer += Change.SetNodeProperty(node, key, value)
     def addEdgeProperty(edge: Edge, key: String, value: AnyRef): Unit =
       buffer += Change.SetEdgeProperty(edge, key, value)
-    def removeNode(node: StoredNode): Unit = buffer += Change.RemoveNode(node)
+    def removeNode(node: StoredNode): Unit =
+      buffer += Change.RemoveNode(node.id.asInstanceOf[Long])
     def removeEdge(edge: Edge): Unit = buffer += Change.RemoveEdge(edge)
     def removeNodeProperty(node: StoredNode, propertyKey: String): Unit =
       buffer += Change.RemoveNodeProperty(node, propertyKey)
@@ -268,7 +269,7 @@ object DiffGraph {
           addEdgeProperty(edge, key, value, inverseBuilder)
         case Change.RemoveEdge(edge)                      => edge.remove()
         case Change.RemoveEdgeProperty(edge, propertyKey) => edge.property(propertyKey).remove()
-        case Change.RemoveNode(node)                      => node.remove()
+        case Change.RemoveNode(nodeId)                      => graph.vertices(nodeId).next().remove()
         case Change.RemoveNodeProperty(node, propertyKey) => node.property(propertyKey).remove()
       }
 
@@ -282,7 +283,8 @@ object DiffGraph {
                                 value: AnyRef,
                                 inverseBuilder: DiffGraph.InverseBuilder) = {
       inverseBuilder.onBeforeNodePropertyChange(node, key)
-      node.property(key, value)
+      println("addNodeProperty", key, value)
+      node.property(Cardinality.single, key, value)
     }
 
     private def addEdge(edgeChange: Change.CreateEdge, inverseBuilder: DiffGraph.InverseBuilder): Unit = {

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -269,7 +269,7 @@ object DiffGraph {
           addEdgeProperty(edge, key, value, inverseBuilder)
         case Change.RemoveEdge(edge)                      => edge.remove()
         case Change.RemoveEdgeProperty(edge, propertyKey) => edge.property(propertyKey).remove()
-        case Change.RemoveNode(nodeId)                      => graph.vertices(nodeId).next().remove()
+        case Change.RemoveNode(nodeId)                    => graph.vertices(nodeId).next().remove()
         case Change.RemoveNodeProperty(node, propertyKey) => node.property(propertyKey).remove()
       }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -317,7 +317,6 @@ object DiffGraph {
                                 value: AnyRef,
                                 inverseBuilder: DiffGraph.InverseBuilder) = {
       inverseBuilder.onBeforeNodePropertyChange(node, key)
-      println("addNodeProperty", key, value)
       node.property(Cardinality.single, key, value)
     }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.passes
 
+import java.security.MessageDigest
 import java.util
 
 import gnu.trove.set.hash.TCustomHashSet
@@ -146,21 +147,33 @@ object DiffGraph {
       val inNodeId = removeEdge.getInNodeKey
       val edgeLabel = removeEdge.getEdgeType.toString
 
-      // TODO check if that's the right way around...
       val edge = cpg.scalaGraph.V(outNodeId).outE(edgeLabel).toList.filter(_.inVertex.id == inNodeId) match {
-        case Nil           => throw new AssertionError(s"unable to find edge that is supposed to be removed: $removeEdge")
         case edge :: Nil   => edge
-        case multipleEdges => ??? //TODO
+        case Nil           => throw new AssertionError(s"unable to find edge that is supposed to be removed: $removeEdge")
+        case candidates => // found multiple edges - try to disambiguate via propertiesHash
+          val wantedPropertiesHash: List[Byte] = removeEdge.getPropertiesHash.toByteArray.toList
+          candidates.filter(edge => propertiesHash(edge).toList == wantedPropertiesHash) match {
+            case edge :: Nil   => edge
+            case Nil           => throw new AssertionError(s"unable to find edge that is supposed to be removed: $removeEdge. n.b. before filtering on propertiesHash, multiple candidates have been found: $candidates")
+            case candidates => throw new AssertionError(s"unable to disambiguate the edge to be removed, since multiple edges match the filter conditions of $removeEdge. Candidates=$candidates")
+          }
       }
 
       builder.removeEdge(edge)
     }
     inverseDiffGraphProto.getRemoveEdgePropertyList.forEach { removeEdgeProperty =>
-//      ???
-      //      builder.removeEdgeProperty()
+//      TODO impl
     }
 
     builder.build()
+  }
+
+  def propertiesHash(edge: Edge): Array[Byte] = {
+    import scala.jdk.CollectionConverters._
+    val propertiesAsString = edge.properties[Any]().asScala.collect {
+      case prop if prop.isPresent => prop.key -> prop.value
+    }.toList.sortBy(_._1).mkString
+    MessageDigest.getInstance("MD5").digest(propertiesAsString.getBytes)
   }
 
   def newBuilder: Builder = new Builder()

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -7,6 +7,7 @@ import gnu.trove.strategy.IdentityHashingStrategy
 import gremlin.scala.{Edge, ScalaGraph}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, Node, StoredNode}
+import io.shiftleft.proto.cpg.Cpg.{DiffGraph => DiffGraphProto}
 import org.apache.logging.log4j.LogManager
 import org.apache.tinkerpop.gremlin.structure.Vertex
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
@@ -132,6 +133,15 @@ object DiffGraph {
     }
   }
 
+  def fromProto(inverseDiffGraphProto: DiffGraphProto): DiffGraph = {
+    val builder = newBuilder
+    inverseDiffGraphProto.getRemoveNodeList.forEach { removeNodeProto =>
+      builder.removeNode(removeNodeProto.getKey)
+    }
+
+    builder.build()
+  }
+
   def newBuilder: Builder = new Builder()
 
   class Builder {
@@ -189,6 +199,8 @@ object DiffGraph {
       buffer += Change.SetNodeProperty(node, key, value)
     def addEdgeProperty(edge: Edge, key: String, value: AnyRef): Unit =
       buffer += Change.SetEdgeProperty(edge, key, value)
+    def removeNode(id: Long): Unit =
+      buffer += Change.RemoveNode(id)
     def removeNode(node: StoredNode): Unit =
       buffer += Change.RemoveNode(node.id.asInstanceOf[Long])
     def removeEdge(edge: Edge): Unit = buffer += Change.RemoveEdge(edge)

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -12,7 +12,7 @@ import io.shiftleft.proto.cpg.Cpg.{AdditionalEdgeProperty, AdditionalNodePropert
   * Provides functionality to serialize diff graphs and add them
   * to existing serialized CPGs as graph overlays.
   * */
-class DiffGraphProtoSerializer() {
+class DiffGraphProtoSerializer {
 
   /**
     * Generates a serialized graph overlay representing this graph
@@ -42,9 +42,9 @@ class DiffGraphProtoSerializer() {
     val builder = DiffGraphProto.newBuilder
     diffGraph.iterator.foreach {
       case RemoveNode(nodeId) => builder.addRemoveNode(removeNodeProto(nodeId))
-      case RemoveNodeProperty(_, _) => ???
+      case RemoveNodeProperty(node, propertyKey) => ???
       case RemoveEdge(edge) => builder.addRemoveEdge(removeEdgeProto(edge))
-      case RemoveEdgeProperty(_, _) => ???
+      case RemoveEdgeProperty(node, propertyKey) => ???
       case _ => ???
     }
     builder.build()

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -26,7 +26,7 @@ class DiffGraphProtoSerializer() {
             .setValue(protoValue(value))))
   }
 
-  def serializeInverseGraph(builder: CpgOverlay.Builder, inverseGraph: DiffGraph): () = {
+  def serializeInverseGraph(builder: CpgOverlay.Builder, inverseGraph: DiffGraph): Unit = {
     inverseGraph.iterator.foreach {
       case c: DiffGraph.Change.CreateEdge       => ???
       case DiffGraph.Change.CreateNode(newNode) => ???

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -5,7 +5,7 @@ import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node.NodeType
 import java.lang.{Long => JLong}
 
 import gremlin.scala.Edge
-import io.shiftleft.codepropertygraph.generated.nodes.NewNode
+import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
 import io.shiftleft.proto.cpg.Cpg.{AdditionalEdgeProperty, AdditionalNodeProperty, BoolList, CpgOverlay, CpgStruct, DoubleList, EdgePropertyName, FloatList, IntList, LongList, NodePropertyName, PropertyValue, StringList, DiffGraph => DiffGraphProto}
 
 /**
@@ -42,9 +42,9 @@ class DiffGraphProtoSerializer {
     val builder = DiffGraphProto.newBuilder
     diffGraph.iterator.foreach {
       case RemoveNode(nodeId) => builder.addRemoveNode(removeNodeProto(nodeId))
-      case RemoveNodeProperty(node, propertyKey) => ???
       case RemoveEdge(edge) => builder.addRemoveEdge(removeEdgeProto(edge))
-      case RemoveEdgeProperty(node, propertyKey) => ???
+      case RemoveNodeProperty(node, propertyKey) => builder.addRemoveNodeProperty(removeNodePropertyProto(node.getId, propertyKey))
+      case RemoveEdgeProperty(edge, propertyKey) => builder.addRemoveEdgeProperty(removeEdgePropertyProto(edge, propertyKey))
       case _ => ???
     }
     builder.build()
@@ -105,11 +105,21 @@ class DiffGraphProtoSerializer {
   private def removeNodeProto(nodeId: Long) =
     DiffGraphProto.RemoveNode.newBuilder.setKey(nodeId).build
 
-  private def removeEdgeProto(edge: Edge) = {
-    val builder = DiffGraphProto.RemoveEdge.newBuilder
+  private def removeEdgeProto(edge: Edge) =
+     DiffGraphProto.RemoveEdge.newBuilder
 //      .setEdgeType(???)
-    builder.build
-  }
+    .build
+
+  private def removeNodePropertyProto(nodeId: Long, propertyKey: String) =
+    DiffGraphProto.RemoveNodeProperty.newBuilder
+      .setKey(nodeId)
+      .setName(NodePropertyName.valueOf(propertyKey))
+      .build
+
+  private def removeEdgePropertyProto(edge: Edge, propertyKey: String) =
+    DiffGraphProto.RemoveEdgeProperty.newBuilder
+//      .set
+      .build
 
   private def nodeProperty(key: String, value: Any) = {
     CpgStruct.Node.Property

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -33,13 +33,22 @@ class DiffGraphProtoSerializer() {
     builder.build()
   }
 
-  /*
-  * TODO: WIP
-      case DiffGraph.Change.RemoveNode(nodeId)                    => builder.addRemoveNode(removeNodeProto(nodeId))
-      case DiffGraph.Change.RemoveNodeProperty(_, _) => ???
-      case DiffGraph.Change.RemoveEdge(edge)                      => builder.addRemoveEdge(removeEdgeProto(edge))
-      case DiffGraph.Change.RemoveEdgeProperty(_, _) => ???
+  /**
+    * Create a proto representation of a (potentially unapplied) DiffGraph (which may also be an
+    * The DiffGraph may not (yet) be applied, and it may be an InverseDiffGraph, e.g. as created by {{{DiffGraph.Applier.applyDiff(..., undoable = true) }}}
    */
+  def serialize(diffGraph: DiffGraph): DiffGraphProto = {
+    import DiffGraph.Change._
+    val builder = DiffGraphProto.newBuilder
+    diffGraph.iterator.foreach {
+      case RemoveNode(nodeId) => builder.addRemoveNode(removeNodeProto(nodeId))
+      case RemoveNodeProperty(_, _) => ???
+      case RemoveEdge(edge) => builder.addRemoveEdge(removeEdgeProto(edge))
+      case RemoveEdgeProperty(_, _) => ???
+      case _ => ???
+    }
+    builder.build()
+  }
 
   private def addNode(implicit builder: CpgOverlay.Builder, node: NewNode, appliedDiffGraph: AppliedDiffGraph): Unit = {
     val nodeId = appliedDiffGraph.nodeToGraphId(node)

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -43,7 +43,7 @@ class DiffGraphProtoSerializer {
     diffGraph.iterator.foreach {
       case RemoveNode(nodeId) => builder.addRemoveNode(removeNodeProto(nodeId))
       case RemoveEdge(edge) => builder.addRemoveEdge(removeEdgeProto(edge))
-      case RemoveNodeProperty(node, propertyKey) => builder.addRemoveNodeProperty(removeNodePropertyProto(node.getId, propertyKey))
+      case RemoveNodeProperty(nodeId, propertyKey) => builder.addRemoveNodeProperty(removeNodePropertyProto(nodeId, propertyKey))
       case RemoveEdgeProperty(edge, propertyKey) => builder.addRemoveEdgeProperty(removeEdgePropertyProto(edge, propertyKey))
       case _ => ???
     }
@@ -107,8 +107,10 @@ class DiffGraphProtoSerializer {
 
   private def removeEdgeProto(edge: Edge) =
      DiffGraphProto.RemoveEdge.newBuilder
-//      .setEdgeType(???)
-    .build
+       .setOutNodeKey(edge.outVertex.id.asInstanceOf[Long])
+       .setInNodeKey(edge.inVertex.id.asInstanceOf[Long])
+       .setEdgeType(EdgeType.valueOf(edge.label))
+       .build
 
   private def removeNodePropertyProto(nodeId: Long, propertyKey: String) =
     DiffGraphProto.RemoveNodeProperty.newBuilder
@@ -118,7 +120,10 @@ class DiffGraphProtoSerializer {
 
   private def removeEdgePropertyProto(edge: Edge, propertyKey: String) =
     DiffGraphProto.RemoveEdgeProperty.newBuilder
-//      .set
+      .setOutNodeKey(edge.outVertex.id.asInstanceOf[Long])
+      .setInNodeKey(edge.inVertex.id.asInstanceOf[Long])
+      .setEdgeType(EdgeType.valueOf(edge.label))
+      .setPropertyName(EdgePropertyName.valueOf(propertyKey))
       .build
 
   private def nodeProperty(key: String, value: Any) = {

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -6,7 +6,22 @@ import java.lang.{Long => JLong}
 
 import gremlin.scala.Edge
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
-import io.shiftleft.proto.cpg.Cpg.{AdditionalEdgeProperty, AdditionalNodeProperty, BoolList, CpgOverlay, CpgStruct, DoubleList, EdgePropertyName, FloatList, IntList, LongList, NodePropertyName, PropertyValue, StringList, DiffGraph => DiffGraphProto}
+import io.shiftleft.proto.cpg.Cpg.{
+  AdditionalEdgeProperty,
+  AdditionalNodeProperty,
+  BoolList,
+  CpgOverlay,
+  CpgStruct,
+  DoubleList,
+  EdgePropertyName,
+  FloatList,
+  IntList,
+  LongList,
+  NodePropertyName,
+  PropertyValue,
+  StringList,
+  DiffGraph => DiffGraphProto
+}
 
 /**
   * Provides functionality to serialize diff graphs and add them
@@ -28,7 +43,8 @@ class DiffGraphProtoSerializer {
       case SetEdgeProperty(edge, key, value) =>
         addEdgeProperty(builder, appliedDiffGraph, edge, key, value)
       case RemoveNode(_) | RemoveNodeProperty(_, _) | RemoveEdge(_) | RemoveEdgeProperty(_, _) =>
-        throw new UnsupportedOperationException("CpgOverlays can be stacked onto each other, therefor they cannot remove anything from the graph")
+        throw new UnsupportedOperationException(
+          "CpgOverlays can be stacked onto each other, therefor they cannot remove anything from the graph")
     }
     builder.build()
   }
@@ -36,15 +52,17 @@ class DiffGraphProtoSerializer {
   /**
     * Create a proto representation of a (potentially unapplied) DiffGraph (which may also be an
     * The DiffGraph may not (yet) be applied, and it may be an InverseDiffGraph, e.g. as created by {{{DiffGraph.Applier.applyDiff(..., undoable = true) }}}
-   */
+    */
   def serialize(diffGraph: DiffGraph): DiffGraphProto = {
     import DiffGraph.Change._
     val builder = DiffGraphProto.newBuilder
     diffGraph.iterator.foreach {
       case RemoveNode(nodeId) => builder.addRemoveNode(removeNodeProto(nodeId))
-      case RemoveEdge(edge) => builder.addRemoveEdge(removeEdgeProto(edge))
-      case RemoveNodeProperty(nodeId, propertyKey) => builder.addRemoveNodeProperty(removeNodePropertyProto(nodeId, propertyKey))
-      case RemoveEdgeProperty(edge, propertyKey) => builder.addRemoveEdgeProperty(removeEdgePropertyProto(edge, propertyKey))
+      case RemoveEdge(edge)   => builder.addRemoveEdge(removeEdgeProto(edge))
+      case RemoveNodeProperty(nodeId, propertyKey) =>
+        builder.addRemoveNodeProperty(removeNodePropertyProto(nodeId, propertyKey))
+      case RemoveEdgeProperty(edge, propertyKey) =>
+        builder.addRemoveEdgeProperty(removeEdgePropertyProto(edge, propertyKey))
       case _ => ???
     }
     builder.build()
@@ -106,11 +124,11 @@ class DiffGraphProtoSerializer {
     DiffGraphProto.RemoveNode.newBuilder.setKey(nodeId).build
 
   private def removeEdgeProto(edge: Edge) =
-     DiffGraphProto.RemoveEdge.newBuilder
-       .setOutNodeKey(edge.outVertex.id.asInstanceOf[Long])
-       .setInNodeKey(edge.inVertex.id.asInstanceOf[Long])
-       .setEdgeType(EdgeType.valueOf(edge.label))
-       .build
+    DiffGraphProto.RemoveEdge.newBuilder
+      .setOutNodeKey(edge.outVertex.id.asInstanceOf[Long])
+      .setInNodeKey(edge.inVertex.id.asInstanceOf[Long])
+      .setEdgeType(EdgeType.valueOf(edge.label))
+      .build
 
   private def removeNodePropertyProto(nodeId: Long, propertyKey: String) =
     DiffGraphProto.RemoveNodeProperty.newBuilder

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -4,24 +4,10 @@ import io.shiftleft.proto.cpg.Cpg.CpgStruct.Edge.EdgeType
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node.NodeType
 import java.lang.{Long => JLong}
 
+import com.google.protobuf.ByteString
 import gremlin.scala.Edge
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
-import io.shiftleft.proto.cpg.Cpg.{
-  AdditionalEdgeProperty,
-  AdditionalNodeProperty,
-  BoolList,
-  CpgOverlay,
-  CpgStruct,
-  DoubleList,
-  EdgePropertyName,
-  FloatList,
-  IntList,
-  LongList,
-  NodePropertyName,
-  PropertyValue,
-  StringList,
-  DiffGraph => DiffGraphProto
-}
+import io.shiftleft.proto.cpg.Cpg.{AdditionalEdgeProperty, AdditionalNodeProperty, BoolList, CpgOverlay, CpgStruct, DoubleList, EdgePropertyName, FloatList, IntList, LongList, NodePropertyName, PropertyValue, StringList, DiffGraph => DiffGraphProto}
 
 /**
   * Provides functionality to serialize diff graphs and add them
@@ -128,6 +114,7 @@ class DiffGraphProtoSerializer {
       .setOutNodeKey(edge.outVertex.id.asInstanceOf[Long])
       .setInNodeKey(edge.inVertex.id.asInstanceOf[Long])
       .setEdgeType(EdgeType.valueOf(edge.label))
+      .setPropertiesHash(ByteString.copyFrom(DiffGraph.propertiesHash(edge)))
       .build
 
   private def removeNodePropertyProto(nodeId: Long, propertyKey: String) =

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -7,7 +7,22 @@ import java.lang.{Long => JLong}
 import com.google.protobuf.ByteString
 import gremlin.scala.Edge
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
-import io.shiftleft.proto.cpg.Cpg.{AdditionalEdgeProperty, AdditionalNodeProperty, BoolList, CpgOverlay, CpgStruct, DoubleList, EdgePropertyName, FloatList, IntList, LongList, NodePropertyName, PropertyValue, StringList, DiffGraph => DiffGraphProto}
+import io.shiftleft.proto.cpg.Cpg.{
+  AdditionalEdgeProperty,
+  AdditionalNodeProperty,
+  BoolList,
+  CpgOverlay,
+  CpgStruct,
+  DoubleList,
+  EdgePropertyName,
+  FloatList,
+  IntList,
+  LongList,
+  NodePropertyName,
+  PropertyValue,
+  StringList,
+  DiffGraph => DiffGraphProto
+}
 
 /**
   * Provides functionality to serialize diff graphs and add them

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -33,7 +33,7 @@ class DiffGraphTest extends WordSpec with Matchers {
       // add edge from existing node "x" to new node "a" to the builder
       diffBuilder.addEdgeFromOriginal(x.asInstanceOf[StoredNode], a, EdgeTypes.AST)
       // modify property of existing node "y"
-      diffBuilder.addNodeProperty(y.asInstanceOf[StoredNode], NodeKeyNames.ORDER, new Integer(123))
+      diffBuilder.addNodeProperty(y.asInstanceOf[StoredNode], NodeKeyNames.ORDER, Int.box(123))
       diffBuilder.addNodeProperty(y.asInstanceOf[StoredNode], NodeKeyNames.CODE, "new y code")
 
       diffBuilder.addEdgeProperty(x2y, EdgeKeyNames.LOCAL_NAME, "new edge attr")

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -2,7 +2,6 @@ package io.shiftleft.codepropertygraph.cpgloading
 
 import gremlin.scala._
 import io.shiftleft.OverflowDbTestInstance
-import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
 import io.shiftleft.passes.DiffGraph

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
@@ -52,10 +52,10 @@ class CpgOverlayIntegrationTest extends WordSpec with Matchers {
       // 2) add two edges with the same label but different properties (they'll later be disambiguated by their property hash, since edges don't have IDs
       val addEdge1Inverse = applyDiffAndGetInverse(cpg)(_.addEdge(
         src = initialNode, dst = additionalNode, edgeLabel = edges.ContainsNode.Label, properties = Seq(EdgeKeyNames.INDEX -> Int.box(1))))
-//      val addEdge2Inverse = applyDiffAndGetInverse(cpg)(_.addEdge(
-//        src = initialNode, dst = additionalNode, edgeLabel = edges.ContainsNode.Label, properties = Seq(EdgeKeyNames.INDEX -> Int.box(2))))
+      val addEdge2Inverse = applyDiffAndGetInverse(cpg)(_.addEdge(
+        src = initialNode, dst = additionalNode, edgeLabel = edges.ContainsNode.Label, properties = Seq(EdgeKeyNames.INDEX -> Int.box(2))))
       def initialNodeOutEdges = initialNode.outE.toList
-      initialNodeOutEdges.size shouldBe 1
+      initialNodeOutEdges.size shouldBe 2
 
       // 3) add node property
       val addNodePropertyInverse = applyDiffAndGetInverse(cpg)(_.addNodeProperty(additionalNode, NodeKeyNames.CODE, "Node2Code"))
@@ -74,7 +74,10 @@ class CpgOverlayIntegrationTest extends WordSpec with Matchers {
       DiffGraph.Applier.applyDiff(addNodePropertyInverse, cpg)
       additionalNode.valueOption(NodeKeys.CODE) shouldBe None
 
-      // 2) remove edge
+      // 2) remove edges - they don't have ids and are therefor disambiguated by their property hash
+      DiffGraph.Applier.applyDiff(addEdge2Inverse, cpg)
+      initialNodeOutEdges.size shouldBe 1
+      initialNode.outE.value(EdgeKeyNames.INDEX).toList shouldBe List(Int.box(1))
       DiffGraph.Applier.applyDiff(addEdge1Inverse, cpg)
       initialNodeOutEdges.size shouldBe 0
 

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
@@ -47,23 +47,26 @@ class CpgOverlayIntegrationTest extends WordSpec with Matchers {
         }
       ))
       cpg.graph.V.count.head shouldBe 2
-      val node2 = cpg.graph.V.hasNot(NodeKeys.CODE).head.asInstanceOf[nodes.StoredNode]
+      val additionalNode = cpg.graph.V.hasNot(NodeKeys.CODE).head.asInstanceOf[nodes.StoredNode]
 
       // add edge
-      val addEdgeInverse = applyDiffAndGetInverse(cpg)(_.addEdge(src = initialNode, dst = node2, edgeLabel = edges.ContainsNode.Label))
+      val addEdgeInverse = applyDiffAndGetInverse(cpg)(_.addEdge(src = initialNode, dst = additionalNode, edgeLabel = edges.ContainsNode.Label))
       val initialNodeOutEdges = initialNode.outE.toList
       initialNodeOutEdges.size shouldBe 1
 
       // add edge property
-      val addEdgePropertyInverse = applyDiffAndGetInverse(cpg)(_.addEdgeProperty(initialNodeOutEdges.head, EdgeKeyNames.INDEX, Int.box(1)))
-      initialNode.start.outE.value(EdgeKeyNames.INDEX).toList shouldBe List(1)
+//      val addEdgePropertyInverse = applyDiffAndGetInverse(cpg)(_.addEdgeProperty(initialNodeOutEdges.head, EdgeKeyNames.INDEX, Int.box(1)))
+//      initialNode.start.outE.value(EdgeKeyNames.INDEX).toList shouldBe List(1)
 
       // add node property
-      val addNodePropertyInverse = applyDiffAndGetInverse(cpg)(_.addNodeProperty(node2, NodeKeyNames.CODE, "Node2Code"))
-      node2.value2(NodeKeys.CODE) shouldBe "Node2Code"
+//      val addNodePropertyInverse = applyDiffAndGetInverse(cpg)(_.addNodeProperty(additionalNode, NodeKeyNames.CODE, "Node2Code"))
+//      additionalNode.value2(NodeKeys.CODE) shouldBe "Node2Code"
 
-      // now apply all inverse diffgraphs in the reverse order
-      // TODO remove node property
+      // now apply all inverse diffgraphs in the reverse order...
+      // remove node property
+//      DiffGraph.Applier.applyDiff(addNodePropertyInverse, cpg)
+//      additionalNode.valueOption(NodeKeys.CODE) shouldBe None
+
       // TODO remove edge
 
       // remove node
@@ -90,7 +93,7 @@ class CpgOverlayIntegrationTest extends WordSpec with Matchers {
     val applied = DiffGraph.Applier.applyDiff(diff, cpg, undoable = true)
     val inverse = applied.inverseDiffGraph.get
     val inverseProto = new DiffGraphProtoSerializer().serialize(inverse)
-    DiffGraph.fromProto(inverseProto)
+    DiffGraph.fromProto(inverseProto, cpg)
   }
 
   def passAddsEdgeTo(from: nodes.StoredNode, propValue: String, cpg: Cpg): CpgPass = {

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
@@ -41,13 +41,14 @@ class CpgOverlayIntegrationTest extends WordSpec with Matchers {
       val overlays = pass1.createApplyAndSerialize().toList
       overlays.size shouldBe 1
       val overlay = overlays.head
-      val inverseOverlay = overlay.getInverseOverlay
+      true shouldBe false
+//      val inverseOverlay = overlay.getInverseOverlay
 
-      println(s"inverseOverlay: $inverseOverlay")
-      println(inverseOverlay.getRemoveEdgeList)
+//      println(s"inverseOverlay: $inverseOverlay")
+//      println(inverseOverlay.getRemoveEdgeList)
 
-      cpg.graph.V.count.head shouldBe 2
-      initialNode.start.out.value(NodeKeys.CODE).toList shouldBe List(Pass1NewNodeCode)
+//      cpg.graph.V.count.head shouldBe 2
+//      initialNode.start.out.value(NodeKeys.CODE).toList shouldBe List(Pass1NewNodeCode)
 
     }
   }

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
@@ -38,7 +38,7 @@ class CpgOverlayIntegrationTest extends WordSpec with Matchers {
       cpg.graph.V.count.head shouldBe 1
       val initialNode = cpg.graph.V.has(NodeKeys.CODE, InitialNodeCode).head.asInstanceOf[nodes.StoredNode]
 
-      // add a new node
+      // 1a) add a new node
       val addNodeInverse = applyDiffAndGetInverse(cpg)(_.addNode(
         new nodes.NewNode with DummyProduct {
           override def containedNodesByLocalName = ???
@@ -49,27 +49,31 @@ class CpgOverlayIntegrationTest extends WordSpec with Matchers {
       cpg.graph.V.count.head shouldBe 2
       val additionalNode = cpg.graph.V.hasNot(NodeKeys.CODE).head.asInstanceOf[nodes.StoredNode]
 
-      // add edge
+      // 2a) add edge
       val addEdgeInverse = applyDiffAndGetInverse(cpg)(_.addEdge(src = initialNode, dst = additionalNode, edgeLabel = edges.ContainsNode.Label))
       val initialNodeOutEdges = initialNode.outE.toList
       initialNodeOutEdges.size shouldBe 1
 
-      // add edge property
+      // 3a) add node property
+      val addNodePropertyInverse = applyDiffAndGetInverse(cpg)(_.addNodeProperty(additionalNode, NodeKeyNames.CODE, "Node2Code"))
+      additionalNode.value2(NodeKeys.CODE) shouldBe "Node2Code"
+
+      // TODO 4a) add edge property - not needed for now?
 //      val addEdgePropertyInverse = applyDiffAndGetInverse(cpg)(_.addEdgeProperty(initialNodeOutEdges.head, EdgeKeyNames.INDEX, Int.box(1)))
 //      initialNode.start.outE.value(EdgeKeyNames.INDEX).toList shouldBe List(1)
 
-      // add node property
-//      val addNodePropertyInverse = applyDiffAndGetInverse(cpg)(_.addNodeProperty(additionalNode, NodeKeyNames.CODE, "Node2Code"))
-//      additionalNode.value2(NodeKeys.CODE) shouldBe "Node2Code"
-
       // now apply all inverse diffgraphs in the reverse order...
-      // remove node property
-//      DiffGraph.Applier.applyDiff(addNodePropertyInverse, cpg)
-//      additionalNode.valueOption(NodeKeys.CODE) shouldBe None
+      // TODO 4b) remove edge property - not needed for now?
+//      DiffGraph.Applier.applyDiff(addEdgePropertyInverse, cpg)
+//      initialNode.start.outE.value(EdgeKeyNames.INDEX).toList shouldBe List.empty
 
-      // TODO remove edge
+      // 3b) remove node property
+      DiffGraph.Applier.applyDiff(addNodePropertyInverse, cpg)
+      additionalNode.valueOption(NodeKeys.CODE) shouldBe None
 
-      // remove node
+      // TODO 2b) remove edge
+
+      // 1b) remove node
       DiffGraph.Applier.applyDiff(addNodeInverse, cpg)
       cpg.graph.V.count.head shouldBe 1
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructure.scala
@@ -5,8 +5,8 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
 import io.shiftleft.semanticcpg.language._
 
 object ControlStructure {
-  val secondChildIndex = new Integer(2)
-  val thirdChildIndex = new Integer(3)
+  val secondChildIndex = Int.box(2)
+  val thirdChildIndex = Int.box(3)
 }
 
 class ControlStructure(val wrapped: NodeSteps[nodes.ControlStructure]) extends AnyVal {


### PR DESCRIPTION
note: using edge propertyHash to deduplicate edges

after createSp there are multiple CONTAINS_NODE edges between the same
nodes. they do have different properties, so we'll use the property values
to deduplicate them

``` importCode("/path/to/hsl.jar") createSp

cpg.scalaGraph.traversal.V.toList.foreach { v =>
 val outEdgeCountByLabelAndInV =
   v.outE.toList.groupBy(e => (e.label, e.inVertex))
 val moreThanOne = outEdgeCountByLabelAndInV.filter(_._2.size > 1)
 if (moreThanOne.size > 0) {
   println(moreThanOne.head._1._1)
 }
}

import java.security.MessageDigest def md5Sum(properties: Map[String,
Any]): Array[Byte] = {
 val propertiesAsString = properties.toList.sortBy(_._1).mkString
 MessageDigest.getInstance("MD5").digest(propertiesAsString.getBytes)
}

// check if there's duplicates including by hash val e =
cpg.scalaGraph.traversal.V.outE("CONTAINS_NODE").head

lazy val tuples = cpg.scalaGraph.traversal.V.toList.flatMap { v =>
 v.outE("CONTAINS_NODE").toList.map { e =>
   (v, md5Sum(e.valueMap), e.inVertex)
 }
} tuples.size tuples.distinct.size
// yay
```