### PR TITLE
Add `LLVM` to `languages` and add comment.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -329,13 +329,15 @@
         {"id" : 2, "name" : "DYNAMIC_DISPATCH", "comment": "For dynamically dispatched calls the target is determined during runtime"}
     ],
 
+    // TODO rename to "frontends"
     "languages" : [
         {"id" : 1, "name" : "JAVA", "comment" : ""},
         {"id" : 2, "name" : "JAVASCRIPT", "comment" : ""},
         {"id" : 3, "name" : "GOLANG", "comment" : ""},
         {"id" : 4, "name" : "CSHARP", "comment" : ""},
         {"id" : 5, "name" : "C", "comment" : ""},
-        {"id" : 6, "name" : "PYTHON", "comment" : ""}
+        {"id" : 6, "name" : "PYTHON", "comment" : ""},
+	{"id" : 7, "name" : "LLVM", "comment" : ""}
     ],
 
     "modifierTypes" : [


### PR DESCRIPTION
Adds `LLVM` to `languages` (which will soon be renamed to `frontends`). Once the backend PR for handling of `policyDirectories` is merged, we can set `language` to `LLVM` in llvm2cpg, and then finally, we renamed to "frontends" in alignment with all other frontend authors.