### PR TITLE
Remove Ocular/Joern greeting

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -85,7 +85,7 @@ trait BridgeBase {
         ammonite
           .Main(
             predefCode = predefPlus(additionalImportCode ++ replConfig ++ shutdownHooks),
-            welcomeBanner = Some("Welcome to ShiftLeft Ocular/Joern"),
+            welcomeBanner = None,
             storageBackend = new StorageBackend(slProduct),
             remoteLogging = false,
             colors = ammoniteColors


### PR DESCRIPTION
This rather redundant greeting (we print a huge ascii logo!) appears out of order, and in particular, after our help message. I'm just removing it.