### PR TITLE
Modify LayerCreatorAPI to allow passing of options by user

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
@@ -3,28 +3,28 @@ package io.shiftleft.dataflowengine.layers.dataflows
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengine.passes.propagateedges.PropagateEdgePass
 import io.shiftleft.dataflowengine.passes.reachingdef.ReachingDefPass
-import io.shiftleft.dataflowengine.semanticsloader.Semantics
+import io.shiftleft.dataflowengine.semanticsloader.{Semantics, SemanticsLoader}
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
 object OssDataFlow {
   val overlayName: String = "dataflowOss"
   val description: String = "Layer to support the OSS lightweight data flow tracker"
+
+  def defaultOpts = new OssDataFlowOptions(null)
 }
 
-class OssDataFlowOptions(val semantics: Semantics) extends LayerCreatorOptions {}
+class OssDataFlowOptions(var semanticsFilename: String) extends LayerCreatorOptions {}
 
-class OssDataFlow() extends LayerCreator {
+class OssDataFlow(optionFunc: () => LayerCreatorOptions) extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description
 
-  override def create(context: LayerCreatorContext,
-                      options: Option[LayerCreatorOptions],
-                      serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
     val cpg = context.cpg
     val serializedCpg = context.serializedCpg
-    val opts = options.asInstanceOf[Option[OssDataFlowOptions]]
-    val semantics = opts.map(_.semantics).orNull
+    val opts = optionFunc().asInstanceOf[OssDataFlowOptions]
+    val semantics = new SemanticsLoader(opts.semanticsFilename).load()
     val enhancementExecList = Iterator(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
     enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
   }

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
@@ -4,7 +4,6 @@ import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengine.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
-import io.shiftleft.dataflowengine.semanticsloader.SemanticsLoader
 import io.shiftleft.semanticcpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
 
 object DataFlowCodeToCpgFixture {
@@ -17,9 +16,8 @@ object DataFlowCodeToCpgFixture {
   private def passes(cpg: Cpg): Unit = {
     val context = new LayerCreatorContext(cpg, new SerializedCpg())
     new Scpg().run(context)
-    val semantics = new SemanticsLoader("dataflowengine/src/test/resources/default.semantics").load()
-    val options = new OssDataFlowOptions(semantics)
-    new OssDataFlow().run(context, Some(options))
+    val options = new OssDataFlowOptions("dataflowengine/src/test/resources/default.semantics")
+    new OssDataFlow(() => options).run(context)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
@@ -13,9 +13,7 @@ abstract class LayerCreator {
   val description: String
   val dependsOn: List[String] = List()
 
-  def run(context: LayerCreatorContext,
-          options: Option[LayerCreatorOptions] = None,
-          serializeInverse: Boolean = false): Unit = {
+  def run(context: LayerCreatorContext, serializeInverse: Boolean = false): Unit = {
     val appliedOverlays = Overlays.appliedOverlays(context.cpg).toSet
     if (!dependsOn.toSet.subsetOf(appliedOverlays)) {
       logger.warn(
@@ -23,13 +21,11 @@ abstract class LayerCreator {
     } else if (appliedOverlays.contains(overlayName)) {
       logger.warn(s"The overlay $overlayName already exists - skipping creation")
     } else {
-      create(context, options, serializeInverse)
+      create(context, serializeInverse)
     }
   }
 
-  def create(context: LayerCreatorContext,
-             options: Option[LayerCreatorOptions],
-             serializeInverse: Boolean = false): Unit
+  def create(context: LayerCreatorContext, serializeInverse: Boolean = false): Unit
 
   /**
     * Heuristically determine if overlay has been

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -28,16 +28,18 @@ import io.shiftleft.semanticcpg.language._
 object Scpg {
   val overlayName: String = "semanticcpg"
   val description: String = "linked code property graph (OSS)"
+
+  def defaultOpts = new LayerCreatorOptions()
 }
 
-class Scpg() extends LayerCreator {
+class Scpg(options: () => LayerCreatorOptions = { () =>
+  null
+}) extends LayerCreator {
 
   override val overlayName: String = Scpg.overlayName
   override val description: String = Scpg.description
 
-  override def create(context: LayerCreatorContext,
-                      options: Option[LayerCreatorOptions],
-                      serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
     val cpg = context.cpg
     val serializedCpg = context.serializedCpg
     val language = cpg.metaData.language


### PR DESCRIPTION
I have been busy creating a sample extension for Ocular/Joern and noticed that we currently had no easy way of passing options to extensions. This also uncovered that running `run.ossdataflow` in `joern` would fail with an NPE because the semantics could not be passed to the analyzer.

This PR fixes this problem. On start of Ocular/Joern, and `opts` object is created with a field for each dynamically determined extension, e.g., there is now `opts.ossdataflow`. Users can set options on the shell before invoking the extension via `run.$extension`.