### PR TITLE
Create working copies of CPGs on open

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
@@ -2,9 +2,16 @@ package io.shiftleft.console.workspacehandling
 
 import java.nio.file.Path
 
+
 import better.files.File
+import better.files.Dsl._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.Overlays
+
+object Project {
+  val workCpgFileName = "cpg.bin.tmp"
+  val persistentCpgFileName = "cpg.bin"
+}
 
 case class ProjectFile(inputPath: String, name: String)
 
@@ -13,6 +20,8 @@ case class ProjectFile(inputPath: String, name: String)
   * @param cpg reference to loaded CPG or None, if the CPG is not loaded
   * */
 case class Project(projectFile: ProjectFile, var path: Path, var cpg: Option[Cpg] = None) {
+
+  import Project._
 
   def name: String = projectFile.name
 
@@ -45,7 +54,13 @@ case class Project(projectFile: ProjectFile, var path: Path, var cpg: Option[Cpg
     * Close project if it is open and do nothing otherwise.
     * */
   def close: Project = {
-    cpg.foreach(_.close)
+    cpg.foreach{ c =>
+      c.close()
+      System.err.println("Turning working copy into new persistent CPG")
+      val workingCopy = path.resolve(workCpgFileName)
+      val persistent = path.resolve(persistentCpgFileName)
+      cp (workingCopy, persistent)
+    }
     cpg = None
     this
   }

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
@@ -2,7 +2,6 @@ package io.shiftleft.console.workspacehandling
 
 import java.nio.file.Path
 
-
 import better.files.File
 import better.files.Dsl._
 import io.shiftleft.codepropertygraph.Cpg
@@ -54,12 +53,12 @@ case class Project(projectFile: ProjectFile, var path: Path, var cpg: Option[Cpg
     * Close project if it is open and do nothing otherwise.
     * */
   def close: Project = {
-    cpg.foreach{ c =>
+    cpg.foreach { c =>
       c.close()
       System.err.println("Turning working copy into new persistent CPG")
       val workingCopy = path.resolve(workCpgFileName)
       val persistent = path.resolve(persistentCpgFileName)
-      cp (workingCopy, persistent)
+      cp(workingCopy, persistent)
     }
     cpg = None
     this

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -275,6 +275,16 @@ class ConsoleTests extends WordSpec with Matchers {
       console.workspace.project("project1").exists(_.cpg.isDefined) shouldBe true
       console.workspace.project("project2").exists(_.cpg.isDefined) shouldBe true
     }
+
+    "copy working copy to persistent copy" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString, "project1")
+      val projectPath = console.project.path
+      console.save
+      val persistentCpgSize = projectPath.resolve("cpg.bin").toFile.length()
+      val workingCpgSize = projectPath.resolve("cpg.bin.tmp").toFile.length()
+      persistentCpgSize shouldBe workingCpgSize
+    }
+
   }
 
   "cpg" should {

--- a/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceManagerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceManagerTests.scala
@@ -82,6 +82,26 @@ class WorkspaceManagerTests extends WordSpec with Matchers {
       }
     }
 
+    "automatically create and open a cpg working copy on open" in {
+      File.usingTemporaryDirectory(tmpDirPrefix) { workspaceFile =>
+        val projectName = "myproject"
+        WorkspaceTests.createFakeProject(workspaceFile, projectName)
+        val manager = new WorkspaceManager[Project](workspaceFile.toString)
+        manager.openProject(projectName, { fileName: String =>
+          fileName.endsWith("cpg.bin.tmp") shouldBe true
+          Some(Cpg.emptyCpg)
+        })
+
+        val project = manager.project(projectName)
+        project match {
+          case Some(p) =>
+            p.path.resolve("cpg.bin").toFile.exists() shouldBe true
+            p.path.resolve("cpg.bin.tmp").toFile.exists() shouldBe true
+          case _ => fail
+        }
+      }
+    }
+
     "allow closing an open project" in {
       File.usingTemporaryDirectory(tmpDirPrefix) { workspaceFile =>
         val projectName = "myproject"


### PR DESCRIPTION
This PR fixes a workflow problem we currently have: when a user does not save the graph on exit, it is left in an inconsistent state on disk. This is because the CPG is just the overflowdb swap file and any nodes/edges that have not been flushed to disk will not be present in this file.

One possibility to fix this problem would be to force a `save` on exit, however, this would mean that the user can't just close a messed up session and start with the last good copy of the CPG, as they would with say a text document or an image file they were editing.

Another possibility is to clone the CPG on open, thereby creating a working copy. On save, we can then overwrite the CPG with the working copy. This PR implements this approach.
