### PR TITLE
Fixes for #688

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -34,7 +34,7 @@ object Run {
            case (varName, typeName) =>
              s"""List("$varName",$typeName.description.trim)"""
          }}
-         | Table(columnNames, rows).render
+         | "\n" + Table(columnNames, rows).render
          | }
          |""".stripMargin
 

--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -26,14 +26,15 @@ object Run {
 
     val toStringCode =
       s"""
+         | import io.shiftleft.semanticcpg.utils.Table
          | override def toString() : String = {
          |  val columnNames = List("name", "description")
          |  val rows =
          |   ${layerCreatorTypeNames.map {
            case (varName, typeName) =>
              s"""List("$varName",$typeName.description.trim)"""
-         }}.map(_.mkString("\\t"))
-         | Table.create(columnNames, rows)
+         }}
+         | Table(columnNames, rows).render
          | }
          |""".stripMargin
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
@@ -14,7 +14,7 @@ case class Table(columnNames: Iterable[String], rows: Iterable[Iterable[String]]
       val ps = use(new PrintStream(baos, true, charset.name))
       val rowsAsArray = rows.map(_.toArray.asInstanceOf[Array[Object]]).toArray
       new TextTable(columnNames.toArray, rowsAsArray).printTable(ps, 0)
-      "\n" + new String(baos.toByteArray, charset)
+      new String(baos.toByteArray, charset)
     }.get
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/Table.scala
@@ -14,7 +14,7 @@ case class Table(columnNames: Iterable[String], rows: Iterable[Iterable[String]]
       val ps = use(new PrintStream(baos, true, charset.name))
       val rowsAsArray = rows.map(_.toArray.asInstanceOf[Array[Object]]).toArray
       new TextTable(columnNames.toArray, rowsAsArray).printTable(ps, 0)
-      new String(baos.toByteArray, charset)
+      "\n" + new String(baos.toByteArray, charset)
     }.get
   }
 


### PR DESCRIPTION
* Adaptions to new `Table` were missing in generated code
* "\n" at the end of each table required on the shell