### PR TITLE
reintroduce (revertCounter=2) fix/rewrite of BindingMethodOverridePass

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPass.scala
@@ -17,7 +17,7 @@ class BindingMethodOverridesPass(cpg: Cpg) extends CpgPass(cpg) {
       bindingTable.update((binding.name, binding.signature, typeDecl), binding)
     }
     for (typeDecl <- cpg.typeDecl.toIterator) {
-      val parentTypeDecls = typeDecl._typeViaInheritsFromOut.flatMap{_._typeDeclViaRefOut}.toList
+      val parentTypeDecls = typeDecl._typeViaInheritsFromOut.flatMap { _._typeDeclViaRefOut }.toList
       for (binding <- typeDecl._bindingViaBindsOut) {
         if (!overwritten.contains(binding)) {
           val method = binding._methodViaRefOut.next

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPass.scala
@@ -1,48 +1,54 @@
 package io.shiftleft.semanticcpg.passes
-
+import scala.collection.mutable
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{NodeKeys, nodes}
-import io.shiftleft.passes.{CpgPass, DiffGraph, ParallelIteratorExecutor}
+import io.shiftleft.codepropertygraph.generated.{nodes, NodeKeyNames}
+import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
-import org.apache.logging.log4j.LogManager
+import scala.jdk.CollectionConverters._
 
 class BindingMethodOverridesPass(cpg: Cpg) extends CpgPass(cpg) {
-  import BindingMethodOverridesPass._
+  val overwritten = mutable.HashSet[nodes.Binding]()
+  val bindingTable = scala.collection.mutable.HashMap[(String, String, nodes.TypeDecl), nodes.Binding]()
 
   override def run(): Iterator[DiffGraph] = {
-    val methodIterator = cpg.method.toIterator()
-    new ParallelIteratorExecutor(methodIterator).map(processMethod)
-  }
-
-  private def processMethod(method: nodes.Method): DiffGraph = {
-    val diff = DiffGraph.newBuilder
-    method.start.referencingBinding
-      .toIterator()
-      .foreach(binding => {
-        val typeDecl: Option[nodes.TypeDecl] = binding.start.bindingTypeDecl.headOption()
-        if (typeDecl.isDefined) {
-          val neverOverriddenFlag = isMethodNeverOverridden(typeDecl.get, binding.name, binding.signature)
-          diff.addNodeProperty(
-            binding,
-            NodeKeys.IS_METHOD_NEVER_OVERRIDDEN.name,
-            neverOverriddenFlag.asInstanceOf[AnyRef]
-          )
-        } else {
-          logger.error(
-            "No binding typeDecl found in BindingMethodOverridesPass: " + method.name + " " + method.signature)
+    val diffGraph = DiffGraph.newBuilder
+    for (typeDecl <- cpg.typeDecl.toIterator;
+         binding <- typeDecl.bindsOut.asScala) {
+      bindingTable.update((binding.name, binding.signature, typeDecl), binding)
+    }
+    for (typeDecl <- cpg.typeDecl.toIterator) {
+      val parentTypeDecls = typeDecl.inheritsFromOut.asScala.map {
+        _.refOut.next
+      }.toList
+      for (binding <- typeDecl.bindsOut.asScala) {
+        if (!overwritten.contains(binding)) {
+          val method = binding.refOut.next
+          for (parentTypeDecl <- parentTypeDecls) {
+            val parentBinding = bindingTable.get((binding.name, binding.signature, parentTypeDecl))
+            if (parentBinding.isDefined && parentBinding.get.refOut.next != method) {
+              markRecurse(parentBinding.get)
+            }
+          }
         }
-      })
-    diff.build()
+      }
+    }
+    for (typeDecl <- cpg.typeDecl.toIterator;
+         binding <- typeDecl.bindsOut.asScala) {
+      diffGraph.addNodeProperty(node = binding,
+                                key = NodeKeyNames.IS_METHOD_NEVER_OVERRIDDEN,
+                                value = (!overwritten.contains(binding)).asInstanceOf[AnyRef])
+    }
+    return Iterator(diffGraph.build())
   }
 
-  def isMethodNeverOverridden(typeDecl: nodes.TypeDecl, bindingName: String, bindingSignature: String): Boolean = {
-    typeDecl.start.derivedTypeDeclTransitive.methodBinding
-      .filter(_.nameExact(bindingName).signatureExact(bindingSignature))
-      .headOption
-      .isEmpty
+  def markRecurse(binding: nodes.Binding): Unit = {
+    val wasAlreadyOverwritten = overwritten.add(binding)
+    if (wasAlreadyOverwritten) {
+      for (parentType <- binding.bindsIn.next.inheritsFromOut.asScala;
+           parentTypeDecl <- parentType.refOut.asScala;
+           parentBinding <- bindingTable.get((binding.name, binding.signature, parentTypeDecl))) {
+        markRecurse(parentBinding)
+      }
+    }
   }
-}
-
-object BindingMethodOverridesPass {
-  private val logger = LogManager.getLogger(getClass)
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPassTests.scala
@@ -1,0 +1,91 @@
+package io.shiftleft.semanticcpg.passes
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.passes.DiffGraph
+import io.shiftleft.semanticcpg.language._
+import org.scalatest.{Matchers, WordSpec}
+
+class BindingMethodOverridesPassTests extends WordSpec with Matchers {
+  "Binding propagation should not mark non-overwritten bindings" in {
+    val cpg       = Cpg.emptyCpg
+    val diffGraph = DiffGraph.newBuilder
+    val typA      = nodes.NewType(name = "tA", fullName = "typA", typeDeclFullName = "typeDeclA")
+    val typB      = nodes.NewType(name = "tB", fullName = "typB", typeDeclFullName = "typeDeclB")
+    val typeDeclA = nodes.NewTypeDecl(name = "tdA",
+      fullName = "typeDeclA",
+      isExternal = false,
+      inheritsFromTypeFullName = List())
+    val typeDeclB = nodes.NewTypeDecl(name = "tdB",
+      fullName = "typeDeclB",
+      isExternal = false,
+      inheritsFromTypeFullName = List("typA"))
+
+    val bindingA = nodes.NewBinding(name = "name", signature = "signature")
+    val bindingB = nodes.NewBinding(name = "name", signature = "signature")
+    val methodA  = nodes.NewMethod(name = "name", fullName = "fullName", isExternal = false)
+    val methodB  = nodes.NewMethod(name = "name", fullName = "fullNameB", isExternal = false)
+
+    diffGraph.addNode(typA)
+    diffGraph.addNode(typB)
+    diffGraph.addNode(typeDeclA)
+    diffGraph.addNode(typeDeclB)
+    diffGraph.addNode(bindingA)
+    diffGraph.addNode(bindingB)
+    diffGraph.addNode(methodA)
+    diffGraph.addNode(methodB)
+    diffGraph.addEdge(typA, typeDeclA, EdgeTypes.REF)
+    diffGraph.addEdge(typB, typeDeclB, EdgeTypes.REF)
+    diffGraph.addEdge(typeDeclB, typA, EdgeTypes.INHERITS_FROM)
+    diffGraph.addEdge(bindingA, methodA, EdgeTypes.REF)
+    diffGraph.addEdge(typeDeclA, bindingA, EdgeTypes.BINDS)
+    diffGraph.addEdge(bindingB, methodA, EdgeTypes.REF)
+    diffGraph.addEdge(typeDeclB, bindingB, EdgeTypes.BINDS)
+
+    DiffGraph.Applier.applyDiff(diffGraph.build(), cpg)
+    DiffGraph.Applier.applyDiff((new BindingMethodOverridesPass(cpg)).run().next(), cpg)
+    cpg.typeDecl("typeDeclA").methodBinding.head.isMethodNeverOverridden shouldBe Some(true)
+    cpg.typeDecl("typeDeclB").methodBinding.head.isMethodNeverOverridden shouldBe Some(true)
+  }
+
+  "Binding propagation should mark overwritten bindings" in {
+    val cpg       = Cpg.emptyCpg
+    val diffGraph = DiffGraph.newBuilder
+    val typA      = nodes.NewType(name = "tA", fullName = "typA", typeDeclFullName = "typeDeclA")
+    val typB      = nodes.NewType(name = "tB", fullName = "typB", typeDeclFullName = "typeDeclB")
+    val typeDeclA = nodes.NewTypeDecl(name = "tdA",
+      fullName = "typeDeclA",
+      isExternal = false,
+      inheritsFromTypeFullName = List())
+    val typeDeclB = nodes.NewTypeDecl(name = "tdB",
+      fullName = "typeDeclB",
+      isExternal = false,
+      inheritsFromTypeFullName = List("typA"))
+
+    val bindingA = nodes.NewBinding(name = "name", signature = "signature")
+    val bindingB = nodes.NewBinding(name = "name", signature = "signature")
+    val methodA  = nodes.NewMethod(name = "name", fullName = "fullName", isExternal = false)
+    val methodB  = nodes.NewMethod(name = "name", fullName = "fullNameB", isExternal = false)
+
+    diffGraph.addNode(typA)
+    diffGraph.addNode(typB)
+    diffGraph.addNode(typeDeclA)
+    diffGraph.addNode(typeDeclB)
+    diffGraph.addNode(bindingA)
+    diffGraph.addNode(bindingB)
+    diffGraph.addNode(methodA)
+    diffGraph.addNode(methodB)
+    diffGraph.addEdge(typA, typeDeclA, EdgeTypes.REF)
+    diffGraph.addEdge(typB, typeDeclB, EdgeTypes.REF)
+    diffGraph.addEdge(typeDeclB, typA, EdgeTypes.INHERITS_FROM)
+    diffGraph.addEdge(bindingA, methodA, EdgeTypes.REF)
+    diffGraph.addEdge(typeDeclA, bindingA, EdgeTypes.BINDS)
+    diffGraph.addEdge(bindingB, methodB, EdgeTypes.REF)
+    diffGraph.addEdge(typeDeclB, bindingB, EdgeTypes.BINDS)
+
+    DiffGraph.Applier.applyDiff(diffGraph.build(), cpg)
+    DiffGraph.Applier.applyDiff((new BindingMethodOverridesPass(cpg)).run().next(), cpg)
+    cpg.typeDecl("typeDeclA").methodBinding.head.isMethodNeverOverridden shouldBe Some(false)
+    cpg.typeDecl("typeDeclB").methodBinding.head.isMethodNeverOverridden shouldBe Some(true)
+  }
+
+}


### PR DESCRIPTION
CF https://github.com/ShiftLeftSecurity/codepropertygraph/pull/704 https://github.com/ShiftLeftSecurity/codepropertygraph/pull/691

There were doubts about performance (new single-threaded vs old multi-threaded). We currently don't have a benchmarking infrastructure in place, but one example (codescience openxava from sptests):

before:
```
[INFO ] Enhancement io.shiftleft.semanticcpg.passes.BindingMethodOverridesPass completed in 449 milliseconds
```
after:
```
[INFO ] Enhancement io.shiftleft.semanticcpg.passes.BindingMethodOverridesPass completed in 58 milliseconds
```

Don't merge yet, this bugfix is currently blocked by testing infra on the codescience side.