### PR TITLE
Handle cases where `identifier` is not argument gracefully.

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/TrackingPoint.scala
@@ -76,7 +76,7 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
   private def getTrackingPoint(node: nodes.StoredNode): Option[nodes.TrackingPoint] =
     node match {
       case identifier: nodes.Identifier =>
-        getTrackingPoint(identifier._argumentIn().onlyChecked)
+        identifier._argumentIn().nextOption.flatMap(getTrackingPoint)
       case call: nodes.Call                       => Some(call)
       case ret: nodes.Return                      => Some(ret)
       case methodReturn: nodes.MethodReturn       => Some(methodReturn)


### PR DESCRIPTION
There are some rare cases where `identifier` nodes are not arguments to operations, and therefore, there is no incoming argument edge and thus no tracking point. Handle this situation gracefully instead of crashing.