### PR TITLE
Add ARGUMENT_INDEX property to ANNOTATION_LITERAL and

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/java-specific.json
+++ b/codepropertygraph/src/main/resources/schemas/java-specific.json
@@ -35,14 +35,14 @@
         },
 
         {"id" : 49, "name" : "ANNOTATION_LITERAL",
-         "keys" : ["CODE", "NAME", "ORDER", "COLUMN_NUMBER", "LINE_NUMBER"],
+         "keys" : ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "COLUMN_NUMBER", "LINE_NUMBER"],
          "comment" : "A literal value assigned to an ANNOTATION_PARAMETER",
          "outEdges" : [ ],
           "is" : ["EXPRESSION"]
         },
 
         {"name" : "ARRAY_INITIALIZER",
-         "keys" : ["CODE", "COLUMN_NUMBER", "LINE_NUMBER", "ORDER"],
+         "keys" : ["CODE", "ORDER", "ARGUMENT_INDEX", "COLUMN_NUMBER", "LINE_NUMBER"],
          "outEdges" : [
              {"edgeName": "AST", "inNodes": ["LITERAL"]},
              {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/KeysValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/KeysValidatorTest.scala
@@ -100,6 +100,7 @@ class KeysValidatorTest extends WordSpec with Matchers {
       node.property("LINE_NUMBER", 1)
       node.property("NAME", "SomeAnnotation")
       node.property("ORDER", 1)
+      node.property("ARGUMENT_INDEX", 1)
       node.property("CODE", "some code;")
       validator.validate(cpg) shouldBe true
     }
@@ -112,6 +113,7 @@ class KeysValidatorTest extends WordSpec with Matchers {
       node.property("LINE_NUMBER", Option.empty)
       node.property("NAME", "SomeAnnotation")
       node.property("ORDER", 1)
+      node.property("ARGUMENT_INDEX", 1)
       node.property("CODE", "some code;")
       validator.validate(cpg) shouldBe true
     }
@@ -123,6 +125,7 @@ class KeysValidatorTest extends WordSpec with Matchers {
       val node = cpg.graph + NodeTypes.ANNOTATION_LITERAL
       node.property("NAME", "SomeAnnotation")
       node.property("ORDER", 1)
+      node.property("ARGUMENT_INDEX", 1)
       node.property("CODE", "some code;")
       validator.validate(cpg) shouldBe true
     }


### PR DESCRIPTION
ORDER and ARGUMENT_INDEX property to ARRAY_INITIALIZER.
The now added properties are required because ANNOTATION_LITERAL and
ARRAY_INITIALIZER are EXPRESSIONs.