### PR TITLE
refactor schema: nest inNode.name to allow for adding cardinality later

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -87,10 +87,29 @@
 		  "LINE_NUMBER", "COLUMN_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER_END", "ORDER", "FILENAME"],
          "comment" : "A method/function/procedure",
          "is": ["DECLARATION", "CFG_NODE", "AST_NODE"],
-         "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["METHOD_RETURN", "METHOD_PARAMETER_IN",
-                                             "MODIFIER", "BLOCK", "TYPE_PARAMETER"]},
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "METHOD_RETURN", "RETURN", "BLOCK", "UNKNOWN"]}
+         "outEdges": [
+           {"edgeName": "AST",
+            "inNodes": [
+              {"name": "METHOD_RETURN", "cardinality":"1:1"},
+              {"name": "METHOD_PARAMETER_IN"},
+              {"name": "MODIFIER"},
+              {"name": "BLOCK"},
+              {"name": "TYPE_PARAMETER"}
+            ]
+           },
+           {"edgeName": "CFG",
+            "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "METHOD_RETURN"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "UNKNOWN"}
+            ]
+           }
          ]
         },
 

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -74,10 +74,8 @@
          "name": "FILE",
          "keys": ["NAME", "ORDER"],
          "comment": "Node representing a source file. Often also the AST root",
-         "outEdges": [
-             {"edgeName": "AST", "inNodes": ["NAMESPACE_BLOCK"]}
-         ],
-	 "is" : ["AST_NODE"]
+         "outEdges": [{"edgeName": "AST", "inNodes": [{"name": "NAMESPACE_BLOCK"}]}],
+         "is" : ["AST_NODE"]
         },
 
         // Nodes of method declarations
@@ -90,7 +88,7 @@
          "outEdges": [
            {"edgeName": "AST",
             "inNodes": [
-              {"name": "METHOD_RETURN", "cardinality":"1:1"},
+              {"name": "METHOD_RETURN"},
               {"name": "METHOD_PARAMETER_IN"},
               {"name": "MODIFIER"},
               {"name": "BLOCK"},
@@ -137,40 +135,44 @@
          "keys" : ["NAME", "FULL_NAME", "TYPE_DECL_FULL_NAME"],
          "comment" : "A type which always has to reference a type declaration and may have type argument children if the referred to type declaration is a template",
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["TYPE_ARGUMENT"]}
+           {"edgeName": "AST", "inNodes": [{"name":"TYPE_ARGUMENT"}]}
          ]
         },
         {"id" : 46, "name" : "TYPE_DECL",
          "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME", "ALIAS_TYPE_FULL_NAME", "ORDER", "FILENAME"],
          "comment" : "A type declaration",
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["TYPE_PARAMETER", "MEMBER", "MODIFIER"]},
-             {"edgeName": "BINDS", "inNodes": ["BINDING"]},
-             {"edgeName": "VTABLE", "inNodes": ["METHOD"]}
+           {"edgeName": "AST", "inNodes": [
+             {"name": "TYPE_PARAMETER"},
+             {"name": "MEMBER"},
+             {"name": "MODIFIER"}
+           ]},
+           {"edgeName": "BINDS", "inNodes": [{"name":"BINDING"}]},
+           {"edgeName": "VTABLE", "inNodes": [{"name":"METHOD"}]}
          ],
-	 "is" : ["AST_NODE"]
+         "is" : ["AST_NODE"]
         },
         {"id" : 146, "name" : "BINDING",
          "keys" : ["NAME", "SIGNATURE"],
          "comment" : "A binding of a METHOD into a TYPE_DECL",
          "outEdges" : [
-             {"edgeName": "REF", "inNodes": ["METHOD"]}
+           {"edgeName": "REF", "inNodes": [{"name":"METHOD"}]}
          ]
         },
         {"id" : 47, "name" : "TYPE_PARAMETER",
          "keys" : ["NAME", "ORDER"],
          "comment" : "Type parameter of TYPE_DECL or METHOD",
          "outEdges" : [],
-	 "is" : ["AST_NODE"]
+         "is" : ["AST_NODE"]
         },
         {"id" : 48, "name" : "TYPE_ARGUMENT",
          "keys" : ["ORDER"],
          "comment" : "Argument for a TYPE_PARAMETER that belongs to a TYPE. It binds another TYPE to a TYPE_PARAMETER",
          "outEdges" : [
-             {"edgeName": "REF", "inNodes": ["TYPE"]},
-             {"edgeName": "BINDS_TO", "inNodes": ["TYPE_PARAMETER"]}
+             {"edgeName": "REF", "inNodes": [{"name":"TYPE"}]},
+             {"edgeName": "BINDS_TO", "inNodes": [{"name":"TYPE_PARAMETER"}]}
          ],
-	 "is" : ["AST_NODE"]
+         "is" : ["AST_NODE"]
         },
 
         {"id" : 9, "name" : "MEMBER",
@@ -194,7 +196,18 @@
          "comment" : "Literal/Constant",
          "is": ["EXPRESSION"],
          "outEdges" : [
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
+           {"edgeName": "CFG",
+            "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "UNKNOWN"}
+            ]
+           }
          ]
         },
         {"id": 15, "name" : "CALL",
@@ -202,10 +215,43 @@
          "comment" : "A (method)-call",
          "is": ["EXPRESSION", "CALL_REPR"],
          "outEdges" : [
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]},
-             {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "CONTROL_STRUCTURE"]},
-             {"edgeName": "RECEIVER", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "BLOCK", "UNKNOWN"]},
-             {"edgeName": "ARGUMENT", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "BLOCK", "UNKNOWN"]}
+           {"edgeName": "CFG", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "METHOD_REF"},
+             {"name": "RETURN"},
+             {"name": "BLOCK"},
+             {"name": "UNKNOWN"}
+           ]},
+           {"edgeName": "AST", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "METHOD_REF"},
+             {"name": "RETURN"},
+             {"name": "BLOCK"},
+             {"name": "CONTROL_STRUCTURE"}
+           ]},
+           {"edgeName": "RECEIVER", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "METHOD_REF"},
+             {"name": "BLOCK"},
+             {"name": "UNKNOWN"}
+           ]},
+           {"edgeName": "ARGUMENT", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "METHOD_REF"},
+             {"name": "BLOCK"},
+             {"name": "UNKNOWN"}
+           ]}
          ]
         },
         {"id":23, "name" : "LOCAL",
@@ -218,8 +264,21 @@
          "comment" : "An arbitrary identifier/reference",
          "is": ["EXPRESSION", "LOCAL_LIKE"],
          "outEdges" : [
-             {"edgeName": "REF", "inNodes": ["LOCAL", "METHOD_PARAMETER_IN"]},
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "METHOD_RETURN", "RETURN", "BLOCK", "UNKNOWN"]}
+           {"edgeName": "REF", "inNodes": [
+             {"name": "LOCAL"},
+             {"name": "METHOD_PARAMETER_IN"}
+           ]},
+           {"edgeName": "CFG", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "METHOD_REF"},
+             {"name": "METHOD_RETURN"},
+             {"name": "RETURN"},
+             {"name": "BLOCK"},
+             {"name": "UNKNOWN"}
+           ]}
          ]
         },
         {"id":2001081, "name": "FIELD_IDENTIFIER",
@@ -227,7 +286,16 @@
           "comment" : "A node that represents which field is accessed in a <operator>.fieldAccess, in e.g. obj.field. The CODE part is used for human display and matching to MEMBER nodes. The CANONICAL_NAME is used for dataflow tracking; typically both coincide. However, suppose that two fields foo and bar are a C-style union; then CODE refers to whatever the programmer wrote (obj.foo or obj.bar), but both share the same CANONICAL_NAME (e.g. GENERATED_foo_bar)",
           "is": ["EXPRESSION"],
           "outEdges" : [
-            {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
+            {"edgeName": "CFG", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "METHOD_REF"},
+             {"name": "RETURN"},
+             {"name": "BLOCK"},
+             {"name": "UNKNOWN"}
+            ]}
           ]
         },
       {"id":30, "name": "RETURN",
@@ -235,9 +303,26 @@
          "comment" : "A return instruction",
          "is": [ "EXPRESSION"],
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN", "CONTROL_STRUCTURE"]},
-             {"edgeName": "CFG", "inNodes": ["METHOD_RETURN"]},
-             {"edgeName": "ARGUMENT", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
+             {"edgeName": "AST", "inNodes": [
+               {"name": "CALL"},
+               {"name": "IDENTIFIER"},
+               {"name": "LITERAL"},
+               {"name": "METHOD_REF"},
+               {"name": "RETURN"},
+               {"name": "BLOCK"},
+               {"name": "UNKNOWN"},
+               {"name": "CONTROL_STRUCTURE"}
+             ]},
+             {"edgeName": "CFG", "inNodes": [{"name": "METHOD_RETURN"}]},
+             {"edgeName": "ARGUMENT", "inNodes": [
+               {"name": "CALL"},
+               {"name": "IDENTIFIER"},
+               {"name": "LITERAL"},
+               {"name": "METHOD_REF"},
+               {"name": "RETURN"},
+               {"name": "BLOCK"},
+               {"name": "UNKNOWN"}
+             ]}
          ]
         },
         {"id":31, "name": "BLOCK",
@@ -245,8 +330,27 @@
          "comment" : "A structuring block in the AST",
          "is": [ "EXPRESSION"],
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["CALL", "IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "LOCAL", "UNKNOWN", "CONTROL_STRUCTURE"]},
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "UNKNOWN"]}
+             {"edgeName": "AST", "inNodes": [
+               {"name": "CALL"},
+               {"name": "IDENTIFIER"},
+               {"name": "LITERAL"},
+               {"name": "METHOD_REF"},
+               {"name": "RETURN"},
+               {"name": "BLOCK"},
+               {"name": "LOCAL"},
+               {"name": "UNKNOWN"},
+               {"name": "CONTROL_STRUCTURE"}
+             ]},
+             {"edgeName": "CFG", "inNodes": [
+               {"name": "CALL"},
+               {"name": "IDENTIFIER"},
+               {"name": "FIELD_IDENTIFIER"},
+               {"name": "LITERAL"},
+               {"name": "METHOD_REF"},
+               {"name": "RETURN"},
+               {"name": "BLOCK"},
+               {"name": "UNKNOWN"}
+             ]}
          ]
         },
         // METHOD_INST is deprecated.
@@ -254,7 +358,7 @@
          "keys":["NAME", "SIGNATURE", "FULL_NAME", "METHOD_FULL_NAME", "ORDER"],
          "comment":"A method instance which always has to reference a method and may have type argument children if the referred to method is a template",
          "outEdges": [
-             {"edgeName": "AST", "inNodes": ["TYPE_ARGUMENT"]}
+             {"edgeName": "AST", "inNodes": [{"name": "TYPE_ARGUMENT"}]}
          ],
 	 "is" : ["AST_NODE"]
         },
@@ -262,7 +366,7 @@
          "keys":[],
          "outEdges": [],
          "comment" : "Initialization construct for arrays",
-	 "is" : ["AST_NODE"]
+         "is" : ["AST_NODE"]
         },
 
         {"id":333, "name":"METHOD_REF",
@@ -270,7 +374,17 @@
           "comment":"Reference to a method instance",
          "is": ["EXPRESSION"],
           "outEdges": [
-            {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "METHOD_RETURN", "RETURN", "BLOCK", "UNKNOWN"]}
+            {"edgeName": "CFG", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "METHOD_RETURN"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "UNKNOWN"}
+             ]}
           ]
         },
 
@@ -279,10 +393,29 @@
 	 "comment" : "A control structure such as if, while, or for",
 	 "is" : ["EXPRESSION"],
 	 "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["LITERAL",
-                                             "MODIFIER", "ARRAY_INITIALIZER", "CALL", "LOCAL",
-                                             "IDENTIFIER", "RETURN", "BLOCK", "UNKNOWN", "CONTROL_STRUCTURE"]},
-	     {"edgeName" : "CONDITION", "inNodes" : ["LITERAL", "CALL", "IDENTIFIER", "RETURN", "BLOCK", "METHOD_REF", "CONTROL_STRUCTURE", "UNKNOWN", "ARRAY_INITIALIZER"] }
+     {"edgeName": "AST", "inNodes": [
+        {"name": "LITERAL"},
+        {"name": "MODIFIER"},
+        {"name": "ARRAY_INITIALIZER"},
+        {"name": "CALL"},
+        {"name": "LOCAL"},
+        {"name": "IDENTIFIER"},
+        {"name": "RETURN"},
+        {"name": "BLOCK"},
+        {"name": "UNKNOWN"},
+        {"name": "CONTROL_STRUCTURE"}
+     ]},
+	   {"edgeName" : "CONDITION", "inNodes" : [
+        {"name": "LITERAL"},
+        {"name": "CALL"},
+        {"name": "IDENTIFIER"},
+        {"name": "RETURN"},
+        {"name": "BLOCK"},
+        {"name": "METHOD_REF"},
+        {"name": "CONTROL_STRUCTURE"},
+        {"name": "UNKNOWN"},
+        {"name": "ARRAY_INITIALIZER"}
+     ] }
 	 ]
 	},
 
@@ -293,10 +426,30 @@
          "comment" : "A language-specific node",
          "is": ["EXPRESSION"],
          "outEdges" : [
-             {"edgeName": "CFG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "RETURN", "METHOD_REF", "BLOCK", "UNKNOWN"]},
-             {"edgeName": "AST", "inNodes": ["LITERAL", "MEMBER",
-                                             "MODIFIER", "ARRAY_INITIALIZER", "CALL", "LOCAL",
-                                             "IDENTIFIER", "FIELD_IDENTIFIER", "RETURN", "BLOCK", "UNKNOWN", "CONTROL_STRUCTURE"]}
+           {"edgeName": "CFG", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "RETURN"},
+             {"name": "METHOD_REF"},
+             {"name": "BLOCK"},
+             {"name": "UNKNOWN"}
+             ]},
+           {"edgeName": "AST", "inNodes": [
+             {"name": "LITERAL"},
+             {"name": "MEMBER"},
+             {"name": "MODIFIER"},
+             {"name": "ARRAY_INITIALIZER"},
+             {"name": "CALL"},
+             {"name": "LOCAL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "RETURN"},
+             {"name": "BLOCK"},
+             {"name": "UNKNOWN"},
+             {"name": "CONTROL_STRUCTURE"}
+           ]}
          ]
         }
     ],

--- a/codepropertygraph/src/main/resources/schemas/closure.json
+++ b/codepropertygraph/src/main/resources/schemas/closure.json
@@ -7,14 +7,19 @@
   "nodeTypes" : [
     { "name" : "METHOD_REF",
       "outEdges" : [
-        {"edgeName": "CAPTURE", "inNodes": ["CLOSURE_BINDING"]}
+        {"edgeName": "CAPTURE", "inNodes": [
+          {"name": "CLOSURE_BINDING"}
+        ]}
       ]
     },
     {"id":334, "name":"CLOSURE_BINDING",
       "keys": [ "CLOSURE_BINDING_ID", "EVALUATION_STRATEGY", "CLOSURE_ORIGINAL_NAME" ],
       "comment":"Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method",
       "outEdges": [
-        {"edgeName": "REF", "inNodes": ["LOCAL", "METHOD_PARAMETER_IN"]}
+        {"edgeName": "REF", "inNodes": [
+          {"name": "LOCAL"},
+          {"name": "METHOD_PARAMETER_IN"}
+        ]}
       ]
     }
   ],

--- a/codepropertygraph/src/main/resources/schemas/dom.json
+++ b/codepropertygraph/src/main/resources/schemas/dom.json
@@ -5,7 +5,7 @@
 	 "comment" : "A node in a Document Object Model (Tree) as obtained from, e.g., an HTML parser",
 	 "keys" : ["NAME"],	 
 	 "outEdges" : [
-	     {"edgeName" : "AST", "inNodes": ["DOM_NODE"]}
+	   {"edgeName" : "AST", "inNodes": [{"name": "DOM_NODE"}]}
 	 ],
 	 "containedNodes" : [
 	     {"nodeType" : "DOM_ATTRIBUTE", "localName" : "attributes", "cardinality" : "list"}
@@ -18,7 +18,7 @@
 	 "outEdges" : []
 	},
 	{"name" : "CONFIG_FILE",
-	 "outEdges" : [{"edgeName" : "CONTAINS", "inNodes" : ["DOM_NODE"]}]
+	 "outEdges" : [{"edgeName" : "CONTAINS", "inNodes" : [{"name": "DOM_NODE"}]}]
 	}
     ]
 }

--- a/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
@@ -31,7 +31,7 @@
             "keys": ["NAME"],
             "comment": "Indicates the usage of a framework. E.g. java spring. The name key is one of the values from frameworks list",
             "outEdges": [
-                {"edgeName": "ATTACHED_DATA", "inNodes": ["FRAMEWORK_DATA"]}
+              {"edgeName": "ATTACHED_DATA", "inNodes": [{"name": "FRAMEWORK_DATA"}]}
             ]
         },
         // deprecated, c.f. CONFIG_FILE
@@ -47,103 +47,388 @@
 
         {"name" : "METHOD", "keys" : ["HAS_MAPPING", "DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
          "outEdges" : [ 
-           {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-           {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]}
+           {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]},
+           {"edgeName": "DOMINATE", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "METHOD_REF"},
+             {"name": "RETURN"},
+             {"name": "BLOCK"},
+             {"name": "METHOD_RETURN"},
+             {"name": "UNKNOWN"}
+           ]}
          ]
         },
         {"name" : "METHOD_RETURN", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
          "outEdges" : [
-           {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-           {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-           {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]}
+           {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]},
+           {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+             {"name": "TYPE_DECL"},
+             {"name": "METHOD"}
+           ]},
+           {"edgeName": "POST_DOMINATE", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "METHOD_REF"},
+             {"name": "RETURN"},
+             {"name": "BLOCK"},
+             {"name": "METHOD"},
+             {"name": "UNKNOWN"}
+           ]}
         ]},
         {"name" : "LITERAL", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
         "outEdges" : [
-            {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-            {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-            {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]},
-            {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]},
-             {"edgeName": "CDG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]}
+            {"edgeName": "TAGGED_BY", "inNodes": [
+              {"name": "TAG"}
+            ]},
+            {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]},
+            {"edgeName": "DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]},
+            {"edgeName": "POST_DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD"},
+              {"name": "UNKNOWN"}
+            ]},
+            {"edgeName": "CDG", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]}
         ]},
         {"name" : "LOCAL",
          "outEdges" : [
-             {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-             {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]}
+             {"edgeName": "TAGGED_BY", "inNodes": [
+              {"name": "TAG"}
+             ]},
+             {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+             ]}
          ]
         },
         {"name" : "MEMBER", "outEdges" : [
-            {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL"]}
+          {"edgeName": "DYNAMIC_TYPE", "inNodes": [{"name": "TYPE_DECL"}]}
         ]
         },
 
         {"name" : "CALL", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
          "outEdges" : [
-             {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-             {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-             {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]},
-             {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]},
-             {"edgeName": "CDG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]}
+             {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]},
+             {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]},
+             {"edgeName": "DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]},
+             {"edgeName": "POST_DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD"},
+              {"name": "UNKNOWN"}
+            ]},
+             {"edgeName": "CDG", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]}
          ]
         },
         {"name" : "IDENTIFIER", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
         "outEdges" : [
-            {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-            {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-            {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]},
-            {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]},
-             {"edgeName": "CDG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]}
+            {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]},
+            {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]},
+            {"edgeName": "DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]},
+            {"edgeName": "POST_DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD"},
+              {"name": "UNKNOWN"}
+            ]},
+             {"edgeName": "CDG", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]}
         ]},
         {"name" : "FIELD_IDENTIFIER", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
-            "outEdges" : [
-                {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-                {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-                {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]},
-                {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]},
-                {"edgeName": "CDG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]}
+          "outEdges" : [
+            {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]},
+            {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
             ]},
+            {"edgeName": "DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]},
+            {"edgeName": "POST_DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD"},
+              {"name": "UNKNOWN"}
+            ]},
+            {"edgeName": "CDG", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]}
+        ]},
         {"name" : "METHOD_PARAMETER_IN",
          "outEdges" : [
-             {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-             {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-             {"edgeName": "TAINT_REMOVE", "inNodes": ["METHOD_PARAMETER_OUT"]}
+            {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]},
+            {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]},
+             {"edgeName": "TAINT_REMOVE", "inNodes": [{"name": "METHOD_PARAMETER_OUT"}]}
          ]
         },
 
         {"name" : "RETURN", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
-            "outEdges": [
-                {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]},
-                {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]}
-            ]
+          "outEdges": [
+            {"edgeName": "DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]},
+            {"edgeName": "POST_DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD"},
+              {"name": "UNKNOWN"}
+            ]}
+          ]
         },
         {"name" : "BLOCK", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
           "outEdges" : [
-             {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-             {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]},
-             {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]},
-             {"edgeName": "CDG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]}
+             {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]},
+             {"edgeName": "DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]},
+             {"edgeName": "POST_DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD"},
+              {"name": "UNKNOWN"}
+            ]},
+             {"edgeName": "CDG", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]}
           ]
         },
         {"name" : "UNKNOWN", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
          "outEdges" : [
-             {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-             {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-             {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]},
-             {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]},
-             {"edgeName": "CDG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]}
+             {"edgeName": "TAGGED_BY", "inNodes": [
+              {"name": "TAG"}
+            ]},
+             {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]},
+             {"edgeName": "DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]},
+             {"edgeName": "POST_DOMINATE", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD"},
+              {"name": "UNKNOWN"}
+            ]},
+             {"edgeName": "CDG", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "METHOD_REF"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"},
+              {"name": "METHOD_RETURN"},
+              {"name": "UNKNOWN"}
+            ]}
          ]
         },
         {
             "name": "METHOD_REF", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
             "outEdges": [
-                {"edgeName": "DYNAMIC_TYPE", "inNodes": ["TYPE_DECL", "METHOD"]},
-                {"edgeName": "DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]},
-                {"edgeName": "POST_DOMINATE", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD", "UNKNOWN"]},
-                {"edgeName": "CDG", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "METHOD_REF", "RETURN", "BLOCK", "METHOD_RETURN", "UNKNOWN"]}
+              {"edgeName": "DYNAMIC_TYPE", "inNodes": [
+                {"name": "TYPE_DECL"},
+                {"name": "METHOD"}
+              ]},
+              {"edgeName": "DOMINATE", "inNodes": [
+                {"name": "CALL"},
+                {"name": "IDENTIFIER"},
+                {"name": "FIELD_IDENTIFIER"},
+                {"name": "LITERAL"},
+                {"name": "METHOD_REF"},
+                {"name": "RETURN"},
+                {"name": "BLOCK"},
+                {"name": "METHOD_RETURN"},
+                {"name": "UNKNOWN"}
+              ]},
+              {"edgeName": "POST_DOMINATE", "inNodes": [
+                {"name": "CALL"},
+                {"name": "IDENTIFIER"},
+                {"name": "FIELD_IDENTIFIER"},
+                {"name": "LITERAL"},
+                {"name": "METHOD_REF"},
+                {"name": "RETURN"},
+                {"name": "BLOCK"},
+                {"name": "METHOD"},
+                {"name": "UNKNOWN"}
+              ]},
+              {"edgeName": "CDG", "inNodes": [
+                {"name": "CALL"},
+                {"name": "IDENTIFIER"},
+                {"name": "FIELD_IDENTIFIER"},
+                {"name": "LITERAL"},
+                {"name": "METHOD_REF"},
+                {"name": "RETURN"},
+                {"name": "BLOCK"},
+                {"name": "METHOD_RETURN"},
+                {"name": "UNKNOWN"}
+              ]}
             ]
         },
         {
-            "name": "CLOSURE_BINDING", "outEdges": [
-            ]
+            "name": "CLOSURE_BINDING", "outEdges": []
         },
         {
             "id": 1001, "name": "DETACHED_TRACKING_POINT", "comment": "", "keys": [],

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -35,15 +35,35 @@
         },
         {
             "name" : "FILE", "outEdges" : [
-                {"edgeName": "CONTAINS", "inNodes": ["TYPE_DECL", "METHOD"]}
+                {"edgeName": "CONTAINS", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]}
             ]
         },
         { "name": "METHOD",
           "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["TYPE_DECL", "METHOD", "METHOD_PARAMETER_OUT", "IMPLICIT_CALL"]},
-             {"edgeName": "REACHING_DEF", "inNodes": ["CALL", "RETURN"]},
-             {"edgeName": "CONTAINS", "inNodes": ["CALL", "IDENTIFIER", "FIELD_IDENTIFIER", "LITERAL", "RETURN", "METHOD_REF", "BLOCK", "UNKNOWN"]},
-             {"edgeName": "SOURCE_FILE", "inNodes": ["FILE"]}
+             {"edgeName": "AST", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"},
+              {"name": "METHOD_PARAMETER_OUT"},
+              {"name": "IMPLICIT_CALL"}
+            ]},
+             {"edgeName": "REACHING_DEF", "inNodes": [
+              {"name": "CALL"},
+              {"name": "RETURN"}
+            ]},
+             {"edgeName": "CONTAINS", "inNodes": [
+              {"name": "CALL"},
+              {"name": "IDENTIFIER"},
+              {"name": "FIELD_IDENTIFIER"},
+              {"name": "LITERAL"},
+              {"name": "RETURN"},
+              {"name": "METHOD_REF"},
+              {"name": "BLOCK"},
+              {"name": "UNKNOWN"}
+            ]},
+             {"edgeName": "SOURCE_FILE", "inNodes": [{"name": "FILE"}]}
           ]
         },
         { "name" : "BINDING",
@@ -51,15 +71,21 @@
         },
         { "name": "RETURN",
           "outEdges" : [
-             {"edgeName": "REACHING_DEF", "inNodes": ["METHOD_RETURN"]}
+             {"edgeName": "REACHING_DEF", "inNodes": [{"name": "METHOD_RETURN"}]}
           ]
         },
         { "name": "METHOD_PARAMETER_IN",
           "outEdges" : [
-            {"edgeName": "PROPAGATE", "inNodes": ["METHOD_PARAMETER_OUT", "METHOD_RETURN"]},
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]},
-            {"edgeName": "REACHING_DEF", "inNodes": ["CALL", "RETURN"]},
-            {"edgeName": "PARAMETER_LINK", "inNodes": ["METHOD_PARAMETER_OUT"]}
+            {"edgeName": "PROPAGATE", "inNodes": [
+              {"name": "METHOD_PARAMETER_OUT"},
+              {"name": "METHOD_RETURN"}
+            ]},
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
+            {"edgeName": "REACHING_DEF", "inNodes": [
+              {"name": "CALL"},
+              {"name": "RETURN"}
+            ]},
+            {"edgeName": "PARAMETER_LINK", "inNodes": [{"name": "METHOD_PARAMETER_OUT"}]}
           ]
         },
         {"id" : 33, "name" : "METHOD_PARAMETER_OUT",
@@ -67,82 +93,98 @@
          "comment" : "This node represents a formal parameter going towards the caller side",
          "is": ["DECLARATION", "TRACKING_POINT", "AST_NODE"],
          "outEdges" : [
-           {"edgeName": "TAGGED_BY", "inNodes": ["TAG"]},
-           {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+           {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]},
+           {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
          ]
         },
         { "name": "METHOD_RETURN",
           "outEdges" : [
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         },
         {
             "name": "NAMESPACE_BLOCK",
             "outEdges": [
-              {"edgeName": "AST", "inNodes": ["TYPE_DECL", "METHOD"]},
-              {"edgeName": "REF", "inNodes": ["NAMESPACE"]},
-              {"edgeName": "SOURCE_FILE", "inNodes": ["FILE"]}
+              {"edgeName": "AST", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]},
+              {"edgeName": "REF", "inNodes": [{"name": "NAMESPACE"}]},
+              {"edgeName": "SOURCE_FILE", "inNodes": [{"name": "FILE"}]}
             ]
         },
         { "name": "METHOD_REF",
           "outEdges" : [
-            {"edgeName": "REF", "inNodes": ["METHOD"]},
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+            {"edgeName": "REF", "inNodes": [{"name": "METHOD"}]},
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         },
         { "name": "TYPE",
           "outEdges" : [
-             {"edgeName": "REF", "inNodes": ["TYPE_DECL"]}
+             {"edgeName": "REF", "inNodes": [{"name": "TYPE_DECL"}]}
           ]
         },
         { "name": "TYPE_DECL",
           "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["TYPE_DECL", "METHOD"]},
-             {"edgeName": "INHERITS_FROM", "inNodes": ["TYPE"]},
-             {"edgeName": "ALIAS_OF", "inNodes": ["TYPE"]},
-             {"edgeName": "CONTAINS", "inNodes": ["METHOD"]},
-             {"edgeName": "SOURCE_FILE", "inNodes": ["FILE"]}
+             {"edgeName": "AST", "inNodes": [
+              {"name": "TYPE_DECL"},
+              {"name": "METHOD"}
+            ]},
+             {"edgeName": "INHERITS_FROM", "inNodes": [{"name": "TYPE"}]},
+             {"edgeName": "ALIAS_OF", "inNodes": [{"name": "TYPE"}]},
+             {"edgeName": "CONTAINS", "inNodes": [{"name": "METHOD"}]},
+             {"edgeName": "SOURCE_FILE", "inNodes": [{"name": "FILE"}]}
           ]
         },
         { "name": "MEMBER",
           "outEdges" : [
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         },
         {"name" : "LITERAL",
           "outEdges" : [
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         },
         { "name": "CALL",
           "outEdges" : [
-            {"edgeName": "REF", "inNodes": ["MEMBER"]},
-            {"edgeName": "CALL", "inNodes": ["METHOD"]},
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]},
-            {"edgeName": "REACHING_DEF", "inNodes": ["CALL", "RETURN"]}
+            {"edgeName": "REF", "inNodes": [{"name": "MEMBER"}]},
+            {"edgeName": "CALL", "inNodes": [{"name": "METHOD"}]},
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
+            {"edgeName": "REACHING_DEF", "inNodes": [
+              {"name": "CALL"},
+              {"name": "RETURN"}
+            ]}
           ]
         },
         { "name": "LOCAL",
           "outEdges" : [
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]},
-            {"edgeName": "CAPTURED_BY", "inNodes": ["CLOSURE_BINDING"]}
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
+            {"edgeName": "CAPTURED_BY", "inNodes": [{"name": "CLOSURE_BINDING"}]}
           ]
         },
         {"name" : "IDENTIFIER",
           "outEdges" : [
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         },
         {"name" : "BLOCK",
           "outEdges" : [
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]},
-	    {"edgeName": "REACHING_DEF", "inNodes": ["CALL", "RETURN", "BLOCK"]}
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
+	    {"edgeName": "REACHING_DEF", "inNodes": [
+              {"name": "CALL"},
+              {"name": "RETURN"},
+              {"name": "BLOCK"}
+            ]}
           ]
         },
         {"name" : "UNKNOWN",
           "outEdges" : [
-            {"edgeName": "REACHING_DEF", "inNodes": ["CALL", "RETURN"]},
-            {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+            {"edgeName": "REACHING_DEF", "inNodes": [
+              {"name": "CALL"},
+              {"name": "RETURN"}
+            ]},
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         }
     ],

--- a/codepropertygraph/src/main/resources/schemas/java-specific.json
+++ b/codepropertygraph/src/main/resources/schemas/java-specific.json
@@ -13,7 +13,7 @@
          "keys": ["CODE", "NAME", "FULL_NAME", "ORDER"],
          "comment" : "A method annotation",
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["ANNOTATION_PARAMETER_ASSIGN"]}
+             {"edgeName": "AST", "inNodes": [{"name": "ANNOTATION_PARAMETER_ASSIGN"}]}
          ],
           "is" : ["AST_NODE"]
         },
@@ -22,7 +22,12 @@
          "keys" : ["CODE", "ORDER"],
          "comment" : "Assignment of annotation argument to annotation parameter",
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["ANNOTATION_PARAMETER", "ARRAY_INITIALIZER", "ANNOTATION_LITERAL", "ANNOTATION"]}
+           {"edgeName": "AST", "inNodes": [
+            {"name": "ANNOTATION_PARAMETER"},
+            {"name": "ARRAY_INITIALIZER"},
+            {"name": "ANNOTATION_LITERAL"},
+            {"name": "ANNOTATION"}
+          ]}
          ],
           "is" : ["AST_NODE"]
         },
@@ -44,28 +49,28 @@
         {"name" : "ARRAY_INITIALIZER",
          "keys" : ["CODE", "ORDER", "ARGUMENT_INDEX", "COLUMN_NUMBER", "LINE_NUMBER"],
          "outEdges" : [
-             {"edgeName": "AST", "inNodes": ["LITERAL"]},
-             {"edgeName": "EVAL_TYPE", "inNodes": ["TYPE"]}
+            {"edgeName": "AST", "inNodes": [{"name": "LITERAL"}]},
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
          ],
-	 "is" : ["EXPRESSION"]
+         "is" : ["EXPRESSION"]
         },
 
         // Modifications to existing node types
 
         {"name" : "METHOD", "keys" : ["BINARY_SIGNATURE"],
-         "outEdges" : [ {"edgeName": "AST", "inNodes": ["ANNOTATION"]} ]
+         "outEdges" : [ {"edgeName": "AST", "inNodes": [{"name": "ANNOTATION"}]} ]
         },
         {
          "name" : "METHOD_PARAMETER_IN", "keys" : [],
-         "outEdges" : [{"edgeName" : "AST", "inNodes" : ["ANNOTATION"] }]
+         "outEdges" : [ {"edgeName": "AST", "inNodes": [{"name": "ANNOTATION"}]} ]
         },
         {
          "name" : "TYPE_DECL", "keys" : [],
-         "outEdges" : [{"edgeName" : "AST", "inNodes" : ["ANNOTATION"] }]
+         "outEdges" : [ {"edgeName": "AST", "inNodes": [{"name": "ANNOTATION"}]} ]
         },
         {
          "name" : "MEMBER", "keys" : [],
-         "outEdges" : [{"edgeName" : "AST", "inNodes" : ["ANNOTATION"] }]
+         "outEdges" : [ {"edgeName": "AST", "inNodes": [{"name": "ANNOTATION"}]} ]
         },
 
         // Node to store config files.

--- a/codepropertygraph/src/main/resources/schemas/sensitivedata.json
+++ b/codepropertygraph/src/main/resources/schemas/sensitivedata.json
@@ -14,7 +14,7 @@
 	     {"localName" : "members", "nodeType" : "SENSITIVE_MEMBER", "cardinality" : "list"}
 	 ],
 	 "outEdges" : [
-	    {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF", "inNodes" : ["TYPE_DECL"]}
+	   {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF", "inNodes" : [{"name": "TYPE_DECL"}]}
 	 ]
 	},
 	
@@ -23,7 +23,10 @@
 	     {"localName" : "names", "nodeType" : "MATCH_INFO", "cardinality" : "list"}
 	 ],
 	 "outEdges" : [
-	     {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF", "inNodes" : ["TYPE", "MEMBER"]}
+	   {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF", "inNodes" : [
+       {"name": "TYPE"},
+       {"name": "MEMBER"}
+     ]}
 	 ]
 	},
 	{"id" : 54, "name" : "SENSITIVE_VARIABLE", "keys" : ["NAME", "EVAL_TYPE", "CATEGORIES"], "comment" : "",
@@ -32,16 +35,24 @@
 	 ], "outEdges" : [
 	     // "inNodes" : "LOCAL_LIKE" is what I want here, but it is currently necessary
 	     // to enumerate all child classes
-	     {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF", "inNodes" : ["METHOD_PARAMETER_IN", "LOCAL", "IDENTIFIER"] },
-	     {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF_REF", "inNodes" : ["SENSITIVE_REFERENCE"] },
-	     {"edgeName" : "IS_SENSITIVE_DATA_OF_TYPE", "inNodes" : ["SENSITIVE_DATA_TYPE"]}
+	     {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF", "inNodes" : [
+        {"name": "METHOD_PARAMETER_IN"},
+        {"name": "LOCAL"},
+        {"name": "IDENTIFIER"}
+       ] },
+	     {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF_REF", "inNodes" : [{"name": "SENSITIVE_REFERENCE"}] },
+	     {"edgeName" : "IS_SENSITIVE_DATA_OF_TYPE", "inNodes" : [{"name": "SENSITIVE_DATA_TYPE"}]}
 	 ]
 	},
 	{"id" : 55, "name" : "SENSITIVE_REFERENCE", "keys" : [], "comment" : "",
 	 "containedNodes" : [
 	     {"localName" : "ioflows", "nodeType" : "IOFLOW", "cardinality" : "list"}
 	 ], "outEdges" : [
-	   {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF_REF", "inNodes" : ["METHOD_PARAMETER_IN", "LOCAL", "IDENTIFIER"]}
+	   {"edgeName" : "IS_SENSITIVE_DATA_DESCR_OF_REF", "inNodes" : [
+      {"name": "METHOD_PARAMETER_IN"},
+      {"name": "LOCAL"},
+      {"name": "IDENTIFIER"}
+     ]}
 	 ]
 	}
     ],

--- a/codepropertygraph/src/main/resources/schemas/source-specific.json
+++ b/codepropertygraph/src/main/resources/schemas/source-specific.json
@@ -8,7 +8,7 @@
 
 	{"name" : "FILE",
 	 "outEdges" : [
-	  {"edgeName": "AST", "inNodes": ["COMMENT"]}
+	   {"edgeName": "AST", "inNodes": [{"name": "COMMENT"}]}
 	 ]
 	}
     ]

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/KeysFactsImporter.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/KeysFactsImporter.scala
@@ -10,7 +10,9 @@ class KeysFactsImporter extends FactsImporter {
 
   case class NodeKey(name: String, comment: String, valueType: String, cardinality: String)
 
-  case class OutEdgeEntry(edgeName: String, inNodes: List[String])
+  case class OutEdgeEntry(edgeName: String, inNodes: List[InNode])
+
+  case class InNode(name: String, cardinality: Option[String])
 
   case class ContainedNode(nodeType: String, localName: String, cardinality: String)
 
@@ -20,14 +22,11 @@ class KeysFactsImporter extends FactsImporter {
                       is: Option[List[String]],
                       containedNodes: Option[List[ContainedNode]])
 
-  implicit val outEdgeEntryRead: Reads[OutEdgeEntry] =
-    Json.reads[OutEdgeEntry]
-  implicit val containedNodeRead: Reads[ContainedNode] =
-    Json.reads[ContainedNode]
-  implicit val nodeKeysRead: Reads[NodeKey] =
-    Json.reads[NodeKey]
-  implicit val nodeTypesRead: Reads[NodeType] =
-    Json.reads[NodeType]
+  implicit val inNodeRead = Json.reads[InNode]
+  implicit val outEdgeEntryRead: Reads[OutEdgeEntry] = Json.reads[OutEdgeEntry]
+  implicit val containedNodeRead: Reads[ContainedNode] = Json.reads[ContainedNode]
+  implicit val nodeKeysRead: Reads[NodeKey] = Json.reads[NodeKey]
+  implicit val nodeTypesRead: Reads[NodeType] = Json.reads[NodeType]
 
   override def loadFacts: List[KeysFact] = {
     val nodeTypes = allNodeTypesByNodeTypeName

--- a/project/meta-build.sbt
+++ b/project/meta-build.sbt
@@ -1,6 +1,6 @@
 libraryDependencies ++= Seq(
   "com.github.pathikrit" %% "better-files" % "3.8.0",
-  "io.shiftleft" %% "overflowdb-codegen" % "1.7",
+  "io.shiftleft" %% "overflowdb-codegen" % "0.0.0-SNAPSHOT",
 )
 
 resolvers += Resolver.bintrayRepo("shiftleft", "maven")

--- a/project/meta-build.sbt
+++ b/project/meta-build.sbt
@@ -1,6 +1,6 @@
 libraryDependencies ++= Seq(
   "com.github.pathikrit" %% "better-files" % "3.8.0",
-  "io.shiftleft" %% "overflowdb-codegen" % "0.0.0-SNAPSHOT",
+  "io.shiftleft" %% "overflowdb-codegen" % "1.8",
 )
 
 resolvers += Resolver.bintrayRepo("shiftleft", "maven")


### PR DESCRIPTION
the resulting generated nodes are identical

depends on https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/7
re https://github.com/ShiftLeftSecurity/codepropertygraph/pull/567
