### PR TITLE
Bring `save` to console + fix import

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -206,6 +206,24 @@ abstract class Console[T <: Project](executor: AmmoniteExecutor, loader: Workspa
   }
 
   @Doc(
+    "Write all changes to disk",
+    """
+      |Close and reopen all loaded CPGs. This ensures
+      |that changes have been flushed to disk.
+      |
+      |Returns list of affected projects
+      |""".stripMargin,
+    "save"
+  )
+  def save: List[Project] = {
+    report("Saving graphs on disk. This may take a while.")
+    workspace.projects.collect {
+      case p: Project if p.cpg.isDefined =>
+        p.close
+        workspace.openProject(p.name)
+    }.flatten
+  }
+  @Doc(
     "Create new project from existing CPG",
     """
       |importCpg(<inputPath>, [projectName])

--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -26,7 +26,7 @@ object Run {
 
     val toStringCode =
       s"""
-         | import io.shiftleft.semanticcpg.utils.Table
+         | import io.shiftleft.overflowdb.traversal.help.Table
          | override def toString() : String = {
          |  val columnNames = List("name", "description")
          |  val rows =


### PR DESCRIPTION
* Bring `save` method from Ocular to `console`
* Fix import that wasn't adapted in #695 