### PR TITLE
Documentation/Usability improvements

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -101,6 +101,12 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
     }
   }
 
+  // Provide `.l` on iterators, specifically so
+  // that `cpgs.flatMap($query).l` is possible
+  implicit class ItExtend[X](it: Iterator[X]) {
+    def l: List[X] = it.toList
+  }
+
   implicit def graph: ScalaGraph = cpg.scalaGraph
 
   @Doc(
@@ -322,7 +328,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
         report(s"Error creating project for input path: `$inputPath`")
       }
 
-      frontendCpgOutFileOpt.flatMap { frontendCpgOutFile =>
+      val result = frontendCpgOutFileOpt.flatMap { frontendCpgOutFile =>
         Some(frontend).flatMap { frontend =>
           cpgGenerator
             .runLanguageFrontend(
@@ -337,6 +343,10 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
             }
         }
       }
+      if (result.isDefined) {
+        report("A new project has been created in the workspace for your code. Type `workspace` to inspect it")
+      }
+      result
     }
 
     def apply(

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -344,7 +344,10 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
         }
       }
       if (result.isDefined) {
-        report("A new project has been created in the workspace for your code. Type `workspace` to inspect it")
+        report(
+          """|Code successfully imported. You can now query it using `cpg`.
+             |For an overview of all imported code, type `workspace`.""".stripMargin
+        )
       }
       result
     }

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -235,6 +235,8 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
     """
       |importCode(<inputPath>, [projectName], [namespaces], [language])
       |
+      |Type `importCode` alone to get a list of all supported languages
+      |
       |Import code at `inputPath`. Creates a new project, generates a CPG,
       |and opens the project. Upon success, the CPG can be queried via the `cpg`
       |object. Default overlays are already applied to the newly created CPG.
@@ -270,7 +272,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
       c,
       csharp,
       golang,
-      jar,
+      java,
       javascript,
       llvm,
     )
@@ -278,7 +280,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
     override def toString: String = {
       val cols = List("name", "description", "available")
       val rows = allFrontends.map { frontend =>
-        List(frontend.language, frontend.description, frontend.isAvailable.toString)
+        List(frontend.language.toLowerCase, frontend.description, frontend.isAvailable.toString)
       }
       "\n" + Table(cols, rows).render
     }
@@ -298,7 +300,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
 
     def c: Frontend = new Frontend(Languages.C, "Fuzzy Parser for C/C++")
     def llvm: Frontend = new Frontend(Languages.LLVM, "LLVM Bitcode Frontend")
-    def jar: Frontend = new Frontend(Languages.JAVA, "JVM/Dalvik Bytecode Frontend")
+    def java: Frontend = new Frontend(Languages.JAVA, "Java/Dalvik Bytecode Frontend")
     def golang: Frontend = new Frontend(Languages.GOLANG, "Golang Source Frontend")
     def javascript: Frontend = new Frontend(Languages.JAVASCRIPT, "Javascript Source Frontend")
     def csharp: Frontend = new Frontend(Languages.CSHARP, "C# Source Frontend (Roslyn)")

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -248,6 +248,13 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
       |object. Default overlays are already applied to the newly created CPG.
       |Returns new CPG and ensures that `cpg` now refers to this new CPG.
       |
+      |By default, `importCode` attempts to guess the source language of
+      |the code you provide. You can also specify the source language
+      |manually, by running `importCode.<language>`. For example, `importCode.c`
+      |runs the C/C++ frontend.
+      |
+      |Type `importCode` alone to get an overview of all available language modules.
+      |
       |Parameters:
       |
       |-----------
@@ -288,7 +295,8 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
       val rows = allFrontends.map { frontend =>
         List(frontend.language.toLowerCase, frontend.description, frontend.isAvailable.toString)
       }
-      "\n" + Table(cols, rows).render
+      "Type `importCode.<language>` to run a specific language frontend\n" +
+        "\n" + Table(cols, rows).render
     }
 
     class Frontend(val language: String, val description: String = "") {

--- a/console/src/main/scala/io/shiftleft/console/Help.scala
+++ b/console/src/main/scala/io/shiftleft/console/Help.scala
@@ -17,25 +17,31 @@ object Help {
         case (name, doc) => List(name, doc.short, doc.example)
       }
       .toList ++ List(runRow)
-    format("""
+
+    val header = formatNoQuotes("""
       |Welcome to the interactive help system. Below you find
       |a table of all available top-level commands. To get
       |more detailed help on a specific command, just type
+      |
       |`help.<command>`.
       |
       |Try `help.importCode` to begin with.
       |
-      |""".stripMargin) +
-      "\n" + Table(columnNames, rows.sortBy(_.head)).render
+      |
+      |""".stripMargin)
+    header + "\n" + Table(columnNames, rows.sortBy(_.head)).render
   }
 
   def format(text: String): String = {
-    "\"\"\"" + "\n" +
-      text.stripMargin
-        .split("\n\n")
-        .map(x => WordUtils.wrap(x.replace("\n", " "), width))
-        .mkString("\n\n")
-        .trim + "\"\"\""
+    "\"\"\"" + "\n" + formatNoQuotes(text) + "\"\"\""
+  }
+
+  def formatNoQuotes(text: String) = {
+    text.stripMargin
+      .split("\n\n")
+      .map(x => WordUtils.wrap(x.replace("\n", " "), width))
+      .mkString("\n\n")
+      .trim
   }
 
   private def runRow: List[String] =

--- a/console/src/main/scala/io/shiftleft/console/Help.scala
+++ b/console/src/main/scala/io/shiftleft/console/Help.scala
@@ -17,7 +17,16 @@ object Help {
         case (name, doc) => List(name, doc.short, doc.example)
       }
       .toList ++ List(runRow)
-    "\n" + Table(columnNames, rows.sortBy(_.head)).render
+    format("""
+      |Welcome to the interactive help system. Below you find
+      |a table of all available top-level commands. To get
+      |more detailed help on a specific command, just type
+      |`help.<command>`.
+      |
+      |Try `help.importCode` to begin with.
+      |
+      |""".stripMargin) +
+      "\n" + Table(columnNames, rows.sortBy(_.head)).render
   }
 
   def format(text: String): String = {

--- a/console/src/main/scala/io/shiftleft/console/Help.scala
+++ b/console/src/main/scala/io/shiftleft/console/Help.scala
@@ -19,6 +19,7 @@ object Help {
       .toList ++ List(runRow)
 
     val header = formatNoQuotes("""
+      |
       |Welcome to the interactive help system. Below you find
       |a table of all available top-level commands. To get
       |more detailed help on a specific command, just type

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Workspace.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Workspace.scala
@@ -21,8 +21,18 @@ class Workspace[ProjectType <: Project](var projects: ListBuffer[ProjectType]) {
     * */
   override def toString: String = {
     if (projects.isEmpty) {
+      System.err.println("The workpace is empty. Use `importCode` or `importCpg` to populate it")
       "empty"
     } else {
+      """
+        |Overview of all projects present in your workspace. You can use `open` and `close`
+        |to load and unload projects respectively. `cpgs` allows you to query all projects
+        |at once. `cpg` points to the Code Property Graph of the *selected* project, which is
+        |always the last project in the list. You can select a project by calling `open(name)`
+        |on it, even if it is already open.
+        |
+        | Type `run` to add additional overlays to code property graphs
+        |""".stripMargin
       "\n" + Table(
         columnNames = List("name", "overlays", "inputPath", "open"),
         rows = projects.map(_.toTableRow).toList

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -277,6 +277,13 @@ class ConsoleTests extends WordSpec with Matchers {
     }
   }
 
+  "cpg" should {
+    "provide .help command" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString)
+      console.cpg.help.contains(".all") shouldBe true
+    }
+  }
+
   private def isZipFile(file: File): Boolean = {
     val bytes = file.bytes
     Try {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -16,14 +16,14 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all nodes.
     */
-  @Doc("Start traversal over all nodes.")
+  @Doc("All nodes of the graph")
   def all: NodeSteps[nodes.StoredNode] =
     new NodeSteps(scalaGraph.V.cast[nodes.StoredNode])
 
   /**
     * Traverse to all comments in source-based CPGs.
     * */
-  @Doc("Start traversal over all comments in source-based CPGs.")
+  @Doc("All comments (only available for source-code-based frontends)")
   def comment: NodeSteps[nodes.Comment] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
 
@@ -36,6 +36,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all source files
     */
+  @Doc("All source files")
   def file: NodeSteps[nodes.File] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.FILE).cast[nodes.File])
 
@@ -48,6 +49,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all namespaces, e.g., packages in Java.
     */
+  @Doc("All namespaces")
   def namespace: NodeSteps[nodes.Namespace] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.NAMESPACE).cast[nodes.Namespace])
 
@@ -72,6 +74,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all types, e.g., Set<String>
     */
+  @Doc("All used types")
   def types: NodeSteps[nodes.Type] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TYPE).cast[nodes.Type])
 
@@ -84,6 +87,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all declarations, e.g., Set<T>
     */
+  @Doc("All declarations of types")
   def typeDecl: NodeSteps[nodes.TypeDecl] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TYPE_DECL).cast[nodes.TypeDecl])
 
@@ -96,6 +100,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all methods
     */
+  @Doc("All methods")
   def method: NodeSteps[nodes.Method] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.METHOD).cast[nodes.Method])
 
@@ -108,12 +113,14 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all formal return parameters
     */
+  @Doc("All formal return parameters")
   def methodReturn: NodeSteps[nodes.MethodReturn] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.METHOD_RETURN).cast[nodes.MethodReturn])
 
   /**
     Traverse to all input parameters
     */
+  @Doc("All parameters")
   def parameter: NodeSteps[nodes.MethodParameterIn] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.METHOD_PARAMETER_IN).cast[nodes.MethodParameterIn])
 
@@ -126,6 +133,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all class members
     */
+  @Doc("All members of complex types (e.g., classes/structures)")
   def member: NodeSteps[nodes.Member] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.MEMBER).cast[nodes.Member])
 
@@ -138,6 +146,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all call sites
     */
+  @Doc("All call sites")
   def call: NodeSteps[nodes.Call] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
@@ -151,6 +160,7 @@ class NodeTypeStarters(cpg: Cpg) {
     Traverse to all local variable declarations
 
     */
+  @Doc("All local variables")
   def local: NodeSteps[nodes.Local] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.LOCAL).cast[nodes.Local])
 
@@ -163,6 +173,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all literals (constant strings and numbers provided directly in the code).
     */
+  @Doc("All literals, e.g., numbers or strings")
   def literal: NodeSteps[nodes.Literal] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.LITERAL).cast[nodes.Literal])
 
@@ -175,6 +186,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
     */
+  @Doc("All identifier usages")
   def identifier: NodeSteps[nodes.Identifier] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.IDENTIFIER).cast[nodes.Identifier])
 
@@ -187,6 +199,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     Traverse to all arguments passed to methods
     */
+  @Doc("All arguments (actual parameters)")
   def argument: NodeSteps[nodes.Expression] =
     call.argument
 
@@ -199,6 +212,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Traverse to all return expressions
     */
+  @Doc("All actual return parameters")
   def returns: NodeSteps[nodes.Return] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.RETURN).cast[nodes.Return])
 
@@ -211,12 +225,14 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Traverse to all meta data entries
     */
+  @Doc("Meta data blocks for graph")
   def metaData: NodeSteps[nodes.MetaData] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.META_DATA).cast[nodes.MetaData])
 
   /**
     * Traverse to all method references
     * */
+  @Doc("All method references")
   def methodRef: NodeSteps[nodes.MethodRef] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.METHOD_REF).cast[nodes.MethodRef])
 
@@ -242,6 +258,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
   Traverse to all tags
     */
+  @Doc("All tags")
   def tag: NodeSteps[nodes.Tag] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TAG).cast[nodes.Tag])
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -23,7 +23,7 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
     * Traverse to all comments in source-based CPGs.
     * */
-  @Doc("All comments (only available for source-code-based frontends)")
+  @Doc("All comments in source-based CPGs")
   def comment: NodeSteps[nodes.Comment] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.COMMENT).cast[nodes.Comment])
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -13,11 +13,11 @@ object NodeTypeStarters {
 class NodeTypeStarters(cpg: Cpg) {
   import NodeTypeStarters._
 
-  @Doc("Start new traversal over all assignments")
+  @Doc("All assignments")
   def assignment: NodeSteps[opnodes.Assignment] =
     cpg.call.name(assignmentPattern).map(new opnodes.Assignment(_))
 
-  @Doc("Start new traversal over all arithmetic operations")
+  @Doc("All arithmetic operations")
   def arithmetic: NodeSteps[opnodes.Arithmetic] =
     cpg.call.name(arithmeticPattern).map(new opnodes.Arithmetic(_))
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -182,9 +182,9 @@ class StepsTest extends WordSpec with Matchers {
     "show domain overview" in {
       val cpg = Cpg.emptyCpg
       cpg.help should include(".comment")
-      cpg.help should include("all comments in source-based CPGs")
+      cpg.help should include("All comments in source-based CPGs")
       cpg.help should include(".arithmetic")
-      cpg.help should include("all arithmetic operations")
+      cpg.help should include("All arithmetic operations")
     }
 
     "provide node-specific overview" in {


### PR DESCRIPTION
* tell people how to get a list of all input modules in documentation of `impotCode`
* rename `importCode.jar` to `importCode.java` so that it matches name of module
* toLowerCase for name of language modules in `importCode` overview 
* direct users to `importCode` and to `help.<command>` after running `help`
* direct users to `cpg` and `workspace` after running `importCode`
* in `workspace` help, direct user to `open`/`close` and `run`
* add short doc strings for all node type starters in `semanticcpg`
* `cpgs.flatMap(_.query).toList` =>`cpgs.flatMap(_.query).l`
* improve `importCode` documentation and point out that `importCode.<language>` exists.