### PR TITLE
Bring over language frontend wrappers + console tests

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -61,4 +61,5 @@ libraryDependencies ++= Seq(
   "org.zeroturnaround"   %  "zt-zip"        % ZeroturnaroundVersion,
   "com.lihaoyi"          %% "ammonite"      % AmmoniteVersion cross CrossVersion.full,
   "org.scalatest"        %% "scalatest"     % ScalatestVersion % Test,
+  "io.shiftleft" %% "fuzzyc2cpg"            % Versions.fuzzyc2cpg % Test,
 )

--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -2,6 +2,8 @@ package io.shiftleft.console
 
 import better.files._
 
+import scala.collection.mutable
+
 /**
   * Installation configuration of Console
   *
@@ -17,4 +19,47 @@ object InstallConfig {
   def apply(): InstallConfig = new InstallConfig()
 }
 
-class ConsoleConfig(val install: InstallConfig = InstallConfig()) {}
+class ConsoleConfig(val install: InstallConfig = InstallConfig(),
+                    val frontend: LanguageFrontendConfig = LanguageFrontendConfig()) {}
+
+object LanguageFrontendConfig {
+  def apply(): LanguageFrontendConfig = new LanguageFrontendConfig()
+}
+
+class LanguageFrontendConfig(var csharp: CSharpFrontendConfig = CSharpFrontendConfig(),
+                             var fuzzyc: FuzzyCFrontendConfig = FuzzyCFrontendConfig(),
+                             var go: GoFrontendConfig = GoFrontendConfig(),
+                             var java: JavaFrontendConfig = JavaFrontendConfig(),
+                             var js: JsFrontendConfig = JsFrontendConfig(),
+                             var llvm: LlvmFrontendConfig = LlvmFrontendConfig())
+
+class CSharpFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
+class FuzzyCFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
+class GoFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
+class JavaFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
+class JsFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
+class LlvmFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
+
+object CSharpFrontendConfig {
+  def apply(): CSharpFrontendConfig = new CSharpFrontendConfig()
+}
+
+object FuzzyCFrontendConfig {
+  def apply(): FuzzyCFrontendConfig = new FuzzyCFrontendConfig()
+}
+
+object GoFrontendConfig {
+  def apply(): GoFrontendConfig = new GoFrontendConfig()
+}
+
+object JavaFrontendConfig {
+  def apply(): JavaFrontendConfig = new JavaFrontendConfig()
+}
+
+object JsFrontendConfig {
+  def apply(): JsFrontendConfig = new JsFrontendConfig()
+}
+
+object LlvmFrontendConfig {
+  def apply(): LlvmFrontendConfig = new LlvmFrontendConfig()
+}

--- a/console/src/main/scala/io/shiftleft/console/DefaultAmmoniteExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/DefaultAmmoniteExecutor.scala
@@ -1,0 +1,8 @@
+package io.shiftleft.console
+
+import io.shiftleft.console.scripting.AmmoniteExecutor
+
+object DefaultAmmoniteExecutor extends AmmoniteExecutor {
+  override lazy val predef: String =
+    Predefined.forScripts
+}

--- a/console/src/main/scala/io/shiftleft/console/LanguageHelper.scala
+++ b/console/src/main/scala/io/shiftleft/console/LanguageHelper.scala
@@ -1,0 +1,45 @@
+package io.shiftleft.console
+
+import java.nio.file.Path
+
+import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.console.cpgcreation.{
+  CSharpLanguageFrontend,
+  FuzzyCLanguageFrontend,
+  GoLanguageFrontend,
+  JavaLanguageFrontend,
+  JsLanguageFrontend,
+  LanguageFrontend,
+  LlvmLanguageFrontend
+}
+
+object LanguageHelper {
+
+  /**
+    * For a given language, return CPG generator script
+    * */
+  def cpgGeneratorForLanguage(language: String,
+                              config: LanguageFrontendConfig,
+                              rootPath: Path): Option[LanguageFrontend] = {
+    language match {
+      case Languages.CSHARP     => Some(CSharpLanguageFrontend(config.csharp, rootPath))
+      case Languages.C          => Some(FuzzyCLanguageFrontend(config.fuzzyc, rootPath))
+      case Languages.LLVM       => Some(LlvmLanguageFrontend(config.llvm, rootPath))
+      case Languages.GOLANG     => Some(GoLanguageFrontend(config.go, rootPath))
+      case Languages.JAVA       => Some(JavaLanguageFrontend(config.java, rootPath))
+      case Languages.JAVASCRIPT => Some(JsLanguageFrontend(config.js, rootPath))
+      case _                    => None
+    }
+  }
+
+  def languageIsKnown(language: String): Boolean = {
+    Set(Languages.C,
+        Languages.CSHARP,
+        Languages.GOLANG,
+        Languages.JAVA,
+        Languages.JAVASCRIPT,
+        Languages.PYTHON,
+        Languages.LLVM).contains(language)
+  }
+
+}

--- a/console/src/main/scala/io/shiftleft/console/Predefined.scala
+++ b/console/src/main/scala/io/shiftleft/console/Predefined.scala
@@ -1,0 +1,34 @@
+package io.shiftleft.console
+
+object Predefined {
+
+  /* ammonite tab completion is partly broken for scala > 2.12.8
+   * applying workaround for package wildcard imports from https://github.com/lihaoyi/Ammonite/issues/1009 */
+  val shared: String = """
+        |import gremlin.scala.{`package` => _, _}
+        |import io.shiftleft.console.{`package` => _, _}
+        |import io.shiftleft.joern.console._
+        |import io.shiftleft.joern.console.JoernConsole._
+        |import io.shiftleft.codepropertygraph.Cpg
+        |import io.shiftleft.codepropertygraph.cpgloading._
+        |import io.shiftleft.codepropertygraph.generated._
+        |import io.shiftleft.codepropertygraph.generated.nodes._
+        |import io.shiftleft.codepropertygraph.generated.edges._
+        |import io.shiftleft.dataflowengine.language.{`package` => _, _}
+        |import io.shiftleft.semanticcpg.language.{`package` => _, _}
+        |import scala.jdk.CollectionConverters._
+        |implicit val resolver: ICallResolver = NoResolve
+        |
+      """.stripMargin
+
+  val forInteractiveShell: String = shared +
+    """
+      |import io.shiftleft.joern.console.Joern._
+    """.stripMargin
+
+  val forScripts: String = shared +
+    """
+      |import io.shiftleft.joern.console.Joern.{cpg =>_, _}
+  """.stripMargin
+
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CSharpLanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CSharpLanguageFrontend.scala
@@ -1,0 +1,41 @@
+package io.shiftleft.console.cpgcreation
+
+import java.nio.file.Path
+
+import io.shiftleft.console.CSharpFrontendConfig
+
+/**
+  * C# language frontend. Translates C# project files into code property graphs.
+  * */
+case class CSharpLanguageFrontend(config: CSharpFrontendConfig, rootPath: Path) extends LanguageFrontend {
+
+  private val dotnetFrameworkOpt = "--dotnet-framework"
+  private val dotnetCoreOpt = "--dotnet-core"
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    **/
+  override def generate(inputPath: String,
+                        outputPath: String = "cpg.bin.zip",
+                        namespaces: List[String] = List()): Option[String] = {
+    var arguments = Seq("-i", inputPath, "-o", outputPath) ++ config.cmdLineParams
+    var command = rootPath.resolve("csharp2cpg.sh").toString
+
+    if (!config.cmdLineParams.exists(param => param == dotnetFrameworkOpt || param == dotnetCoreOpt)) {
+      System.err.println(
+        s"Neither $dotnetFrameworkOpt or $dotnetCoreOpt were specified. Defaulting to $dotnetFrameworkOpt...")
+      arguments = arguments :+ dotnetFrameworkOpt
+    }
+
+    if (System.getProperty("os.name").startsWith("Windows")) {
+      command = "powershell"
+      arguments = Seq(rootPath.resolve("csharp2cpg.ps1").toString) ++ arguments
+    }
+    runShellCommand(command, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean = rootPath.resolve("csharp2cpg.sh").toFile.exists()
+
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGenerator.scala
@@ -1,0 +1,84 @@
+package io.shiftleft.console.cpgcreation
+
+import java.nio.file.Path
+
+import better.files.Dsl._
+import better.files.File
+import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
+import io.shiftleft.console.ConsoleConfig
+import io.shiftleft.overflowdb.OdbConfig
+import io.shiftleft.console.LanguageHelper.{cpgGeneratorForLanguage, languageIsKnown}
+
+import scala.util.Try
+
+class CpgGenerator(config: ConsoleConfig) {
+
+  /**
+    * For a given input path, try to guess a suitable language
+    * frontend and return it
+    * */
+  def createFrontendByPath(inputPath: String): Option[LanguageFrontend] = {
+    LanguageGuesser
+      .guessLanguage(inputPath)
+      .flatMap { l =>
+        cpgGeneratorForLanguage(l, config.frontend, config.install.rootPath.path)
+      }
+  }
+
+  /**
+    * For a language, return the language frontend
+    * */
+  def createFrontendByLanguage(language: String): Option[LanguageFrontend] = {
+    Some(language)
+      .filter(languageIsKnown)
+      .flatMap(
+        lang =>
+          cpgGeneratorForLanguage(
+            lang,
+            config.frontend,
+            config.install.rootPath.path
+        ))
+  }
+
+  def runLanguageFrontend(frontend: LanguageFrontend,
+                          inputPath: String,
+                          outputPath: String,
+                          namespaces: List[String] = List()): Option[Path] = {
+    val outputFileOpt: Option[File] =
+      frontend.generate(inputPath, outputPath, namespaces).map(File(_))
+    outputFileOpt.map { outFile =>
+      val parentPath = outFile.parent.path.toAbsolutePath
+      if (isZipFile(outFile)) {
+        report("Creating database from bin.zip")
+        val srcFilename = outFile.path.toAbsolutePath.toString
+        val dstFilename = parentPath.resolve("cpg.bin").toAbsolutePath.toString
+        // MemoryHelper.hintForInsufficientMemory(srcFilename).map(report)
+        convertProtoCpgToOverflowDb(srcFilename, dstFilename)
+      } else {
+        report("moving cpg.bin.zip to cpg.bin because it is already a database file")
+        val srcPath = parentPath.resolve("cpg.bin.zip")
+        if (srcPath.toFile.exists()) {
+          mv(srcPath, parentPath.resolve("cpg.bin"))
+        }
+      }
+      parentPath
+    }
+  }
+
+  def convertProtoCpgToOverflowDb(srcFilename: String, dstFilename: String): Unit = {
+    val odbConfig = OdbConfig.withDefaults.withStorageLocation(dstFilename)
+    val config = CpgLoaderConfig.withDefaults.doNotCreateIndexesOnLoad.withOverflowConfig(odbConfig)
+    CpgLoader.load(srcFilename, config).close
+    File(srcFilename).delete()
+  }
+
+  def isZipFile(file: File): Boolean = {
+    val bytes = file.bytes
+    Try {
+      bytes.next() == 'P' && bytes.next() == 'K'
+    }.getOrElse(false)
+  }
+
+  private def report(str: String): Unit = System.err.println(str)
+
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCLanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCLanguageFrontend.scala
@@ -1,0 +1,27 @@
+package io.shiftleft.console.cpgcreation
+
+import java.nio.file.Path
+
+import io.shiftleft.console.FuzzyCFrontendConfig
+
+/**
+  * Fuzzy C/C++ language frontend. Translates C/C++ source files
+  * into code property graphs via fuzzy parsing.
+  * */
+case class FuzzyCLanguageFrontend(config: FuzzyCFrontendConfig, rootPath: Path) extends LanguageFrontend {
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    **/
+  override def generate(inputPath: String,
+                        outputPath: String = "cpg.bin.zip",
+                        namespaces: List[String] = List()): Option[String] = {
+    val fuzzyc2cpgsh = rootPath.resolve("fuzzyc2cpg.sh").toString
+    val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
+    runShellCommand(fuzzyc2cpgsh, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean = rootPath.resolve("fuzzyc2cpg.sh").toFile.exists
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/GoLanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/GoLanguageFrontend.scala
@@ -1,0 +1,32 @@
+package io.shiftleft.console.cpgcreation
+
+import java.nio.file.Path
+
+import io.shiftleft.console.GoFrontendConfig
+
+/**
+  * Language frontend for Go code.  Translates Go source code into Code Property Graphs.
+  */
+case class GoLanguageFrontend(config: GoFrontendConfig, rootPath: Path) extends LanguageFrontend {
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    **/
+  override def generate(inputPath: String,
+                        outputPath: String = "cpg.bin.zip",
+                        namespaces: List[String] = List()): Option[String] = {
+    var command = rootPath.resolve("go2cpg.sh").toString
+    var arguments = Seq("--output", outputPath) ++ config.cmdLineParams ++ Seq("generate") ++ List(inputPath)
+
+    if (System.getProperty("os.name").startsWith("Windows")) {
+      command = "powershell"
+      arguments = Seq(rootPath.resolve("go2cpg.ps1").toString) ++ arguments
+    }
+
+    runShellCommand(command, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean = rootPath.resolve("go2cpg.sh").toFile.exists()
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/JavaLanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/JavaLanguageFrontend.scala
@@ -1,0 +1,59 @@
+package io.shiftleft.console.cpgcreation
+
+import java.nio.file.Path
+
+import io.shiftleft.console.JavaFrontendConfig
+
+/**
+  * Language frontend for Java archives (JAR files). Translates Java archives into code property graphs.
+  * */
+case class JavaLanguageFrontend(config: JavaFrontendConfig, rootPath: Path) extends LanguageFrontend {
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    **/
+  override def generate(inputPath: String,
+                        outputPath: String = "cpg.bin.zip",
+                        namespaces: List[String] = List()): Option[String] = {
+    if (inputPath.endsWith(".apk")) {
+      println("found .apk ending - will first transform it to a jar using dex2jar.sh")
+      val dex2jar = rootPath.resolve("dex2jar.sh").toString
+      runShellCommand(dex2jar, Seq(inputPath)).flatMap { _ =>
+        val jarPath = s"${inputPath}.jar"
+        generate(jarPath, outputPath, namespaces)
+      }
+    } else {
+      var command = rootPath.resolve("java2cpg.sh").toString
+      var arguments = Seq(inputPath, "-o", outputPath) ++ jvmLanguages ++ namespaceArgs(namespaces) ++ config.cmdLineParams
+      if (System.getProperty("os.name").startsWith("Windows")) {
+        command = "powershell"
+        arguments = Seq(rootPath.resolve("java2cpg.ps1").toString) ++ arguments
+      }
+      runShellCommand(command, arguments).map(_ => outputPath)
+    }
+  }
+
+  private def jvmLanguages: List[String] = {
+    if (JavaLanguageFrontend.experimentalLanguages.nonEmpty) {
+      List("--experimental-langs", JavaLanguageFrontend.experimentalLanguages.mkString(","))
+    } else Nil
+  }
+
+  private def namespaceArgs(namespaces: List[String]): List[String] = {
+    val csvString = namespaces.mkString(",")
+    // if no namespaces are specified, use smart unpacking
+    if (csvString.isEmpty) {
+      List("-su")
+    } else {
+      List("-nb", "-w", csvString)
+    }
+  }
+
+  override def isAvailable: Boolean = rootPath.resolve("java2cpg.sh").toFile.exists()
+}
+
+object JavaLanguageFrontend {
+  private final val experimentalLanguages: List[String] = List("scala")
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/JsLanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/JsLanguageFrontend.scala
@@ -1,0 +1,23 @@
+package io.shiftleft.console.cpgcreation
+
+import java.nio.file.Path
+
+import io.shiftleft.console.JsFrontendConfig
+
+case class JsLanguageFrontend(config: JsFrontendConfig, rootPath: Path) extends LanguageFrontend {
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    **/
+  override def generate(inputPath: String,
+                        outputPath: String = "cpg.bin.zip",
+                        namespaces: List[String] = List()): Option[String] = {
+    val js2cpgsh = rootPath.resolve("js2cpg.sh").toString
+    val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
+    runShellCommand(js2cpgsh, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean = rootPath.resolve("js2cpg.sh").toFile.exists()
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/LanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/LanguageFrontend.scala
@@ -1,0 +1,43 @@
+package io.shiftleft.console.cpgcreation
+
+import better.files.File
+
+import scala.sys.process._
+
+/**
+  * A language frontend translates code into code property graphs. Each
+  * supported language implements a LanguageFrontend, e.g., [[JavaLanguageFrontend]]
+  * implements Java Archive to CPG conversion, while [[CSharpLanguageFrontend]]
+  * translates C# projects into code property graphs.
+  * */
+abstract class LanguageFrontend() {
+
+  def isAvailable: Boolean
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    *
+    * This method appends command line options
+    * in config.frontend.cmdLineParams to the
+    * shell command.
+    * */
+  def generate(inputPath: String, outputPath: String = "cpg.bin.zip", namespaces: List[String] = List()): Option[String]
+
+  protected def runShellCommand(program: String, arguments: Seq[String]): Option[String] = {
+    if (!File(program).exists) {
+      System.err.println("Support for this language is only available in ShiftLeft Ocular with an appropriate license")
+      return None
+    }
+    val cmd = Seq[String](program) ++ arguments
+    val exitValue = cmd.run.exitValue()
+    if (exitValue == 0) {
+      Some(cmd.toString)
+    } else {
+      System.err.println(s"Error running shell command: $cmd")
+      None
+    }
+  }
+
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/LanguageGuesser.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/LanguageGuesser.scala
@@ -1,0 +1,57 @@
+package io.shiftleft.console.cpgcreation
+
+import java.io.File
+import java.nio.file.Path
+
+import io.shiftleft.codepropertygraph.generated.Languages
+
+object LanguageGuesser {
+
+  /**
+    * Heuristically determines language by inspecting
+    * file/dir at path.
+    * */
+  def guessLanguage(path: String): Option[String] = {
+    val lowerCasePath = path.toLowerCase
+    if (lowerCasePath.endsWith(".jar") ||
+        lowerCasePath.endsWith(".war") ||
+        lowerCasePath.endsWith(".ear") ||
+        lowerCasePath.endsWith(".apk")) {
+      Some(Languages.JAVA)
+    } else if (lowerCasePath.endsWith("csproj")) {
+      Some(Languages.CSHARP)
+    } else if (lowerCasePath.endsWith(".go")) {
+      Some(Languages.GOLANG)
+    } else {
+      val file = new File(path)
+      if (file.isDirectory) {
+        val files = file.list()
+        if (files.exists(f =>
+              f.endsWith(".go") || Set("Gopkg.lock", "Gopkg.toml", "go.mod", "go.sum")
+                .contains(f))) {
+          Some(Languages.GOLANG)
+        } else if (files.exists(f => f.endsWith(".js") || Set("package.json").contains(f))) {
+          Some(Languages.JAVASCRIPT)
+        } else if (files.exists(f => isLlvmSrcFile(new File(f).toPath))) {
+          Some(Languages.LLVM)
+        } else {
+          Some(Languages.C)
+        }
+      } else if (file.isFile) {
+        if (isLlvmSrcFile(file.toPath)) {
+          Some(Languages.LLVM)
+        } else {
+          None
+        }
+      } else {
+        None
+      }
+    }
+  }
+
+  private def isLlvmSrcFile(path: Path): Boolean = {
+    val filename = path.getFileName.toString
+    filename.endsWith(".bc") || filename.endsWith(".ll")
+  }
+
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/LlvmLanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/LlvmLanguageFrontend.scala
@@ -1,0 +1,26 @@
+package io.shiftleft.console.cpgcreation
+
+import java.nio.file.Path
+
+import io.shiftleft.console.LlvmFrontendConfig
+
+/**
+  * Language frontend for LLVM.  Translates LLVM bitcode into Code Property Graphs.
+  */
+case class LlvmLanguageFrontend(config: LlvmFrontendConfig, rootPath: Path) extends LanguageFrontend {
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    **/
+  override def generate(inputPath: String,
+                        outputPath: String = "cpg.bin.zip",
+                        namespaces: List[String] = List()): Option[String] = {
+    val command = rootPath.resolve("llvm2cpg.sh").toString
+    val arguments = Seq("--output", outputPath) ++ config.cmdLineParams ++ List(inputPath)
+    runShellCommand(command, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean = rootPath.resolve("llvm2cpg.sh").toFile.exists()
+}

--- a/console/src/main/scala/io/shiftleft/console/testing/package.scala
+++ b/console/src/main/scala/io/shiftleft/console/testing/package.scala
@@ -1,0 +1,29 @@
+package io.shiftleft.console
+
+import better.files.Dsl._
+import better.files._
+import io.shiftleft.console.workspacehandling.Project
+
+import scala.util.{Failure, Success, Try}
+
+package object testing {
+
+  def createStandaloneCpg(console: Console[Project], codeDir: File): File = {
+    val tmpProjectName = "standalonecpg"
+    console.importCode(codeDir.toString, tmpProjectName)
+    val project = console.workspace.project(tmpProjectName)
+    val cpgPath = project.get.path.resolve("cpg.bin")
+    val tmpCpg = File.newTemporaryFile("console")
+    Try {
+      cp(cpgPath, tmpCpg)
+      console.workspace.reset()
+      tmpCpg
+    } match {
+      case Success(v) => v
+      case Failure(exc) =>
+        tmpCpg.delete()
+        throw exc
+    }
+  }
+
+}

--- a/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
@@ -1,0 +1,18 @@
+package io.shiftleft.console
+
+import better.files.File
+import org.scalatest.{Matchers, WordSpec}
+
+class ConsoleConfigTest extends WordSpec with Matchers {
+  "An InstallConfig" should {
+    "set the rootPath to the current working directory by default" in {
+      val config = new InstallConfig(environment = Map.empty)
+      config.rootPath shouldBe File(".")
+    }
+
+    "set the rootPath to SHIFTLEFT_CONSOLE_INSTALL_DIR if it is defined" in {
+      val config = new InstallConfig(environment = Map("SHIFTLEFT_CONSOLE_INSTALL_DIR" -> "/tmp"))
+      config.rootPath shouldBe File("/tmp")
+    }
+  }
+}

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -1,0 +1,287 @@
+package io.shiftleft.console
+
+import java.io.FileOutputStream
+import java.util.zip.ZipOutputStream
+
+import better.files.Dsl.cp
+import better.files._
+import io.shiftleft.console.fixtures.ConsoleFixture
+import org.scalatest.{Matchers, WordSpec}
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.console.testing._
+import io.shiftleft.semanticcpg.layers.Scpg
+
+import scala.util.Try
+
+class ConsoleTests extends WordSpec with Matchers {
+
+  "importCode" should {
+    "provide overview of available language modules" in ConsoleFixture() { (console, _) =>
+      console.importCode.toString.contains("| C") shouldBe true
+    }
+
+    "allow importing code with specific module" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode.c(codeDir.toString)
+      console.workspace.numberOfProjects shouldBe 1
+    }
+
+    "allow importing code" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString)
+      console.workspace.numberOfProjects shouldBe 1
+      Set("main", "bar").subsetOf(console.cpg.method.name.toSet)
+      console.project.appliedOverlays shouldBe List("semanticcpg")
+    }
+
+    "allow importing code and setting project name" in ConsoleFixture() { (console, codeDir) =>
+      val projectName = "test"
+      console.importCode(codeDir.toString, projectName)
+      console.workspace.numberOfProjects shouldBe 1
+      console.workspace.project(projectName) match {
+        case Some(p) =>
+          p.name shouldBe projectName
+          p.cpg should not be empty
+        case None => fail()
+      }
+      console.project.appliedOverlays shouldBe List("semanticcpg")
+    }
+
+    "allow importing multiple code bases" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString, "foo")
+      console.importCode(codeDir.toString, "bar")
+      console.workspace.numberOfProjects shouldBe 2
+      console.project.name shouldBe "bar"
+      console.project.appliedOverlays shouldBe List("semanticcpg")
+      console.workspace.project("foo").get.appliedOverlays shouldBe List("semanticcpg")
+    }
+
+    "set project to active" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString, "foo")
+      Set("main", "bar").subsetOf(console.cpg.method.name.toSet)
+    }
+
+  }
+
+  "importCpg" should {
+
+    "gracefully handle request to import non-existing CPG" in ConsoleFixture() { (console, _) =>
+      console.importCpg("idontexist")
+      console.workspace.numberOfProjects shouldBe 0
+    }
+
+    "convert legacy CPGs on import" in ConsoleFixture() { (console, _) =>
+      File.usingTemporaryFile("console") { file =>
+        new ZipOutputStream(new FileOutputStream(file.toString)).close()
+        val projectName = "myproject"
+        val cpg = console.importCpg(file.toString, projectName)
+        console.workspace.numberOfProjects shouldBe 1
+        console.workspace.projectByCpg(cpg.get).map(_.name) shouldBe Some(projectName)
+        console.project.appliedOverlays shouldBe List()
+      }
+    }
+
+    "handle broken legacy CPG gracefully" in ConsoleFixture() { (console, _) =>
+      File.usingTemporaryFile("console") { file =>
+        file.write("PK")
+        console.importCpg(file.toString)
+      }
+    }
+
+    "gracefully handle broken CPGs" in ConsoleFixture() { (console, _) =>
+      File.usingTemporaryFile("console") { file =>
+        file.writeBytes(List[Byte]('F', 'O').iterator)
+        console.importCpg(file.toString)
+        console.workspace.numberOfProjects shouldBe 0
+      }
+    }
+
+    "allow importing an existing CPG" in ConsoleFixture() { (console, codeDir) =>
+      val tmpCpg = createStandaloneCpg(console, codeDir)
+      try {
+        console.importCpg(tmpCpg.toString)
+        console.workspace.numberOfProjects shouldBe 1
+        Set("main", "bar").subsetOf(console.cpg.method.name.toSet)
+        console.project.appliedOverlays shouldBe List("semanticcpg")
+      } finally {
+        Some(tmpCpg).find(_.exists).foreach(_.delete())
+      }
+    }
+
+    "allow importing an existing CPG with custom project name" in ConsoleFixture() { (console, codeDir) =>
+      val tmpCpg = createStandaloneCpg(console, codeDir)
+      try {
+        console.importCpg(tmpCpg.toString, "foobar")
+        console.workspace.numberOfProjects shouldBe 1
+        console.workspace.project("foobar") should not be empty
+        Set("main", "bar").subsetOf(console.cpg.method.name.toSet)
+      } finally {
+        Some(tmpCpg).find(_.exists).foreach(_.delete())
+      }
+    }
+
+    "allow importing two CPGs with the same filename but different paths" in ConsoleFixture() { (console, codeDir) =>
+      val cpgFile = createStandaloneCpg(console, codeDir)
+      File.usingTemporaryDirectory("console") { dir1 =>
+        File.usingTemporaryDirectory("console") { dir2 =>
+          File.usingTemporaryDirectory("console") { dir3 =>
+            val cpg1Path = dir1.path.resolve("cpg.bin")
+            val cpg2Path = dir2.path.resolve("cpg.bin")
+            val cpg3Path = dir3.path.resolve("cpg.bin")
+            cp(cpgFile, cpg1Path)
+            cp(cpgFile, cpg2Path)
+            cp(cpgFile, cpg3Path)
+            console.importCpg(cpg1Path.toString)
+            console.importCpg(cpg2Path.toString)
+            console.importCpg(cpg3Path.toString)
+            console.workspace.numberOfProjects shouldBe 3
+            console.workspace.project(cpg1Path.toFile.getName) should not be empty
+            console.workspace.project(cpg1Path.toFile.getName + "1") should not be empty
+            console.workspace.project(cpg1Path.toFile.getName + "2") should not be empty
+            console.workspace.project(cpg1Path.toFile.getName + "12") shouldBe empty
+          }
+        }
+      }
+    }
+
+    "overwrite project if a project for the inputPath exists" in ConsoleFixture() { (console, codeDir) =>
+      val tmpCpg = createStandaloneCpg(console, codeDir)
+      try {
+        console.importCpg(tmpCpg.toString)
+        console.importCpg(tmpCpg.toString)
+        console.workspace.numberOfProjects shouldBe 1
+        Set("main", "bar").subsetOf(console.cpg.method.name.toSet)
+        console.project.appliedOverlays shouldBe List("semanticcpg")
+      } finally {
+        Some(tmpCpg).find(_.exists).foreach(_.delete())
+      }
+    }
+  }
+
+  "open/close" should {
+    "allow opening an already open project to make it active" in ConsoleFixture() { (console, codeDir) =>
+      val projectName = "myproject"
+      console.importCode(codeDir.toString, projectName)
+      console.importCpg(codeDir.path.resolve("cpg.bin").toString, "foo")
+      val project = console.open(projectName)
+      project match {
+        case Some(p) =>
+          p.name shouldBe projectName
+          console.workspace.projectByCpg(p.cpg.get).map(_.name) shouldBe Some(projectName)
+        case None => fail
+      }
+    }
+
+    "allow closing and then opening a project again" in ConsoleFixture() { (console, codeDir) =>
+      val projectName = "myproject"
+      console.importCode(codeDir.toString, projectName)
+      console.close(projectName).get.cpg shouldBe empty
+      console.open(projectName).get.cpg should not be empty
+    }
+
+    "allow closing currently active project" in ConsoleFixture() { (console, codeDir) =>
+      val projectName = "myproject"
+      console.importCode(codeDir.toString, projectName)
+      val project = console.close
+      project.get.name shouldBe projectName
+      project.get.cpg shouldBe empty
+    }
+
+    "should keep project active on close and allow setting other as active" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString, "foo")
+      console.importCode(codeDir.toString, "bar")
+      console.close
+      a[RuntimeException] should be thrownBy (console.cpg)
+      console.open("foo")
+      Set("main", "bar").subsetOf(console.cpg.method.name.toSet)
+    }
+  }
+
+  "delete" should {
+
+    "remove a project from disk" in ConsoleFixture() { (console, codeDir) =>
+      val cpg = console.importCode(codeDir.toString, "foo")
+      val projectDir = console.workspace.projectByCpg(cpg.get).get.path.toFile
+      console.delete("foo")
+      projectDir.exists shouldBe false
+    }
+
+    "handle request to delete non-existing project gracefully" in ConsoleFixture() { (console, _) =>
+      val project = console.delete("foo")
+      project shouldBe None
+    }
+
+  }
+
+  "runAnalyzer" should {
+
+    "prohibit adding semanticcpg again" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString)
+      console.project.appliedOverlays shouldBe List("semanticcpg")
+      val numOverlayFilesBefore = console.project.path.resolve("overlays").toFile.list().size
+      numOverlayFilesBefore shouldBe 1
+      console._runAnalyzer(new Scpg)
+      console.project.appliedOverlays shouldBe List("semanticcpg")
+      console.project.path.resolve("overlays").toFile.list().size shouldBe numOverlayFilesBefore
+    }
+
+    "store zip files for each overlay in project" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString)
+      val overlayDir = console.project.path.resolve("overlays")
+      overlayDir.toFile.list.toSet shouldBe Set("semanticcpg")
+
+      val overlayFiles = overlayDir.toFile.listFiles()
+      overlayFiles.foreach { file =>
+        isZipFile(File(file.getPath)) shouldBe true
+      }
+    }
+  }
+
+  "undo" should {
+    "remove layer from meta information" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString)
+      console.project.appliedOverlays shouldBe List("semanticcpg")
+      console.undo
+      console.project.appliedOverlays shouldBe List()
+    }
+
+    "remove overlay file from project" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString)
+      val overlayDir = console.project.path.resolve("overlays")
+      val overlayFilesBefore = overlayDir.toFile.list.toSet
+      overlayFilesBefore shouldBe Set("semanticcpg")
+      console.undo
+      val overlayFilesAfter = overlayDir.toFile.list.toSet
+      overlayFilesAfter shouldBe Set()
+    }
+
+    "actually remove some nodes" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString)
+      console.cpg.parameter.asOutput.l.size should be > 0
+      console.project.appliedOverlays shouldBe List("semanticcpg")
+      console.undo
+      console.project.appliedOverlays shouldBe List()
+      console.cpg.parameter.asOutput.l.size shouldBe 0
+      console._runAnalyzer(new Scpg)
+      console.cpg.parameter.asOutput.l.size should be > 0
+    }
+  }
+
+  "save" should {
+    "close and reopen projects" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString, "project1")
+      console.importCode(codeDir.toString, "project2")
+      console.workspace.project("project1").exists(_.cpg.isDefined) shouldBe true
+      console.workspace.project("project2").exists(_.cpg.isDefined) shouldBe true
+      console.save
+      console.workspace.project("project1").exists(_.cpg.isDefined) shouldBe true
+      console.workspace.project("project2").exists(_.cpg.isDefined) shouldBe true
+    }
+  }
+
+  private def isZipFile(file: File): Boolean = {
+    val bytes = file.bytes
+    Try {
+      bytes.next() == 'P' && bytes.next() == 'K'
+    }.getOrElse(false)
+  }
+
+}

--- a/console/src/test/scala/io/shiftleft/console/HelpTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/HelpTests.scala
@@ -1,0 +1,14 @@
+package io.shiftleft.console
+
+import io.shiftleft.console.workspacehandling.Project
+import org.scalatest.{Matchers, WordSpec}
+
+class HelpTests extends WordSpec with Matchers {
+
+  "Help" should {
+    "provide overview of commands as table" in {
+      Help.overview[io.shiftleft.console.Console[Project]].contains("| CPG") shouldBe true
+    }
+  }
+
+}

--- a/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
@@ -1,0 +1,77 @@
+package io.shiftleft.console
+
+import better.files.Dsl._
+import better.files._
+import io.shiftleft.codepropertygraph.generated.Languages
+import io.shiftleft.console.LanguageHelper._
+import io.shiftleft.console.cpgcreation.LanguageGuesser._
+import io.shiftleft.console.cpgcreation.LlvmLanguageFrontend
+import org.scalatest.{Matchers, WordSpec}
+
+class LanguageHelperTests extends WordSpec with Matchers {
+
+  "LanguageHelper.guessLanguage" should {
+
+    "guess `Java` for .jars/wars/ears" in {
+      guessLanguage("foo.jar") shouldBe Some(Languages.JAVA)
+      guessLanguage("foo.war") shouldBe Some(Languages.JAVA)
+      guessLanguage("foo.ear") shouldBe Some(Languages.JAVA)
+    }
+
+    "guess `C#` for .csproj" in {
+      guessLanguage("foo.csproj") shouldBe Some(Languages.CSHARP)
+    }
+
+    "guess `Go` for a .go file" in {
+      guessLanguage("foo.go") shouldBe Some(Languages.GOLANG)
+    }
+
+    "guess `Go` for a directory containing `Gopkg.lock`" in {
+      File.usingTemporaryDirectory("oculartests") { tmpDir =>
+        touch(tmpDir / "Gopkg.lock")
+        guessLanguage(tmpDir.toString) shouldBe Some(Languages.GOLANG)
+      }
+    }
+
+    "guess `Go` for a directory containing `Gopkg.toml` its root" in {
+      File.usingTemporaryDirectory("oculartests") { tmpDir =>
+        touch(tmpDir / "Gopkg.toml")
+        guessLanguage(tmpDir.toString) shouldBe Some(Languages.GOLANG)
+      }
+    }
+
+    "guess `Javascript` for a directory containing `package.json` in its root" in {
+      File.usingTemporaryDirectory("oculartests") { tmpDir =>
+        touch(tmpDir / "package.json")
+        guessLanguage(tmpDir.toString) shouldBe Some(Languages.JAVASCRIPT)
+      }
+    }
+
+    "guess `C` for a directory containing .ll (LLVM) file in its root" in {
+      File.usingTemporaryDirectory("oculartests") { tmpDir =>
+        touch(tmpDir / "foobar.ll")
+        guessLanguage(tmpDir.toString) shouldBe Some(Languages.LLVM)
+      }
+    }
+
+    "guess `C` for a directory that does not contain any special file" in {
+      File.usingTemporaryDirectory("oculartests") { tmpDir =>
+        guessLanguage(tmpDir.toString) shouldBe Some(Languages.C)
+      }
+    }
+
+  }
+
+  "LanguageHelper.cpgGeneratorForLanguage" should {
+
+    "select LLVM frontend for directories containing ll files" in {
+      val frontend = cpgGeneratorForLanguage(
+        Languages.LLVM,
+        new LanguageFrontendConfig(),
+        File(".").path
+      )
+      frontend.get.isInstanceOf[LlvmLanguageFrontend] shouldBe true
+    }
+  }
+
+}

--- a/console/src/test/scala/io/shiftleft/console/fixtures/ConsoleFixture.scala
+++ b/console/src/test/scala/io/shiftleft/console/fixtures/ConsoleFixture.scala
@@ -1,0 +1,37 @@
+package io.shiftleft.console.fixtures
+
+import java.nio.file.Path
+
+import better.files.Dsl.mkdir
+import better.files.File
+import io.shiftleft.console.workspacehandling.{Project, ProjectFile, WorkspaceLoader}
+import io.shiftleft.console.{Console, ConsoleConfig, DefaultAmmoniteExecutor, InstallConfig}
+
+object ConsoleFixture {
+  def apply()(fun: (TestConsole, File) => Unit): Unit = {
+    File.usingTemporaryDirectory("console") { workspaceDir =>
+      File.usingTemporaryDirectory("console") { codeDir =>
+        mkdir(codeDir / "dir1")
+        mkdir(codeDir / "dir2")
+        (codeDir / "dir1" / "foo.c")
+          .write("int main(int argc, char **argv) { char *ptr = 0x1 + argv; return argc; }")
+        (codeDir / "dir2" / "bar.c").write("int bar(int x) { return x; }")
+        val console = new TestConsole(workspaceDir.toString)
+        fun(console, codeDir)
+      }
+    }
+  }
+}
+
+object TestWorkspaceLoader extends WorkspaceLoader[Project] {
+  override def createProject(projectFile: ProjectFile, path: Path): Project = Project(projectFile, path)
+}
+
+private class TestConsole(workspaceDir: String) extends Console[Project](DefaultAmmoniteExecutor, TestWorkspaceLoader) {
+  override def config = new ConsoleConfig(
+    install = new InstallConfig(Map("SHIFTLEFT_CONSOLE_INSTALL_DIR" -> workspaceDir))
+  )
+
+  override val cpgGenerator = new TestCpgGenerator(config)
+
+}

--- a/console/src/test/scala/io/shiftleft/console/fixtures/TestCpgGenerator.scala
+++ b/console/src/test/scala/io/shiftleft/console/fixtures/TestCpgGenerator.scala
@@ -1,0 +1,38 @@
+package io.shiftleft.console.fixtures
+
+import java.util.concurrent.LinkedBlockingQueue
+
+import better.files.File
+import io.shiftleft.console.ConsoleConfig
+import io.shiftleft.console.cpgcreation.{CpgGenerator, LanguageFrontend}
+import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
+import io.shiftleft.proto.cpg.Cpg.CpgStruct
+
+class TestCpgGenerator(config: ConsoleConfig) extends CpgGenerator(config) {
+  override def createFrontendByPath(
+      inputPath: String,
+  ): Option[LanguageFrontend] = {
+    Some(new FuzzyCTestingFrontend)
+  }
+
+  override def createFrontendByLanguage(language: String): Option[LanguageFrontend] = {
+    Some(new FuzzyCTestingFrontend)
+  }
+
+  private class FuzzyCTestingFrontend extends LanguageFrontend {
+
+    override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
+      val queue = new LinkedBlockingQueue[CpgStruct.Builder]()
+      val factory =
+        new io.shiftleft.fuzzyc2cpg.output.overflowdb.OutputModuleFactory(outputPath, queue)
+      val fuzzyc = new FuzzyC2Cpg(factory)
+      File(inputPath).list.foreach(println(_))
+      fuzzyc.runAndOutput(Set(inputPath), Set(".c"))
+      Some(outputPath)
+    }
+
+    def isAvailable: Boolean = true
+
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -44,7 +44,7 @@ class Scpg() extends LayerCreator {
       .getOrElse(throw new Exception("Meta node missing."))
 
     val enhancementExecList = createEnhancementExecList(cpg, language)
-    enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
+    enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg, serializeInverse))
     Overlays.appendOverlayName(cpg, Scpg.overlayName)
   }
 


### PR DESCRIPTION
* Make `importCode` available in the base Console, allowing us to also port over tests. This, I believe is the right move because the test code should be closely bundled with the code it is testing
* This now means that wrapper for language modules are available, however, the language module itself can only be used if it is installed. If it is not, the Console will inform the user about it. This will allow us to show Joern users which frontends are available in Joern vs Ocular.