### PR TITLE
Allow setting policyDirs in MockCpg

### DIFF
--- a/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceTests.scala
@@ -21,7 +21,7 @@ class WorkspaceTests extends WordSpec with Matchers {
         mkdir(project / "overlays")
         val inputPath = "/input/path"
         val projectFile = ProjectFile(inputPath, project.name)
-        val cpg = MockCpg().withMetaData("C", List("foo", "bar")).cpg
+        val cpg = MockCpg().withMetaData("C", List("foo", "bar"), List()).cpg
         val projects = ListBuffer(
           Project(projectFile, project.path, Some(cpg))
         )

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
@@ -18,12 +18,12 @@ package object testing {
 
   case class MockCpg(cpg: Cpg = Cpg.emptyCpg) {
 
-    def withMetaData(language: String = Languages.C): MockCpg = withMetaData(language, List())
+    def withMetaData(language: String = Languages.C): MockCpg = withMetaData(language, List(), List())
 
-    def withMetaData(language: String, overlays: List[String]): MockCpg = {
+    def withMetaData(language: String, overlays: List[String], policyDirs: List[String]): MockCpg = {
       withCustom { (diffGraph, _) =>
         diffGraph.addNode(
-          nodes.NewMetaData(language = language, overlays = overlays)
+          nodes.NewMetaData(language = language, overlays = overlays, policyDirectories = policyDirs)
         )
       }
     }


### PR DESCRIPTION
To allow testing of the new `policyDirs` via MockCpgs, we need to allow setting them.