### PR TITLE
DiffGraph proto format: ensure changes are in a list

### DIFF
--- a/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
+++ b/codepropertygraph/codegen/src/main/resources/templates/cpg.proto.tpl
@@ -172,12 +172,18 @@ message DiffGraph {
     EdgePropertyName property_name = 5;
   }
 
-  repeated CpgStruct.Node node = 1;
-  repeated CpgStruct.Edge edge = 2;
-  repeated AdditionalNodeProperty node_property = 3;
-  repeated AdditionalEdgeProperty edge_property = 4;
-  repeated RemoveNode remove_node = 5;
-  repeated RemoveNodeProperty remove_node_property = 6;
-  repeated RemoveEdge remove_edge = 7;
-  repeated RemoveEdgeProperty remove_edge_property = 8;
+  message Entry {
+    oneof value {
+      CpgStruct.Node node = 1;
+      CpgStruct.Edge edge = 2;
+      AdditionalNodeProperty node_property = 3;
+      AdditionalEdgeProperty edge_property = 4;
+      RemoveNode remove_node = 5;
+      RemoveNodeProperty remove_node_property = 6;
+      RemoveEdge remove_edge = 7;
+      RemoveEdgeProperty remove_edge_property = 8;
+    }
+  }
+
+  repeated Entry entries = 1;
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -59,19 +59,20 @@ class DiffGraphProtoSerializer {
   def serialize(diffGraph: DiffGraph): DiffGraphProto = {
     import DiffGraph.Change._
     val builder = DiffGraphProto.newBuilder
-    diffGraph.iterator.foreach {
+    def newEntry = DiffGraphProto.Entry.newBuilder
+    diffGraph.iterator.map {
       case SetNodeProperty(node, key, value) =>
-        builder.addNodeProperty(addNodeProperty(node.getId, key, value))
+        newEntry.setNodeProperty(addNodeProperty(node.getId, key, value))
       case SetEdgeProperty(edge, key, value) =>
-        builder.addEdgeProperty(addEdgeProperty(edge, key, value))
-      case RemoveNode(nodeId) => builder.addRemoveNode(removeNodeProto(nodeId))
-      case RemoveEdge(edge)   => builder.addRemoveEdge(removeEdgeProto(edge))
+        newEntry.setEdgeProperty(addEdgeProperty(edge, key, value))
+      case RemoveNode(nodeId) => newEntry.setRemoveNode(removeNodeProto(nodeId))
+      case RemoveEdge(edge)   => newEntry.setRemoveEdge(removeEdgeProto(edge))
       case RemoveNodeProperty(nodeId, propertyKey) =>
-        builder.addRemoveNodeProperty(removeNodePropertyProto(nodeId, propertyKey))
+        newEntry.setRemoveNodeProperty(removeNodePropertyProto(nodeId, propertyKey))
       case RemoveEdgeProperty(edge, propertyKey) =>
-        builder.addRemoveEdgeProperty(removeEdgePropertyProto(edge, propertyKey))
+        newEntry.setRemoveEdgeProperty(removeEdgePropertyProto(edge, propertyKey))
       case other => throw new NotImplementedError(s"not (yet?) supported for DiffGraph: ${other.getClass}")
-    }
+    }.foreach(builder.addEntries)
     builder.build()
   }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -60,19 +60,21 @@ class DiffGraphProtoSerializer {
     import DiffGraph.Change._
     val builder = DiffGraphProto.newBuilder
     def newEntry = DiffGraphProto.Entry.newBuilder
-    diffGraph.iterator.map {
-      case SetNodeProperty(node, key, value) =>
-        newEntry.setNodeProperty(addNodeProperty(node.getId, key, value))
-      case SetEdgeProperty(edge, key, value) =>
-        newEntry.setEdgeProperty(addEdgeProperty(edge, key, value))
-      case RemoveNode(nodeId) => newEntry.setRemoveNode(removeNodeProto(nodeId))
-      case RemoveEdge(edge)   => newEntry.setRemoveEdge(removeEdgeProto(edge))
-      case RemoveNodeProperty(nodeId, propertyKey) =>
-        newEntry.setRemoveNodeProperty(removeNodePropertyProto(nodeId, propertyKey))
-      case RemoveEdgeProperty(edge, propertyKey) =>
-        newEntry.setRemoveEdgeProperty(removeEdgePropertyProto(edge, propertyKey))
-      case other => throw new NotImplementedError(s"not (yet?) supported for DiffGraph: ${other.getClass}")
-    }.foreach(builder.addEntries)
+    diffGraph.iterator
+      .map {
+        case SetNodeProperty(node, key, value) =>
+          newEntry.setNodeProperty(addNodeProperty(node.getId, key, value))
+        case SetEdgeProperty(edge, key, value) =>
+          newEntry.setEdgeProperty(addEdgeProperty(edge, key, value))
+        case RemoveNode(nodeId) => newEntry.setRemoveNode(removeNodeProto(nodeId))
+        case RemoveEdge(edge)   => newEntry.setRemoveEdge(removeEdgeProto(edge))
+        case RemoveNodeProperty(nodeId, propertyKey) =>
+          newEntry.setRemoveNodeProperty(removeNodePropertyProto(nodeId, propertyKey))
+        case RemoveEdgeProperty(edge, propertyKey) =>
+          newEntry.setRemoveEdgeProperty(removeEdgePropertyProto(edge, propertyKey))
+        case other => throw new NotImplementedError(s"not (yet?) supported for DiffGraph: ${other.getClass}")
+      }
+      .foreach(builder.addEntries)
     builder.build()
   }
 


### PR DESCRIPTION
prior to this, we had to manually ensure that orders are processed in
the correct order. now, the order is guaranteed.

n.b. tested with ocular: importCode, run.securityprofile, undo, run.securityprofile