### PR TITLE
Fix bug in help overview

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Help.scala
+++ b/console/src/main/scala/io/shiftleft/console/Help.scala
@@ -65,6 +65,7 @@ object Help {
       }
       .mkString("\n")
 
+    val overview = Help.overview[C](tag)
     s"""
        | class Helper() {
        |
@@ -72,7 +73,7 @@ object Help {
        |
        | def run : String = Help.runLongHelp
        |
-       |  override def toString : String = Help.overview
+       |  override def toString : String = \"\"\"${overview}\"\"\"
        | }
        |
        | val help = new Helper


### PR DESCRIPTION
Forgot to pass type parameter to `Helper.overview` in generated code, yielding an almost empty table. This PR fixes that.