### PR TITLE
use latest odb-codgen

### DIFF
--- a/project/meta-build.sbt
+++ b/project/meta-build.sbt
@@ -1,6 +1,6 @@
 libraryDependencies ++= Seq(
   "com.github.pathikrit" %% "better-files" % "3.8.0",
-  "io.shiftleft" %% "overflowdb-codegen" % "1.4",
+  "io.shiftleft" %% "overflowdb-codegen" % "1.5",
 )
 
 resolvers += Resolver.bintrayRepo("shiftleft", "maven")


### PR DESCRIPTION
depends on https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/4

before merging, double check locally if this fixes the problem in https://github.com/ShiftLeftSecurity/ocular/tree/fabs/undobug
n.b. can't do that currently because ocular-latest is red