### PR TITLE
reduce log-level for dynamic call linker fails 

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -50,8 +50,7 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
         val resolvedMethodOption = methodFullNameToNode.get(call.methodFullName)
         if (resolvedMethodOption.isDefined) {
           dstGraph.addEdgeInOriginal(call, resolvedMethodOption.get, EdgeTypes.CALL)
-        }
-        else {
+        } else {
           logger.info(
             s"Unable to link static CALL with METHOD_FULL_NAME ${call.methodFullName}, NAME ${call.name}, " +
               s"SIGNATURE ${call.signature}, CODE ${call.code}")
@@ -85,7 +84,7 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
                 logger.debug(
                   s"Unable to link dynamic CALL with METHOD_FULL_NAME ${call.methodFullName}, NAME ${call.name}, " +
                     s"SIGNATURE ${call.signature}, CODE ${call.code}")
-                */
+               */
               }
           }
         } else {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -77,9 +77,15 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
               if (resolvedMethodOption.isDefined) {
                 dstGraph.addEdgeInOriginal(call, resolvedMethodOption.get, EdgeTypes.CALL)
               } else {
+                /*
+                There is no binding that declares the VTable slot.
+                This is a valid possibility in message-passing style languages.
+
+                In JVM and .NET this should not happen -- place breakpoint or uncomment here when debugging frontends
                 logger.debug(
                   s"Unable to link dynamic CALL with METHOD_FULL_NAME ${call.methodFullName}, NAME ${call.name}, " +
                     s"SIGNATURE ${call.signature}, CODE ${call.code}")
+                */
               }
           }
         } else {


### PR DESCRIPTION
(these are expected for non-vtable based languages)