### PR TITLE
refactor schema: nest inNode.name to allow for adding cardinality later

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "overflowdb-traversal" % "0712770c6b31a02073437374d7c4113e29202806",
+  "io.shiftleft" %% "overflowdb-traversal" % "0.71",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,7 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "overflowdb-traversal" % "0.68",
+  "io.shiftleft" %% "overflowdb-traversal" % "0712770c6b31a02073437374d7c4113e29202806",
   "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
   "com.google.guava" % "guava" % "21.0",
   "org.apache.commons" % "commons-lang3" % "3.5",

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Path.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Path.scala
@@ -3,7 +3,6 @@ package io.shiftleft.dataflowengine.language
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.overflowdb.traversal.help.Table
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.nodemethods.CfgNodeMethods
 
 case class Path(elements: List[nodes.TrackingPoint])
 
@@ -22,7 +21,7 @@ object Path {
           case _: nodes.MethodParameterIn =>
             val paramsPretty = method.parameter.l.sortBy(_.order).map(_.code).mkString(", ")
             s"$methodName($paramsPretty)"
-          case _ => CfgNodeMethods.repr(trackingPoint.cfgNode)
+          case _ => trackingPoint.cfgNode.repr
         }
 
         Array(trackedSymbol, lineNumber, methodName, fileName)

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CpgDataFlowTests.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/CpgDataFlowTests.scala
@@ -3,9 +3,6 @@ package io.shiftleft.dataflowengine.language
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.nodemethods.CfgNodeMethods
-import io.shiftleft.semanticcpg.language.types.expressions.Literal
-import io.shiftleft.semanticcpg.language.types.structure.{Member, Method}
 import org.scalatest.{Matchers, WordSpec}
 
 class CpgDataFlowTests extends WordSpec with Matchers {
@@ -25,13 +22,13 @@ class CpgDataFlowTests extends WordSpec with Matchers {
   protected def flowToResultPairs(path: Path): List[(String, Option[Integer])] = {
     path.elements.map { point =>
       point match {
-        case methodParamIn: nodes.MethodParameterIn => {
+        case _: nodes.MethodParameterIn => {
           val method = point.start.method.head
           val method_name = method.name
           val code = s"$method_name(${method.start.parameter.l.sortBy(_.order).map(_.code).mkString(", ")})"
           (code, point.cfgNode.lineNumber)
         }
-        case _ => (CfgNodeMethods.repr(point.cfgNode), point.cfgNode.lineNumber)
+        case _ => (point.cfgNode.repr, point.cfgNode.lineNumber)
       }
     }
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.language
 
 import gremlin.scala.{BranchCase, BranchOtherwise, GremlinScala, P, Vertex}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.overflowdb.traversal.help
 import io.shiftleft.overflowdb.traversal.help.Doc
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 
@@ -10,6 +11,7 @@ import io.shiftleft.semanticcpg.codedumper.CodeDumper
   *
   * This is the base class for all steps defined on nodes.
   * */
+@help.Traversal(elementType = classOf[nodes.StoredNode])
 class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) extends Steps[NodeType](raw) {
 
   @Doc(
@@ -107,7 +109,7 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
     )
   }
 
-  @Doc("Tags at this node")
+  @Doc("Tags attached to this node")
   def tagList: List[List[nodes.TagBase]] =
     raw.map { taggedNode =>
       taggedNode.tagList

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -2,17 +2,13 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.overflowdb.traversal.help
-import io.shiftleft.overflowdb.traversal.help.Doc
 import io.shiftleft.semanticcpg.language._
 
-@help.Traversal(elementType = classOf[nodes.AstNode])
 class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
 
   /**
     * All nodes of the abstract syntax tree rooted in this node
     * */
-  @Doc("All nodes of the abstract syntax tree")
   def ast: NodeSteps[nodes.AstNode] = node.start.ast
 
   /**
@@ -43,11 +39,7 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
 
   def isBlock: Boolean = node.isInstanceOf[nodes.Block]
 
-  @Doc("Depth of the abstract syntax tree")
-  def depth: Int =
-    depth({ _ =>
-      true
-    }): Int
+  def depth: Int = depth(_ => true)
 
   /**
     * The depth of the AST rooted in this node. Upon walking
@@ -55,7 +47,6 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
     * nodes where `p(node)` is true.
     * */
   def depth(p: nodes.AstNode => Boolean): Int = {
-
     val additionalDepth = if (p(node)) { 1 } else { 0 }
 
     val childDepths = node.start.astChildren.map(_.depth(p)).l

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -1,23 +1,18 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.overflowdb.traversal.help
-import io.shiftleft.overflowdb.traversal.help.Doc
 
-@help.Traversal(elementType = classOf[nodes.CfgNode])
-object CfgNodeMethods {
+class CfgNodeMethods(val node: nodes.CfgNode) extends AnyVal {
 
   /**
     * Textual representation of CFG node
     * */
-  @Doc("Textual representation of CFG node")
-  def repr(cfgNode: nodes.CfgNode): String = {
-    cfgNode match {
+  def repr: String =
+    node match {
       case method: nodes.MethodBase             => method.name
       case methodReturn: nodes.MethodReturnBase => methodReturn.code
       case expr: nodes.Expression               => expr.code
       case call: nodes.ImplicitCallBase         => call.code
     }
-  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
@@ -2,23 +2,18 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes.{Node, StoredNode}
-import io.shiftleft.overflowdb.traversal.help
-import io.shiftleft.overflowdb.traversal.help.Doc
 import io.shiftleft.semanticcpg.language._
 
 import scala.jdk.CollectionConverters._
 
-@help.Traversal(elementType = classOf[nodes.Node])
 class NodeMethods(val node: Node) extends AnyVal {
 
-  @Doc("Human-readable location")
   def location: nodes.NewLocation =
     node match {
       case storedNode: StoredNode => LocationCreator(storedNode)
       case _                      => LocationCreator.emptyLocation("", None)
     }
 
-  @Doc("Tags attached to this node")
   def tagList: List[nodes.TagBase] =
     node match {
       case storedNode: StoredNode =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -27,6 +27,7 @@ import io.shiftleft.semanticcpg.language.dotextension.MethodDot
 import io.shiftleft.semanticcpg.language.nodemethods.{
   AstNodeMethods,
   CallMethods,
+  CfgNodeMethods,
   ExpressionMethods,
   MethodMethods,
   MethodReturnMethods,
@@ -54,6 +55,7 @@ package object language extends operatorextension.Implicits {
   implicit def toExtendedNode(node: Node): NodeMethods = new NodeMethods(node)
   implicit def withMethodMethodsQp(node: nodes.WithinMethod): WithinMethodMethods = new WithinMethodMethods(node)
   implicit def toAstNodeMethods(node: nodes.AstNode): AstNodeMethods = new AstNodeMethods(node)
+  implicit def toCfgNodeMethods(node: nodes.CfgNode): CfgNodeMethods = new CfgNodeMethods(node)
   implicit def toExpressionMethods(node: nodes.Expression): ExpressionMethods = new ExpressionMethods(node)
   implicit def toMethodMethods(node: nodes.Method): MethodMethods = new MethodMethods(node)
   implicit def toMethodReturnMethods(node: nodes.MethodReturn): MethodReturnMethods = new MethodReturnMethods(node)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -2,20 +2,28 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.overflowdb.traversal.help
+import io.shiftleft.overflowdb.traversal.help.Doc
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.language._
 
+@help.Traversal(elementType = classOf[nodes.AstNode])
 class AstNode[A <: nodes.AstNode](val wrapped: NodeSteps[A]) extends AnyVal {
   private def raw: GremlinScala[A] = wrapped.raw
 
   /**
     * Nodes of the AST rooted in this node, including the node itself.
     * */
+  @Doc("All nodes of the abstract syntax tree")
   def ast: NodeSteps[nodes.AstNode] =
     new NodeSteps(raw.emit.repeat(_.out(EdgeTypes.AST)).cast[nodes.AstNode])
 
   def containsCallTo(regex: String): NodeSteps[A] =
     wrapped.where(_.ast.isCall.name(regex).size > 0)
+
+  @Doc("Depth of the abstract syntax tree")
+  def depth: Steps[Int] =
+    wrapped.map(_.depth)
 
   def depth(p: nodes.AstNode => Boolean): Steps[Int] =
     wrapped.map(_.depth(p))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -2,11 +2,22 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.overflowdb.traversal.help
+import io.shiftleft.overflowdb.traversal.help.Doc
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.utils.ExpandTo
 
+@help.Traversal(elementType = classOf[nodes.CfgNode])
 class CfgNode[A <: nodes.CfgNode](val wrapped: NodeSteps[A]) extends AnyVal {
   private def raw: GremlinScala[A] = wrapped.raw
+
+  /**
+    * Textual representation of CFG node
+    * */
+  @Doc("Textual representation of CFG node")
+  def repr: Steps[String] = {
+    wrapped.map(_.repr)
+  }
 
   /**
   Traverse to enclosing method

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -191,6 +191,7 @@ class StepsTest extends WordSpec with Matchers {
       val methodSteps = new Steps[nodes.Method](null)
       methodSteps.help should include("Available steps for Method")
       methodSteps.help should include(".namespace")
+      methodSteps.help should include(".depth") //from AstNode
 
       methodSteps.helpVerbose should include("traversal name")
       methodSteps.helpVerbose should include("io.shiftleft.semanticcpg.language.types.structure.Method")


### PR DESCRIPTION
the resulting generated nodes are identical

part of https://github.com/ShiftLeftSecurity/codepropertygraph/pull/713
depends on https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/7