### PR TITLE
Allow creation of CPGs from strings in interactive sessions

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.console
 
-import better.files.Dsl.{cp, rm}
+import better.files.Dsl._
 import better.files.File
 import gremlin.scala.{GraphAsScala, ScalaGraph}
 import io.shiftleft.SerializedCpg
@@ -314,7 +314,19 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
       }
     }
 
-    def c: Frontend = new Frontend(Languages.C, "Fuzzy Parser for C/C++")
+    class CFrontend extends Frontend(Languages.C, "Fuzzy Parser for C/C++") {
+      def fromString(str: String): Option[Cpg] = {
+        val dir = File.newTemporaryDirectory("console")
+        val result = Try {
+          (dir / "tmp.c").write(str)
+          apply(dir.path.toString)
+        }.toOption.flatten
+        dir.delete()
+        result
+      }
+    }
+
+    def c: CFrontend = new CFrontend()
     def llvm: Frontend = new Frontend(Languages.LLVM, "LLVM Bitcode Frontend")
     def java: Frontend = new Frontend(Languages.JAVA, "Java/Dalvik Bytecode Frontend")
     def golang: Frontend = new Frontend(Languages.GOLANG, "Golang Source Frontend")


### PR DESCRIPTION
I am creating a few posts to showcase some of our abilities, and it occurred to me that I can stay in the shell if only I can create CPGs from strings quickly. Since this isn't something that works for all frontends, for now, I've made the method specific to the C frontend: `importCode.c.fromString` will allow you to create a CPG from a string.