### PR TITLE
`CpgLoader.addDiffGraphs`

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "overflowdb-traversal" % "215b495ee579de8403ecfef2753d0e88ee7e797e",
+  "io.shiftleft" %% "overflowdb-traversal" % "0.56",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "overflowdb-traversal" % "0.55",
+  "io.shiftleft" %% "overflowdb-traversal" % "215b495ee579de8403ecfef2753d0e88ee7e797e",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -52,7 +52,7 @@ object CpgLoader {
   def addOverlays(overlayFilenames: Seq[String], cpg: Cpg): Unit =
     new CpgLoader().addOverlays(overlayFilenames, cpg)
 
-  def addDiffGraphs(diffGraphFilenames : Seq[String], cpg : Cpg) : Unit =
+  def addDiffGraphs(diffGraphFilenames: Seq[String], cpg: Cpg): Unit =
     new CpgLoader().addDiffGraphs(diffGraphFilenames, cpg)
 
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -51,6 +51,10 @@ object CpgLoader {
     * */
   def addOverlays(overlayFilenames: Seq[String], cpg: Cpg): Unit =
     new CpgLoader().addOverlays(overlayFilenames, cpg)
+
+  def addDiffGraphs(diffGraphFilenames : Seq[String], cpg : Cpg) : Unit =
+    new CpgLoader().addDiffGraphs(diffGraphFilenames, cpg)
+
 }
 
 private class CpgLoader {
@@ -84,6 +88,12 @@ private class CpgLoader {
   def addOverlays(overlayFilenames: Seq[String], cpg: Cpg): Unit = {
     overlayFilenames.foreach { overlayFilename =>
       CpgOverlayLoader.load(overlayFilename, cpg)
+    }
+  }
+
+  def addDiffGraphs(diffGraphFilenames: Seq[String], cpg: Cpg): Unit = {
+    diffGraphFilenames.foreach { filename =>
+      CpgOverlayLoader.loadInverse(filename, cpg)
     }
   }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.scala
@@ -48,17 +48,11 @@ object ProtoCpgLoader {
   def loadFromListOfProtos(cpgs: JList[CpgStruct], overflowDbConfig: OdbConfig): Cpg =
     loadFromListOfProtos(cpgs.asScala.toSeq, overflowDbConfig)
 
-  def loadOverlays(fileName: String): Try[Iterator[CpgOverlay]] = {
-    loadOverlays(fileName, { is =>
-      CpgOverlay.parseFrom(is)
-    })
-  }
+  def loadOverlays(fileName: String): Try[Iterator[CpgOverlay]] =
+    loadOverlays(fileName, CpgOverlay.parseFrom)
 
-  def loadDiffGraphs(fileName: String): Try[Iterator[DiffGraph]] = {
-    loadOverlays(fileName, { is =>
-      DiffGraph.parseFrom(is)
-    })
-  }
+  def loadDiffGraphs(fileName: String): Try[Iterator[DiffGraph]] =
+    loadOverlays(fileName, DiffGraph.parseFrom)
 
   private def loadOverlays[T <: GeneratedMessageV3](fileName: String, f: InputStream => T): Try[Iterator[T]] =
     Using(new ZipArchive(fileName)) { zip =>

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -136,8 +136,8 @@ object DiffGraph {
 
   def fromProto(inverseDiffGraphProto: DiffGraphProto, cpg: Cpg): DiffGraph = {
     val builder = newBuilder
-    inverseDiffGraphProto.getRemoveNodeList.forEach { removeNodeProto =>
-      builder.removeNode(removeNodeProto.getKey)
+    inverseDiffGraphProto.getRemoveEdgePropertyList.forEach { removeEdgeProperty =>
+      //      TODO impl
     }
     inverseDiffGraphProto.getRemoveNodePropertyList.forEach { removeNodePropertyProto =>
       builder.removeNodeProperty(removeNodePropertyProto.getKey, removeNodePropertyProto.getName.toString)
@@ -165,8 +165,8 @@ object DiffGraph {
 
       builder.removeEdge(edge)
     }
-    inverseDiffGraphProto.getRemoveEdgePropertyList.forEach { removeEdgeProperty =>
-//      TODO impl
+    inverseDiffGraphProto.getRemoveNodeList.forEach { removeNodeProto =>
+      builder.removeNode(removeNodeProto.getKey)
     }
 
     builder.build()

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -79,8 +79,9 @@ class DiffGraphTest extends WordSpec with Matchers {
     }
   }
 
-  "apply and revert DiffGraph with nodes _and_ edges" in {
-    withTestOdb { g =>
+  "apply and revert DiffGraph with nodes _and_ edges" when {
+
+    "testing simple scenario" in withTestOdb { g =>
       val diffBuilder = DiffGraph.newBuilder
       val newNodeA = makeNode("a")
       val newNodeB = makeNode("b")
@@ -91,6 +92,25 @@ class DiffGraphTest extends WordSpec with Matchers {
       val appliedDiff = DiffGraph.Applier.applyDiff(diff, g.graph, true)
       assert(g.V.count.head == 2)
       assert(g.E.count.head == 1)
+      DiffGraph.Applier.unapplyDiff(g.graph, appliedDiff.inverseDiffGraph.get)
+      assert(g.V.count.head == 0)
+    }
+
+    "testing more complex scenario" in withTestOdb { g =>
+      val diffBuilder = DiffGraph.newBuilder
+      val newNodeA = makeNode("a")
+      val newNodeB = makeNode("b")
+      diffBuilder.addNode(newNodeA)
+      diffBuilder.addNode(newNodeB)
+      diffBuilder.addEdge(newNodeA, newNodeB, EdgeTypes.AST)
+      val newNodeC = makeNode("c")
+      diffBuilder.addNode(newNodeC)
+      diffBuilder.addEdge(newNodeB, newNodeC, EdgeTypes.AST)
+      val diff = diffBuilder.build()
+      val appliedDiff = DiffGraph.Applier.applyDiff(diff, g.graph, true)
+      assert(g.V.count.head == 3)
+      assert(g.E.count.head == 2)
+      println(appliedDiff.inverseDiffGraph.get.iterator.toList)
       DiffGraph.Applier.unapplyDiff(g.graph, appliedDiff.inverseDiffGraph.get)
       assert(g.V.count.head == 0)
     }

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -27,8 +27,8 @@ class DiffGraphTest extends WordSpec with Matchers {
       val c = makeNode("c")
       diffBuilder.addNode(c)
       // add edge a -> b -> c to the DiffGraph.Builder
-      makeEdgeBetweenNewNodes(g, diffBuilder, a, b)
-      makeEdgeBetweenNewNodes(g, diffBuilder, b, c)
+      makeEdgeBetweenNewNodes(diffBuilder, a, b)
+      makeEdgeBetweenNewNodes(diffBuilder, b, c)
       // add edge from existing node "x" to new node "a" to the builder
       diffBuilder.addEdgeFromOriginal(x.asInstanceOf[StoredNode], a, EdgeTypes.AST)
       // modify property of existing node "y"
@@ -79,6 +79,23 @@ class DiffGraphTest extends WordSpec with Matchers {
     }
   }
 
+  "apply and revert DiffGraph with nodes _and_ edges" in {
+    withTestOdb { g =>
+      val diffBuilder = DiffGraph.newBuilder
+      val newNodeA = makeNode("a")
+      val newNodeB = makeNode("b")
+      diffBuilder.addNode(newNodeA)
+      diffBuilder.addNode(newNodeB)
+      diffBuilder.addEdge(newNodeA, newNodeB, EdgeTypes.AST)
+      val diff = diffBuilder.build()
+      val appliedDiff = DiffGraph.Applier.applyDiff(diff, g.graph, true)
+      assert(g.V.count.head == 2)
+      assert(g.E.count.head == 1)
+      DiffGraph.Applier.unapplyDiff(g.graph, appliedDiff.inverseDiffGraph.get)
+      assert(g.V.count.head == 0)
+    }
+  }
+
   def withTestOdb[T](f: ScalaGraph => T): T = {
     val graph: ScalaGraph = OverflowDbTestInstance.create
     try f(graph)
@@ -102,6 +119,6 @@ class DiffGraphTest extends WordSpec with Matchers {
     diff.addEdge(a.asInstanceOf[nodes.StoredNode], b.asInstanceOf[nodes.StoredNode], EdgeTypes.AST)
   }
 
-  def makeEdgeBetweenNewNodes(g: ScalaGraph, diff: DiffGraph.Builder, a: NewNode, b: NewNode) =
+  def makeEdgeBetweenNewNodes(diff: DiffGraph.Builder, a: NewNode, b: NewNode) =
     diff.addEdge(a, b, EdgeTypes.AST)
 }

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -20,11 +20,11 @@ class DiffGraphTest extends WordSpec with Matchers {
       // make diffgraph
       val diffBuilder = DiffGraph.newBuilder
       // add a b c nodes to the DiffGraph.Builder
-      val a = makeNode(g, "a")
+      val a = makeNode("a")
       diffBuilder.addNode(a)
-      val b = makeNode(g, "b")
+      val b = makeNode("b")
       diffBuilder.addNode(b)
-      val c = makeNode(g, "c")
+      val c = makeNode("c")
       diffBuilder.addNode(c)
       // add edge a -> b -> c to the DiffGraph.Builder
       makeEdgeBetweenNewNodes(g, diffBuilder, a, b)
@@ -59,9 +59,9 @@ class DiffGraphTest extends WordSpec with Matchers {
   "should be able to revert DiffGraph and reapply again" in {
     withTestOdb { g =>
       var diffBuilder = DiffGraph.newBuilder
-      diffBuilder.addNode(makeNode(g, "a"))
-      diffBuilder.addNode(makeNode(g, "b"))
-      diffBuilder.addNode(makeNode(g, "c"))
+      diffBuilder.addNode(makeNode("a"))
+      diffBuilder.addNode(makeNode("b"))
+      diffBuilder.addNode(makeNode("c"))
       val threeNodes = diffBuilder.build()
       val appliedDiff1 = DiffGraph.Applier.applyDiff(threeNodes, g.graph, true)
       assert(g.V.count.head == 3)
@@ -85,7 +85,7 @@ class DiffGraphTest extends WordSpec with Matchers {
     finally graph.close()
   }
 
-  def makeNode(g: ScalaGraph, code: String) = new nodes.NewNode {
+  def makeNode(code: String) = new nodes.NewNode {
     override def containedNodesByLocalName = ???
     override def label = NodeTypes.UNKNOWN
     override def properties = Map(NodeKeyNames.CODE -> code)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.semanticcpg
 
+import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.MetaData
 import org.apache.tinkerpop.gremlin.structure.VertexProperty.Cardinality
@@ -11,6 +12,29 @@ object Overlays {
     cpg.metaData.l.headOption match {
       case Some(metaData) =>
         metaData.property(Cardinality.list, MetaData.PropertyNames.Overlays, name)
+      case None =>
+        System.err.println("Missing metaData block")
+    }
+  }
+
+  def removeLastOverlayName(cpg: Cpg): Unit = {
+    cpg.metaData.l.headOption match {
+      case Some(metaData) => {
+        // This is currently sub-optimal: we do not have
+        // and operation to simply set a list as a property,
+        // all we have is `removeProperty` and an append-
+        //operation via `.property(Cardinality.list,...`).
+        // Moreover, `remove` only works if the list has
+        // only a single element, hence the call to
+        // `property("OVERLAYS", "")` right before the remove.
+        // It works, but it's not pretty.
+        val newValue = metaData.overlays.dropRight(1)
+        metaData.property(MetaData.PropertyNames.Overlays, "")
+        metaData.removeProperty(Key(MetaData.PropertyNames.Overlays))
+        newValue.foreach { e =>
+          metaData.property(Cardinality.list, MetaData.PropertyNames.Overlays, e)
+        }
+      }
       case None =>
         System.err.println("Missing metaData block")
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -41,7 +41,7 @@ object Overlays {
   }
 
   def appliedOverlays(cpg: Cpg): List[String] = {
-    cpg.metaData.l.headOption match {
+    cpg.metaData.headOption match {
       case Some(metaData) => Option(metaData.overlays).getOrElse(Nil)
       case None =>
         System.err.println("Missing metaData block")

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -18,7 +18,7 @@ object Overlays {
   }
 
   def removeLastOverlayName(cpg: Cpg): Unit = {
-    cpg.metaData.l.headOption match {
+    cpg.metaData.headOption match {
       case Some(metaData) => {
         // This is currently sub-optimal: we do not have
         // and operation to simply set a list as a property,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -42,7 +42,7 @@ object Overlays {
 
   def appliedOverlays(cpg: Cpg): List[String] = {
     cpg.metaData.l.headOption match {
-      case Some(metaData) => Some(metaData.overlays).filter(_ != null).getOrElse(List())
+      case Some(metaData) => Option(metaData.overlays).getOrElse(Nil)
       case None =>
         System.err.println("Missing metaData block")
         List()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -42,7 +42,7 @@ object Overlays {
 
   def appliedOverlays(cpg: Cpg): List[String] = {
     cpg.metaData.l.headOption match {
-      case Some(metaData) => metaData.overlays
+      case Some(metaData) => Some(metaData.overlays).filter(_ != null).getOrElse(List())
       case None =>
         System.err.println("Missing metaData block")
         List()

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
@@ -31,7 +31,7 @@ class OverlaysTests extends WordSpec with Matchers {
       Overlays.removeLastOverlayName(cpg)
       Overlays.appliedOverlays(cpg) shouldBe List("foo")
       Overlays.removeLastOverlayName(cpg)
-      Overlays.appliedOverlays(cpg) shouldBe null
+      Overlays.appliedOverlays(cpg) shouldBe List()
     }
 
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
@@ -22,6 +22,18 @@ class OverlaysTests extends WordSpec with Matchers {
       Overlays.appliedOverlays(cpg) shouldBe List("foo", "bar")
     }
 
+    "allow removing last overlay name" in {
+      val cpg = MockCpg().withMetaData().cpg
+      Overlays.appendOverlayName(cpg, "foo")
+      Overlays.appliedOverlays(cpg) shouldBe List("foo")
+      Overlays.appendOverlayName(cpg, "bar")
+      Overlays.appliedOverlays(cpg) shouldBe List("foo", "bar")
+      Overlays.removeLastOverlayName(cpg)
+      Overlays.appliedOverlays(cpg) shouldBe List("foo")
+      Overlays.removeLastOverlayName(cpg)
+      Overlays.appliedOverlays(cpg) shouldBe null
+    }
+
   }
 
 }


### PR DESCRIPTION
Bring in `CpgLoader.addDiffGraphs` to allow adding of inverse diffgraphs to a CPG, as well as a method to remove the last overlay name from `metaData.overlays`. This is a requirement for `undo`.