### PR TITLE
consolidate and refactor Table.scala

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -60,8 +60,6 @@ libraryDependencies ++= Seq(
   "io.circe"             %% "circe-parser"  % CirceVersion,
   "org.zeroturnaround"   %  "zt-zip"        % ZeroturnaroundVersion,
   "com.lihaoyi"          %% "ammonite"      % AmmoniteVersion cross CrossVersion.full,
-  "com.massisframework"  %  "j-text-utils"  % "0.3.4",
   "org.reflections" % "reflections"           % "0.9.12",
-
   "org.scalatest"        %% "scalatest"     % ScalatestVersion % Test,
 )

--- a/console/src/main/scala/io/shiftleft/console/Help.scala
+++ b/console/src/main/scala/io/shiftleft/console/Help.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.console
 
+import io.shiftleft.semanticcpg.utils.Table
 import org.apache.commons.lang.WordUtils
 
 import scala.reflect.runtime.universe._
@@ -14,7 +15,7 @@ object Help {
     val rows = funcNameDocPairs[C].map {
       case (name, doc) => s"$name\t${doc.short}\t${doc.example}"
     } ++ List(runRow)
-    Table.create(columnNames, rows.sorted)
+    Table(columnNames, rows.sorted).render
   }
 
   def funcNameDocPairs[C](implicit tag: TypeTag[C]): List[(String, Doc)] = {

--- a/console/src/main/scala/io/shiftleft/console/Help.scala
+++ b/console/src/main/scala/io/shiftleft/console/Help.scala
@@ -15,7 +15,7 @@ object Help {
     val rows = funcNameDocPairs[C].map {
       case (name, doc) => s"$name\t${doc.short}\t${doc.example}"
     } ++ List(runRow)
-    Table(columnNames, rows.sorted).render
+    "\n" + Table(columnNames, rows.sorted).render
   }
 
   def funcNameDocPairs[C](implicit tag: TypeTag[C]): List[(String, Doc)] = {

--- a/console/src/main/scala/io/shiftleft/console/Help.scala
+++ b/console/src/main/scala/io/shiftleft/console/Help.scala
@@ -13,9 +13,9 @@ object Help {
   def overview[C](implicit tag: TypeTag[C]): String = {
     val columnNames = List("command", "description", "example")
     val rows = funcNameDocPairs[C].map {
-      case (name, doc) => s"$name\t${doc.short}\t${doc.example}"
+      case (name, doc) => List(name, doc.short, doc.example)
     } ++ List(runRow)
-    "\n" + Table(columnNames, rows.sorted).render
+    "\n" + Table(columnNames, rows.sortBy(_.head)).render
   }
 
   def funcNameDocPairs[C](implicit tag: TypeTag[C]): List[(String, Doc)] = {
@@ -43,9 +43,8 @@ object Help {
         .trim + "\"\"\""
   }
 
-  private def runRow: String = {
-    "run\tRun analyzer on active CPG\trun.securityprofile"
-  }
+  private def runRow: List[String] =
+    List("run", "Run analyzer on active CPG", "run.securityprofile")
 
   // Since `run` is generated dynamically, it's not picked up when looking
   // through methods via reflection, and therefore, we are adding

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
@@ -27,12 +27,14 @@ case class Project(projectFile: ProjectFile, var path: Path, var cpg: Option[Cpg
     appliedOverlays.map(o => overlayDir / o)
   }
 
-  override def toString: String = {
+  override def toString: String =
+    toTableRow.mkString("\t")
+
+  def toTableRow: List[String] = {
     val cpgLoaded = cpg.isDefined
-    val overlays = appliedOverlays
-      .mkString(",")
+    val overlays = appliedOverlays.mkString(",")
     val inputPath = projectFile.inputPath
-    s"$name\t$overlays\t$inputPath\t$cpgLoaded"
+    List(name, overlays, inputPath, cpgLoaded.toString)
   }
 
   /**

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Workspace.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Workspace.scala
@@ -25,7 +25,7 @@ class Workspace[ProjectType <: Project](var projects: ListBuffer[ProjectType]) {
     } else {
       "\n" + Table(
         columnNames = List("name", "overlays", "inputPath", "open"),
-        rows = projects.map(_.toString).toList
+        rows = projects.map(_.toTableRow).toList
       ).render
     }
 

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Workspace.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Workspace.scala
@@ -23,7 +23,7 @@ class Workspace[ProjectType <: Project](var projects: ListBuffer[ProjectType]) {
     if (projects.isEmpty) {
       "empty"
     } else {
-      Table(
+      "\n" + Table(
         columnNames = List("name", "overlays", "inputPath", "open"),
         rows = projects.map(_.toString).toList
       ).render

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Workspace.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Workspace.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.console.workspacehandling
 
-import io.shiftleft.console.Table
+import io.shiftleft.semanticcpg.utils.Table
 
 import scala.collection.mutable.ListBuffer
 
@@ -23,9 +23,10 @@ class Workspace[ProjectType <: Project](var projects: ListBuffer[ProjectType]) {
     if (projects.isEmpty) {
       "empty"
     } else {
-      val rows = projects.map(_.toString).toList
-      val columnNames = List("name", "overlays", "inputPath", "open")
-      Table.create(columnNames, rows)
+      Table(
+        columnNames = List("name", "overlays", "inputPath", "open"),
+        rows = projects.map(_.toString).toList
+      ).render
     }
 
   }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Path.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Path.scala
@@ -9,8 +9,8 @@ case class Path(elements: List[nodes.TrackingPoint])
 
 object Path {
 
-  implicit val show: Show[Path] =
-    (path: Path) => Table(
+  implicit val show: Show[Path] = { path: Path =>
+    Table(
       columnNames = Array("tracked", "lineNumber", "method", "file"),
       rows = path.elements.map { trackingPoint =>
         val method = trackingPoint.method
@@ -28,5 +28,6 @@ object Path {
         Array(trackedSymbol, lineNumber, methodName, fileName)
       }
     ).render
+  }
 
 }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Path.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Path.scala
@@ -1,29 +1,21 @@
 package io.shiftleft.dataflowengine.language
 
-import dnl.utils.text.table.TextTable
-import io.shiftleft.semanticcpg.language.Show
-import java.io.{ByteArrayOutputStream, PrintStream}
-import java.nio.charset.StandardCharsets
-
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.{Show, _}
 import io.shiftleft.semanticcpg.language.nodemethods.CfgNodeMethods
-
-import scala.util.Using
+import io.shiftleft.semanticcpg.utils.Table
 
 case class Path(elements: List[nodes.TrackingPoint])
 
 object Path {
 
-  implicit val show: Show[Path] = (path: Path) =>
-    Using.Manager { use =>
-      val baos = use(new ByteArrayOutputStream)
-      val ps = use(new PrintStream(baos, true, "utf-8"))
-
-      val rows = path.elements.map { trackingPoint =>
+  implicit val show: Show[Path] =
+    (path: Path) => Table(
+      columnNames = Array("tracked", "lineNumber", "method", "file"),
+      rows = path.elements.map { trackingPoint =>
         val method = trackingPoint.method
         val methodName = method.name
-        val lineNumber = trackingPoint.cfgNode.lineNumber.getOrElse("N/A")
+        val lineNumber = trackingPoint.cfgNode.lineNumber.getOrElse("N/A").toString
         val fileName = method.start.file.name.headOption.getOrElse("N/A")
 
         val trackedSymbol = trackingPoint match {
@@ -33,13 +25,8 @@ object Path {
           case _ => CfgNodeMethods.repr(trackingPoint.cfgNode)
         }
 
-        s"$trackedSymbol\t$lineNumber\t$methodName\t$fileName"
+        Array(trackedSymbol, lineNumber, methodName, fileName)
       }
-
-      val columnNames = Array("tracked", "lineNumber", "method", "file")
-      val data = rows.map(_.split("\t").toArray[Object]).toArray
-      new TextTable(columnNames, data).printTable(ps, 1)
-      new String(baos.toByteArray, StandardCharsets.UTF_8)
-    }.get
+    ).render
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Help.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Help.scala
@@ -43,7 +43,8 @@ object Help {
       else baseColumns
     }
 
-    val entriesTable = Using.Manager { use =>
+    val entriesTable =
+      Using.Manager { use =>
       val baos = use(new ByteArrayOutputStream)
       val ps = use(new PrintStream(baos, true, "utf-8"))
       new TextTable(columnNames, rowData).printTable(ps, 0)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Help.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Help.scala
@@ -1,17 +1,13 @@
 package io.shiftleft.semanticcpg.language
 
-import java.io.{ByteArrayOutputStream, PrintStream}
-import java.nio.charset.StandardCharsets
-
-import dnl.utils.text.table.TextTable
 import io.shiftleft.codepropertygraph.generated.nodes.Node
+import io.shiftleft.semanticcpg.utils.Table
 import io.shiftleft.semanticcpg.{Doc, Traversal}
 import org.reflections.Reflections
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 import scala.tools.reflect.ToolBox
-import scala.util.Using
 
 object Help {
 
@@ -36,23 +32,17 @@ object Help {
       }
     }
 
-    val columnNames = if (verbose) ColumnNamesVerbose else ColumnNames
-    val rowData = stepDocs.sortBy(_.methodName).toArray.map { stepDoc =>
-      val baseColumns: Array[Object] = Array(s".${stepDoc.methodName}", stepDoc.doc.short)
-      if (verbose) baseColumns :+ stepDoc.traversalClassName
-      else baseColumns
-    }
-
-    val entriesTable =
-      Using.Manager { use =>
-      val baos = use(new ByteArrayOutputStream)
-      val ps = use(new PrintStream(baos, true, "utf-8"))
-      new TextTable(columnNames, rowData).printTable(ps, 0)
-      new String(baos.toByteArray, StandardCharsets.UTF_8)
-    }.get
+    val table = Table(
+      columnNames = if (verbose) ColumnNamesVerbose else ColumnNames,
+      rows = stepDocs.sortBy(_.methodName).map { stepDoc =>
+        val baseColumns = List(s".${stepDoc.methodName}", stepDoc.doc.short)
+        if (verbose) baseColumns :+ stepDoc.traversalClassName
+        else baseColumns
+      }
+    )
 
     s"""Available steps for ${elementClass.getSimpleName}:
-         |$entriesTable
+         |${table.render}
          |""".stripMargin
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -125,7 +125,7 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
   def literal: NodeSteps[nodes.Literal] =
     new NodeSteps(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
-  def topLevelExpressions: NodeSteps[nodes.Expression] =
+def topLevelExpressions: NodeSteps[nodes.Expression] =
     new NodeSteps(
       raw
         .out(EdgeTypes.AST)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -125,7 +125,7 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
   def literal: NodeSteps[nodes.Literal] =
     new NodeSteps(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
-def topLevelExpressions: NodeSteps[nodes.Expression] =
+  def topLevelExpressions: NodeSteps[nodes.Expression] =
     new NodeSteps(
       raw
         .out(EdgeTypes.AST)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
@@ -5,13 +5,13 @@ import java.nio.charset.StandardCharsets
 
 import dnl.utils.text.table.TextTable
 
-case class Table(columnNames: List[String], rows: List[String]) {
+case class Table(columnNames: Iterable[String], rows: Iterable[Iterable[String]]) {
 
   def render: String = {
     val outStream = new ByteArrayOutputStream()
     val ps = new PrintStream(outStream, true, "utf-8")
-    val data = rows.map(_.split("\t").toArray).toArray.asInstanceOf[Array[Array[Object]]]
-    new TextTable(columnNames.toArray, data).printTable(ps, 1)
+    val data = rows.map(_.toArray).toArray
+    new TextTable(columnNames.toArray, data.asInstanceOf[Array[Array[Object]]]).printTable(ps, 1)
     val content = new String(outStream.toByteArray, StandardCharsets.UTF_8)
     ps.close()
     content

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
@@ -1,20 +1,21 @@
 package io.shiftleft.semanticcpg.utils
 
+import dnl.utils.text.table.TextTable
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
-
-import dnl.utils.text.table.TextTable
+import scala.util.Using
 
 case class Table(columnNames: Iterable[String], rows: Iterable[Iterable[String]]) {
 
-  def render: String = {
-    val outStream = new ByteArrayOutputStream()
-    val ps = new PrintStream(outStream, true, "utf-8")
-    val data = rows.map(_.toArray).toArray
-    new TextTable(columnNames.toArray, data.asInstanceOf[Array[Array[Object]]]).printTable(ps, 1)
-    val content = new String(outStream.toByteArray, StandardCharsets.UTF_8)
-    ps.close()
-    content
+  lazy val render: String = {
+    Using.Manager { use =>
+      val charset = StandardCharsets.UTF_8
+      val baos = use(new ByteArrayOutputStream)
+      val ps = use(new PrintStream(baos, true, charset.name))
+      val rowsAsArray = rows.map(_.toArray.asInstanceOf[Array[Object]]).toArray
+      new TextTable(columnNames.toArray, rowsAsArray).printTable(ps, 0)
+      new String(baos.toByteArray, charset)
+    }.get
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
@@ -1,12 +1,13 @@
-package io.shiftleft.console
+package io.shiftleft.semanticcpg.utils
 
-import dnl.utils.text.table.TextTable
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
 
-object Table {
+import dnl.utils.text.table.TextTable
 
-  def create(columnNames: List[String], rows: List[String]): String = {
+case class Table(columnNames: List[String], rows: List[String]) {
+
+  def render: String = {
     val outStream = new ByteArrayOutputStream()
     val ps = new PrintStream(outStream, true, "utf-8")
     val data = rows.map(_.split("\t").toArray).toArray.asInstanceOf[Array[Array[Object]]]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
@@ -14,7 +14,7 @@ case class Table(columnNames: List[String], rows: List[String]) {
     new TextTable(columnNames.toArray, data).printTable(ps, 1)
     val content = new String(outStream.toByteArray, StandardCharsets.UTF_8)
     ps.close()
-    "\n" + content.toString
+    content
   }
 
 }


### PR DESCRIPTION
* centralise usage of TextTable
* use ARM to ensure all buffers are always closed
* use Lists instead of tab-delimited strings