### PR TITLE
Allow plotting of CFGs from console

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
@@ -8,15 +8,9 @@ object DotAstGenerator {
   def toDotAst[T <: nodes.AstNode](step: NodeSteps[T]): Steps[String] = step.map(dotAst)
 
   def dotAst(astRoot: nodes.AstNode): String = {
-    val sb = new StringBuilder
-    val name = astRoot match {
-      case method: nodes.Method => method.name
-      case _                    => ""
-    }
-    sb.append(s"digraph $name {\n")
+    val sb = Shared.namedGraphBegin(astRoot)
     sb.append(nodesAndEdges(astRoot).mkString("\n"))
-    sb.append("\n}\n")
-    sb.toString
+    Shared.graphEnd(sb)
   }
 
   private def nodesAndEdges(astRoot: nodes.AstNode): List[String] = {
@@ -38,18 +32,4 @@ object DotAstGenerator {
     nodeStrings ++ edgeStrings
   }
 
-  private def stringRepr(vertex: nodes.AstNode): String = {
-    vertex match {
-      case call: nodes.Call               => (call.name, call.code).toString
-      case expr: nodes.Expression         => (expr.label, expr.code).toString
-      case method: nodes.Method           => (method.label, method.name).toString
-      case ret: nodes.MethodReturn        => (ret.label, ret.typeFullName).toString
-      case param: nodes.MethodParameterIn => ("PARAM", param.code).toString
-      case _                              => ""
-    }
-  }
-
-  private def escape(str: String): String = {
-    str.replaceAllLiterally("\"", "\\\"")
-  }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
@@ -21,7 +21,7 @@ object DotAstGenerator {
     val edges = vertices.map(v => (v.getId, v.start.astChildren.where(shouldBeDisplayed).id.l))
 
     val nodeStrings = vertices.map { node =>
-      s""""${node.getId}" [label = "${escape(stringRepr(node))}" ]""".stripMargin
+      s""""${node.getId}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
     }
 
     val edgeStrings = edges.flatMap {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -1,0 +1,20 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
+
+object DotCfgGenerator {
+
+  def toDotCfg[T <: nodes.CfgNode](step: NodeSteps[T]): Steps[String] = step.map(dotCfg)
+
+  def dotCfg(cfgRoot: nodes.CfgNode): String = {
+    val sb = Shared.namedGraphBegin(cfgRoot)
+    sb.append(nodesAndEdges(cfgRoot).mkString("\n"))
+    Shared.graphEnd(sb)
+  }
+
+  private def nodesAndEdges(cfgStartNode: nodes.CfgNode): List[String] = {
+
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -1,20 +1,62 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
+import io.shiftleft.semanticcpg.language._
+import scala.jdk.CollectionConverters._
 
 object DotCfgGenerator {
 
   def toDotCfg[T <: nodes.CfgNode](step: NodeSteps[T]): Steps[String] = step.map(dotCfg)
 
   def dotCfg(cfgRoot: nodes.CfgNode): String = {
-    val sb = Shared.namedGraphBegin(cfgRoot)
-    sb.append(nodesAndEdges(cfgRoot).mkString("\n"))
-    Shared.graphEnd(sb)
+    cfgRoot match {
+      case method: nodes.Method =>
+        val sb = Shared.namedGraphBegin(method)
+        sb.append(nodesAndEdges(method).mkString("\n"))
+        Shared.graphEnd(sb)
+      case _ =>
+        System.err.println("dotCfg only makes sense for methods")
+        ""
+    }
   }
 
-  private def nodesAndEdges(cfgStartNode: nodes.CfgNode): List[String] = {
+  private def nodesAndEdges(methodNode: nodes.Method): List[String] = {
 
+    def shouldBeDisplayed(v: nodes.Node): Boolean = !(
+      v.isInstanceOf[nodes.Literal] ||
+        v.isInstanceOf[nodes.Identifier] ||
+        v.isInstanceOf[nodes.Block]
+    )
+
+    val vertices = methodNode.start.cfgNode.l ++ List(methodNode, methodNode.methodReturn)
+    val verticesToDisplay = vertices.filter(shouldBeDisplayed)
+
+    def visibleNeighbors(v: nodes.CfgNode, visited: List[nodes.StoredNode] = List()): List[nodes.StoredNode] = {
+      if (visited.contains(v)) {
+        List()
+      } else {
+        val children = v._cfgOut().asScala.filter(vertices.contains)
+        val (visible, invisible) = children.partition(shouldBeDisplayed)
+        visible.toList ++ invisible.toList.flatMap { n =>
+          visibleNeighbors(n.asInstanceOf[nodes.CfgNode], visited ++ List(v))
+        }
+      }
+    }
+
+    val edges = verticesToDisplay.map { v =>
+      (v.getId, visibleNeighbors(v).map(_.getId))
+    }
+
+    val nodeStrings = verticesToDisplay.map { node =>
+      s""""${node.getId}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
+    }
+
+    val edgeStrings = edges.flatMap {
+      case (id, childIds) =>
+        childIds.map(childId => s"""  "$id" -> "$childId"  """)
+    }
+
+    nodeStrings ++ edgeStrings
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes
 
 object Shared {
 
-  def namedGraphBegin(root : nodes.AstNode) : StringBuilder = {
+  def namedGraphBegin(root: nodes.AstNode): StringBuilder = {
     val sb = new StringBuilder
     val name = root match {
       case method: nodes.Method => method.name
@@ -14,21 +14,23 @@ object Shared {
   }
 
   def stringRepr(vertex: nodes.AstNode): String = {
-    vertex match {
-      case call: nodes.Call               => (call.name, call.code).toString
-      case expr: nodes.Expression         => (expr.label, expr.code).toString
-      case method: nodes.Method           => (method.label, method.name).toString
-      case ret: nodes.MethodReturn        => (ret.label, ret.typeFullName).toString
-      case param: nodes.MethodParameterIn => ("PARAM", param.code).toString
-      case _                              => ""
-    }
+    escape(
+      vertex match {
+        case call: nodes.Call               => (call.name, call.code).toString
+        case expr: nodes.Expression         => (expr.label, expr.code).toString
+        case method: nodes.Method           => (method.label, method.name).toString
+        case ret: nodes.MethodReturn        => (ret.label, ret.typeFullName).toString
+        case param: nodes.MethodParameterIn => ("PARAM", param.code).toString
+        case _                              => ""
+      }
+    )
   }
 
   private def escape(str: String): String = {
     str.replaceAllLiterally("\"", "\\\"")
   }
 
-  def graphEnd(sb : StringBuilder): String = {
+  def graphEnd(sb: StringBuilder): String = {
     sb.append("\n}\n")
     sb.toString
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
@@ -1,0 +1,36 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.generated.nodes
+
+object Shared {
+
+  def namedGraphBegin(root : nodes.AstNode) : StringBuilder = {
+    val sb = new StringBuilder
+    val name = root match {
+      case method: nodes.Method => method.name
+      case _                    => ""
+    }
+    sb.append(s"digraph $name {\n")
+  }
+
+  def stringRepr(vertex: nodes.AstNode): String = {
+    vertex match {
+      case call: nodes.Call               => (call.name, call.code).toString
+      case expr: nodes.Expression         => (expr.label, expr.code).toString
+      case method: nodes.Method           => (method.label, method.name).toString
+      case ret: nodes.MethodReturn        => (ret.label, ret.typeFullName).toString
+      case param: nodes.MethodParameterIn => ("PARAM", param.code).toString
+      case _                              => ""
+    }
+  }
+
+  private def escape(str: String): String = {
+    str.replaceAllLiterally("\"", "\\\"")
+  }
+
+  def graphEnd(sb : StringBuilder): String = {
+    sb.append("\n}\n")
+    sb.toString
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
@@ -1,43 +1,17 @@
 package io.shiftleft.semanticcpg.language.dotextension
 
-import better.files.File
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.dotgenerator.DotAstGenerator
 import io.shiftleft.semanticcpg.language._
 
-import scala.sys.process.Process
 import scala.language.postfixOps
-import scala.util.{Failure, Success, Try}
-
-trait ImageViewer {
-  def view(pathStr: String): Try[String]
-}
 
 class AstNodeDot[NodeType <: nodes.AstNode](val wrapped: NodeSteps[NodeType]) extends AnyVal {
 
   def dotAst: Steps[String] = DotAstGenerator.toDotAst(wrapped)
 
   def plotDotAst(implicit viewer: ImageViewer): Unit = {
-    wrapped.dotAst.foreach { dotString =>
-      File.usingTemporaryFile("semanticcpg") { dotFile =>
-        File.usingTemporaryFile("semanticcpg") { svgFile =>
-          dotFile.write(dotString)
-          createSvgFile(dotFile, svgFile).toOption.foreach(_ => viewer.view(svgFile.path.toAbsolutePath.toString))
-        }
-      }
-    }
-  }
-
-  private def createSvgFile(in: File, out: File): Try[String] = {
-    Try {
-      Process(Seq("dot", "-Tsvg", in.path.toAbsolutePath.toString, "-o", out.path.toAbsolutePath.toString)).!!
-    } match {
-      case Success(v) => Success(v)
-      case Failure(exc) =>
-        System.err.println("Executing `dot` failed: is `graphviz` installed?")
-        System.err.println(exc)
-        Failure(exc)
-    }
+    Shared.plotAndDisplay(wrapped.dotAst.l, viewer)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
@@ -1,0 +1,15 @@
+package io.shiftleft.semanticcpg.language.dotextension
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.dotgenerator.DotCfgGenerator
+import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
+
+class CfgNodeDot[NodeType <: nodes.CfgNode](val wrapped: NodeSteps[NodeType]) extends AnyVal {
+
+  def dotCfg: Steps[String] = DotCfgGenerator.toDotCfg(wrapped)
+
+  def plotDotCfg(implicit viewer: ImageViewer): Unit = {
+    Shared.plotAndDisplay(wrapped.dotCfg.l, viewer)
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/Shared.scala
@@ -1,0 +1,37 @@
+package io.shiftleft.semanticcpg.language.dotextension
+
+import better.files.File
+
+import scala.sys.process.Process
+import scala.util.{Failure, Success, Try}
+
+trait ImageViewer {
+  def view(pathStr: String): Try[String]
+}
+
+object Shared {
+
+  def plotAndDisplay(dotStrings: List[String], viewer: ImageViewer): Unit = {
+    dotStrings.foreach { dotString =>
+      File.usingTemporaryFile("semanticcpg") { dotFile =>
+        File.usingTemporaryFile("semanticcpg") { svgFile =>
+          dotFile.write(dotString)
+          createSvgFile(dotFile, svgFile).toOption.foreach(_ => viewer.view(svgFile.path.toAbsolutePath.toString))
+        }
+      }
+    }
+  }
+
+  private def createSvgFile(in: File, out: File): Try[String] = {
+    Try {
+      Process(Seq("dot", "-Tsvg", in.path.toAbsolutePath.toString, "-o", out.path.toAbsolutePath.toString)).!!
+    } match {
+      case Success(v) => Success(v)
+      case Failure(exc) =>
+        System.err.println("Executing `dot` failed: is `graphviz` installed?")
+        System.err.println(exc)
+        Failure(exc)
+    }
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -23,7 +23,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
 }
 import io.shiftleft.overflowdb.traversal.Traversal
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
-import io.shiftleft.semanticcpg.language.dotextension.AstNodeDot
+import io.shiftleft.semanticcpg.language.dotextension.{AstNodeDot, CfgNodeDot}
 import io.shiftleft.semanticcpg.language.nodemethods.{
   AstNodeMethods,
   CallMethods,
@@ -221,8 +221,11 @@ package object language extends operatorextension.Implicits {
   // / Call graph extension
 
   //
-  implicit def toMethodDOTForCallGraph[NodeType <: nodes.AstNode](steps: Steps[NodeType]): AstNodeDot[NodeType] =
+  implicit def toAstNodeDot[NodeType <: nodes.AstNode](steps: Steps[NodeType]): AstNodeDot[NodeType] =
     new AstNodeDot(steps)
+
+  implicit def toCfgNodeDot[NodeType <: nodes.CfgNode](steps: Steps[NodeType]): CfgNodeDot[NodeType] =
+    new CfgNodeDot(steps)
 
   implicit def toNodeSteps[NodeType <: nodes.StoredNode](original: Steps[NodeType]): NodeSteps[NodeType] =
     new NodeSteps[NodeType](original.raw)

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGeneratorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGeneratorTests.scala
@@ -1,0 +1,54 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
+import org.scalatest.{Matchers, WordSpec}
+import io.shiftleft.semanticcpg.language._
+
+class DotCfgGeneratorTests extends WordSpec with Matchers {
+
+  private val code =
+    """
+      |int main(int argc, char **argv) {
+      |   int i = 0;
+      |   while(i < 10) {
+      |     printf("Hello World");
+      |     i++;
+      |   }
+      |   return 0;
+      |}
+      |""".stripMargin
+
+  "A CfgDotGenerator" should {
+    CodeToCpgFixture(code) { cpg =>
+      "create a dot graph" in {
+        cpg.method.name("main").dotCfg.l match {
+          case x :: _ =>
+            x.startsWith("digraph main {") shouldBe true
+            x.contains("(<operator>.assignment,i = 0)") shouldBe true
+            x.endsWith("}\n") shouldBe true
+          case _ => fail
+        }
+      }
+
+      "not contain IDENTIFIER nodes" in {
+        cpg.method.name("main").dotCfg.l match {
+          case x :: _ =>
+            x.contains("IDENTIFIER") shouldBe false
+          case _ => fail
+        }
+      }
+
+      "contain seven nodes" in {
+        val dotStr = cpg.method.name("main").dotCfg.head
+        dotStr.split("\n").count(x => x.contains("label")) shouldBe 7
+      }
+
+      "contain seven edges" in {
+        val dotStr = cpg.method.name("main").dotCfg.head
+        dotStr.split("\n").count(x => x.contains("->")) shouldBe 7
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
Allow plotting of condensed forms of control flow graphs via `cpg.method.plotDotCfg`. In the raw graph, all expressions are control flow nodes and we use control flow edges to model inner-expression control flow. This is somewhat redundant because expression ASTs already implicitly define control flow, however, it's shown to be pretty convenient for analyzers, and in particular, our on-demand data flow tracker. For visualization, the raw graph is too verbose though. This plotting utility therefore removes at least identifiers and literals and ensures that edges to literals and identifiers are connected to their next visible neighbors instead.

Resulting graph for a small sample code snippet:
![dotcfg](https://user-images.githubusercontent.com/1379115/81405738-8bed4400-9138-11ea-8677-122a90432eb6.png)
