### PR TITLE
Simplify `LayerCreator` option passing.

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -34,7 +34,7 @@ object Run {
         |""".stripMargin
 
     val membersCode = layerCreatorTypeNames
-      .map { case (varName, typeName) => s"def $varName: Cpg = _runAnalyzer(new $typeName({ () => opts.$varName}))" }
+      .map { case (varName, typeName) => s"def $varName: Cpg = _runAnalyzer(new $typeName(opts.$varName))" }
       .mkString("\n")
 
     val toStringCode =

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
@@ -15,7 +15,7 @@ object OssDataFlow {
 
 class OssDataFlowOptions(var semanticsFilename: String) extends LayerCreatorOptions {}
 
-class OssDataFlow(optionFunc: () => LayerCreatorOptions) extends LayerCreator {
+class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description
@@ -23,7 +23,6 @@ class OssDataFlow(optionFunc: () => LayerCreatorOptions) extends LayerCreator {
   override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
     val cpg = context.cpg
     val serializedCpg = context.serializedCpg
-    val opts = optionFunc().asInstanceOf[OssDataFlowOptions]
     val semantics = new SemanticsLoader(opts.semanticsFilename).load()
     val enhancementExecList = Iterator(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
     enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
@@ -17,7 +17,7 @@ object DataFlowCodeToCpgFixture {
     val context = new LayerCreatorContext(cpg, new SerializedCpg())
     new Scpg().run(context)
     val options = new OssDataFlowOptions("dataflowengine/src/test/resources/default.semantics")
-    new OssDataFlow(() => options).run(context)
+    new OssDataFlow(options).run(context)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -32,9 +32,7 @@ object Scpg {
   def defaultOpts = new LayerCreatorOptions()
 }
 
-class Scpg(options: () => LayerCreatorOptions = { () =>
-  null
-}) extends LayerCreator {
+class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
 
   override val overlayName: String = Scpg.overlayName
   override val description: String = Scpg.description


### PR DESCRIPTION
Improvement over #738:
Just noticed that we do not have to pass in a function which returns options into LayerCreators after all. It's perfectly sufficient if the fields of option objects are mutable, as they need to be anyway to change them on the shell.