### PR TITLE
Support serialization of inverse diffgraphs via passes API

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -5,6 +5,7 @@ import java.net.{URI, URISyntaxException}
 import java.nio.file.{FileSystem, FileSystems, Files}
 import java.util
 
+import com.google.protobuf.GeneratedMessageV3
 import io.shiftleft.proto.cpg.Cpg
 
 class SerializedCpg extends AutoCloseable {
@@ -41,7 +42,7 @@ class SerializedCpg extends AutoCloseable {
     * Add overlay graph named `name` to the zip file
     **/
   @throws[IOException]
-  def addOverlay(overlay: Cpg.CpgOverlay, name: String): Unit = {
+  def addOverlay(overlay: GeneratedMessageV3, name: String): Unit = {
     if (!isEmpty) {
       val pathInZip = zipFileSystem.getPath(s"${counter}_${name}")
       counter += 1

--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -54,10 +54,8 @@ class SerializedCpg extends AutoCloseable {
 
   @throws[IOException]
   def addOverlay(overlays: Iterator[GeneratedMessageV3], name: String): Unit = {
-    if (!isEmpty) {
-      overlays.zipWithIndex.foreach {
-        case (overlay, i) => addOverlay(overlay, name + "_" + i)
-      }
+    overlays.zipWithIndex.foreach {
+      case (overlay, i) => addOverlay(overlay, name + "_" + i)
     }
   }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -6,7 +6,6 @@ import java.nio.file.{FileSystem, FileSystems, Files}
 import java.util
 
 import com.google.protobuf.GeneratedMessageV3
-import io.shiftleft.proto.cpg.Cpg
 
 class SerializedCpg extends AutoCloseable {
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -54,8 +54,10 @@ class SerializedCpg extends AutoCloseable {
 
   @throws[IOException]
   def addOverlay(overlays: Iterator[GeneratedMessageV3], name: String): Unit = {
-    overlays.zipWithIndex.foreach {
-      case (overlay, i) => addOverlay(overlay, name + "_" + i)
+    if (!isEmpty) {
+      overlays.zipWithIndex.foreach {
+        case (overlay, i) => addOverlay(overlay, name + "_" + i)
+      }
     }
   }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -53,7 +53,7 @@ class SerializedCpg extends AutoCloseable {
   }
 
   @throws[IOException]
-  def addOverlay(overlays: Iterator[Cpg.CpgOverlay], name: String): Unit = {
+  def addOverlay(overlays: Iterator[GeneratedMessageV3], name: String): Unit = {
     overlays.zipWithIndex.foreach {
       case (overlay, i) => addOverlay(overlay, name + "_" + i)
     }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -60,8 +60,11 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") {
     *
     * @param serializedCpg the destination serialized CPG to add overlays to
     * @param inverse invert the diffgraph before serializing
+    * @param prefix a prefix to add to the output name
     * */
-  def createApplySerializeAndStore(serializedCpg: SerializedCpg, inverse: Boolean = false): Unit = {
+  def createApplySerializeAndStore(serializedCpg: SerializedCpg,
+                                   inverse: Boolean = false,
+                                   prefix: String = ""): Unit = {
     if (serializedCpg.isEmpty) {
       createAndApply()
     } else {
@@ -69,7 +72,7 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") {
       overlays.zipWithIndex.foreach {
         case (overlay, index) => {
           if (overlay.getSerializedSize > 0) {
-            serializedCpg.addOverlay(overlay, outputName + "_" + index)
+            serializedCpg.addOverlay(overlay, prefix + "_" + outputName + "_" + index)
           }
         }
       }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -3,7 +3,6 @@ package io.shiftleft.passes
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.SerializedCpg
-import io.shiftleft.proto.cpg.Cpg.CpgOverlay
 import java.util
 import java.lang.{Long => JLong}
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -60,6 +60,7 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") {
     * from the class name of the pass.
     *
     * @param serializedCpg the destination serialized CPG to add overlays to
+    * @param inverse invert the diffgraph before serializing
     * */
   def createApplySerializeAndStore(serializedCpg: SerializedCpg, inverse: Boolean = false): Unit = {
     if (serializedCpg.isEmpty) {
@@ -78,6 +79,7 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") {
 
   /**
     * Execute and create a serialized overlay
+    * @param inverse invert the diffgraph before serializing
     */
   def createApplyAndSerialize(inverse: Boolean = false): Iterator[GeneratedMessageV3] =
     withStartEndTimesLogged {


### PR DESCRIPTION
To bring in `undo` functionality even across restarts, we need to serialize inverse diff graphs. This PR introduces boolean `serializeInverse` flags to methods of the passes API to allow this. We also pass an additional `prefix` parameter to `createApplySerializeAndStore` to provide an alternative to `createApplyAndSerialize` followed by `addOverlay`. The latter results in the creation of the proto-serialized graph even when `serializedCpg` is actually empty, which is wasteful.