### PR TITLE
use facts from validation in schema 1/2

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -91,7 +91,7 @@
               {"name": "METHOD_RETURN", "cardinality":"1:1"},
               {"name": "METHOD_PARAMETER_IN"},
               {"name": "MODIFIER"},
-              {"name": "BLOCK"},
+              {"name": "BLOCK", "cardinality":"1:1"},
               {"name": "TYPE_PARAMETER"}
             ]
            },

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -313,7 +313,9 @@
                {"name": "UNKNOWN"},
                {"name": "CONTROL_STRUCTURE"}
              ]},
-             {"edgeName": "CFG", "inNodes": [{"name": "METHOD_RETURN"}]},
+             {"edgeName": "CFG", "inNodes": [
+               {"name": "METHOD_RETURN", "cardinality": "0-1:1"}
+              ]},
              {"edgeName": "ARGUMENT", "inNodes": [
                {"name": "CALL"},
                {"name": "IDENTIFIER"},

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -156,7 +156,9 @@
          "keys" : ["NAME", "SIGNATURE"],
          "comment" : "A binding of a METHOD into a TYPE_DECL",
          "outEdges" : [
-           {"edgeName": "REF", "inNodes": [{"name":"METHOD"}]}
+           {"edgeName": "REF", "inNodes": [
+            {"name":"METHOD", "cardinality": "n:1"}
+           ]}
          ]
         },
         {"id" : 47, "name" : "TYPE_PARAMETER",

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -289,7 +289,7 @@
           "is": ["EXPRESSION"],
           "outEdges" : [
             {"edgeName": "CFG", "inNodes": [
-             {"name": "CALL"},
+             {"name": "CALL", "cardinality": "n:1"},
              {"name": "IDENTIFIER"},
              {"name": "FIELD_IDENTIFIER"},
              {"name": "LITERAL"},

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -102,7 +102,7 @@
               {"name": "FIELD_IDENTIFIER"},
               {"name": "LITERAL"},
               {"name": "METHOD_REF"},
-              {"name": "METHOD_RETURN"},
+              {"name": "METHOD_RETURN", "cardinality":"n:0-1"},
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "UNKNOWN"}

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -317,12 +317,12 @@
                {"name": "METHOD_RETURN", "cardinality": "0-1:1"}
               ]},
              {"edgeName": "ARGUMENT", "inNodes": [
-               {"name": "CALL"},
-               {"name": "IDENTIFIER"},
-               {"name": "LITERAL"},
-               {"name": "METHOD_REF"},
-               {"name": "RETURN"},
-               {"name": "BLOCK"},
+               {"name": "CALL", "cardinality": "0-1:0-1"},
+               {"name": "IDENTIFIER", "cardinality": "0-1:0-1"},
+               {"name": "LITERAL", "cardinality": "0-1:0-1"},
+               {"name": "METHOD_REF", "cardinality": "0-1:0-1"},
+               {"name": "RETURN", "cardinality": "0-1:0-1"},
+               {"name": "BLOCK", "cardinality": "0-1:0-1"},
                {"name": "UNKNOWN"}
              ]}
          ]

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -236,11 +236,11 @@
              {"name": "CONTROL_STRUCTURE"}
            ]},
            {"edgeName": "RECEIVER", "inNodes": [
-             {"name": "CALL"},
-             {"name": "IDENTIFIER"},
-             {"name": "LITERAL"},
-             {"name": "METHOD_REF"},
-             {"name": "BLOCK"},
+             {"name": "CALL", "cardinality": "0-1:0-1"},
+             {"name": "IDENTIFIER", "cardinality": "0-1:0-1"},
+             {"name": "LITERAL", "cardinality": "0-1:0-1"},
+             {"name": "METHOD_REF", "cardinality": "0-1:0-1"},
+             {"name": "BLOCK", "cardinality": "0-1:0-1"},
              {"name": "UNKNOWN"}
            ]},
            {"edgeName": "ARGUMENT", "inNodes": [

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -265,8 +265,8 @@
          "is": ["EXPRESSION", "LOCAL_LIKE"],
          "outEdges" : [
            {"edgeName": "REF", "inNodes": [
-             {"name": "LOCAL"},
-             {"name": "METHOD_PARAMETER_IN"}
+             {"name": "LOCAL", "cardinality":"n:0-1"},
+             {"name": "METHOD_PARAMETER_IN", "cardinality":"n:0-1"}
            ]},
            {"edgeName": "CFG", "inNodes": [
              {"name": "CALL"},

--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -102,7 +102,7 @@
               {"name": "FIELD_IDENTIFIER"},
               {"name": "LITERAL"},
               {"name": "METHOD_REF"},
-              {"name": "METHOD_RETURN", "cardinality":"n:0-1"},
+              {"name": "METHOD_RETURN", "cardinality":"0-1:0-1"},
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "UNKNOWN"}
@@ -289,7 +289,7 @@
           "is": ["EXPRESSION"],
           "outEdges" : [
             {"edgeName": "CFG", "inNodes": [
-             {"name": "CALL", "cardinality": "n:1"},
+             {"name": "CALL", "cardinality": "0-1:1"},
              {"name": "IDENTIFIER"},
              {"name": "FIELD_IDENTIFIER"},
              {"name": "LITERAL"},

--- a/codepropertygraph/src/main/resources/schemas/closure.json
+++ b/codepropertygraph/src/main/resources/schemas/closure.json
@@ -17,7 +17,7 @@
       "comment":"Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method",
       "outEdges": [
         {"edgeName": "REF", "inNodes": [
-          {"name": "LOCAL"},
+          {"name": "LOCAL", "cardinality": "n:1"},
           {"name": "METHOD_PARAMETER_IN"}
         ]}
       ]

--- a/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
@@ -66,7 +66,7 @@
            {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]},
            {"edgeName": "DYNAMIC_TYPE", "inNodes": [
              {"name": "TYPE_DECL"},
-             {"name": "METHOD"}
+             {"name": "METHOD", "cardinality": "n:0-1"}
            ]},
            {"edgeName": "POST_DOMINATE", "inNodes": [
              {"name": "CALL"},

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodReturnMethods.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes
 
 class MethodReturnMethods(val node: nodes.MethodReturn) extends AnyVal {
 
-  def toReturn: Iterator[nodes.Return] =
+  def toReturn: Option[nodes.Return] =
     node._returnViaCfgIn
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturn.scala
@@ -33,7 +33,5 @@ class MethodReturn(val wrapped: NodeSteps[nodes.MethodReturn]) extends AnyVal {
     new NodeSteps(raw.out(EdgeTypes.EVAL_TYPE).cast[nodes.Type])
 
   def toReturn: NodeSteps[nodes.Return] =
-    new NodeSteps(raw.flatMap { mr =>
-      __(mr.toReturn.toSeq: _*)
-    })
+    new NodeSteps(raw.map(_.toReturn).collect { case Some(ret) => ret })
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPass.scala
@@ -20,10 +20,10 @@ class BindingMethodOverridesPass(cpg: Cpg) extends CpgPass(cpg) {
       val parentTypeDecls = typeDecl._typeViaInheritsFromOut.flatMap { _._typeDeclViaRefOut }.toList
       for (binding <- typeDecl._bindingViaBindsOut) {
         if (!overwritten.contains(binding)) {
-          val method = binding._methodViaRefOut.next
+          val method = binding._methodViaRefOut.get
           for (parentTypeDecl <- parentTypeDecls) {
             val parentBinding = bindingTable.get((binding.name, binding.signature, parentTypeDecl))
-            if (parentBinding.isDefined && parentBinding.get._methodViaRefOut.next != method) {
+            if (parentBinding.isDefined && parentBinding.get._methodViaRefOut.get != method) {
               markRecurse(parentBinding.get)
             }
           }


### PR DESCRIPTION
part 1/2 is driven by https://github.com/ShiftLeftSecurity/codepropertygraph/blob/master/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/OutFactsImporter.scala

each cardinality is handled in a separate commit - only a few required code changes