### PR TITLE
Allow TAGGED_BY edges between members and tags

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
@@ -135,8 +135,9 @@
          ]
         },
         {"name" : "MEMBER", "outEdges" : [
-          {"edgeName": "DYNAMIC_TYPE", "inNodes": [{"name": "TYPE_DECL"}]}
-        ]
+          {"edgeName": "DYNAMIC_TYPE", "inNodes": [{"name": "TYPE_DECL"}]},
+	  {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]}
+	]
         },
 
         {"name" : "CALL", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],


### PR DESCRIPTION
The graph doesn't currently support tagging member variables because `TAGGED_BY` edges between members and tags are not allowed. This PR changes this.