### PR TITLE
Fix `importCode` on very large code bases

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -1,21 +1,17 @@
 package io.shiftleft
 
-import java.io.{File, IOException}
-import java.net.{URI, URISyntaxException}
-import java.nio.file.{FileSystem, FileSystems, Files}
-import java.util
-
+import java.io.IOException
 import com.google.protobuf.GeneratedMessageV3
+import better.files._
+import better.files.Dsl._
 
 class SerializedCpg extends AutoCloseable {
 
   /**
     * We allow creating a dummy serialized CPG that does not do anything.
     */
-  private[this] var zipFileSystem: FileSystem = null
-  private[this] var fname: String = null
   private[this] var counter = 0
-  private[this] var bytesWritten = 0
+  private[this] var fname: String = null
 
   /**
     * Create Serialized CPG from existing file. If the file does not exist,
@@ -24,41 +20,20 @@ class SerializedCpg extends AutoCloseable {
   def this(filename: String) {
     this()
     fname = filename
-    initZipFilesystem(filename)
+    mkdirs(File(filename))
   }
 
-  def isEmpty: Boolean = zipFileSystem == null
-
-  @throws[URISyntaxException]
-  @throws[IOException]
-  private[this] def initZipFilesystem(filename: String): Unit = {
-    val env = new util.HashMap[String, String]
-    // This ensures that the file is created if it does not exist
-    env.put("create", "true")
-    val fileUri = new File(filename).toURI
-    val outputUri = new URI("jar:" + fileUri.getScheme, null, fileUri.getPath, null)
-    zipFileSystem = FileSystems.newFileSystem(outputUri, env)
-  }
+  def isEmpty: Boolean = fname == null
 
   /**
     * Add overlay graph named `name` to the zip file
     **/
   @throws[IOException]
   def addOverlay(overlay: GeneratedMessageV3, name: String): Unit = {
-
-    if (!isEmpty) {
-      val pathInZip = zipFileSystem.getPath(s"${counter}_${name}")
-      counter += 1
-      val outputStream = Files.newOutputStream(pathInZip)
-      overlay.writeTo(outputStream)
-      outputStream.close()
-    }
-    val bytesUntilFlush = 500000;
-    bytesWritten += overlay.getSerializedSize
-    if (bytesWritten > bytesUntilFlush) {
-      flush
-      bytesWritten = 0
-    }
+    val outputStream = (File(fname) / s"${counter}_${name}").newOutputStream
+    counter += 1
+    overlay.writeTo(outputStream)
+    outputStream.close()
   }
 
   @throws[IOException]
@@ -68,16 +43,5 @@ class SerializedCpg extends AutoCloseable {
     }
   }
 
-  @throws[IOException]
-  def flush: Unit = {
-    zipFileSystem.close()
-    initZipFilesystem(fname)
-  }
-
-  @throws[IOException]
-  override def close(): Unit = {
-    if (!isEmpty) {
-      zipFileSystem.close()
-    }
-  }
+  override def close(): Unit = {}
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.scala
@@ -8,6 +8,7 @@ import io.shiftleft.proto.cpg.Cpg.{CpgOverlay, CpgStruct, DiffGraph}
 import org.apache.logging.log4j.LogManager
 import java.util.{Collection => JCollection, List => JList}
 
+import better.files.File
 import com.google.protobuf.GeneratedMessageV3
 
 import scala.jdk.CollectionConverters._
@@ -54,22 +55,23 @@ object ProtoCpgLoader {
   def loadDiffGraphs(fileName: String): Try[Iterator[DiffGraph]] =
     loadOverlays(fileName, DiffGraph.parseFrom)
 
-  private def loadOverlays[T <: GeneratedMessageV3](fileName: String, f: InputStream => T): Try[Iterator[T]] =
-    Using(new ZipArchive(fileName)) { zip =>
-      zip.entries
+  private def loadOverlays[T <: GeneratedMessageV3](fileName: String, f: InputStream => T): Try[Iterator[T]] = {
+    Try {
+      File(fileName).list.toList
         .sortWith(compareOverlayPath)
-        .map { path =>
-          val is = Files.newInputStream(path)
+        .map { file =>
+          val is = Files.newInputStream(file.path)
           f(is)
         }
         .iterator
     }
+  }
 
-  private def compareOverlayPath(a: Path, b: Path): Boolean = {
-    val file1Split: Array[String] = a.toString.replace("/", "").split("_")
-    val file2Split: Array[String] = b.toString.replace("/", "").split("_")
+  private def compareOverlayPath(a: File, b: File): Boolean = {
+    val file1Split: Array[String] = a.name.replace("/", "").split("_")
+    val file2Split: Array[String] = b.name.replace("/", "").split("_")
     if (file1Split.length < 2 || file2Split.length < 2)
-      a.toString < b.toString
+      a.name < b.name
     else
       file1Split(0).toInt < file2Split(0).toInt
   }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -105,7 +105,7 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") {
     }
 
   private def withStartEndTimesLogged[A](fun: => A): A = {
-    logger.debug(s"Start of enhancement: $name")
+    logger.info(s"Start of enhancement: $name")
     val startTime = System.currentTimeMillis
     try {
       fun

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCLanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCLanguageFrontend.scala
@@ -19,7 +19,7 @@ case class FuzzyCLanguageFrontend(config: FuzzyCFrontendConfig, rootPath: Path) 
                         outputPath: String = "cpg.bin.zip",
                         namespaces: List[String] = List()): Option[String] = {
     val fuzzyc2cpgsh = rootPath.resolve("fuzzyc2cpg.sh").toString
-    val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
+    val arguments = Seq(inputPath, "--output", outputPath, "--overflowdb") ++ config.cmdLineParams
     runShellCommand(fuzzyc2cpgsh, arguments).map(_ => outputPath)
   }
 

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -10,8 +10,6 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.console.testing._
 import io.shiftleft.semanticcpg.layers.Scpg
 
-import scala.util.Try
-
 class ConsoleTests extends WordSpec with Matchers {
 
   "importCode" should {
@@ -223,14 +221,14 @@ class ConsoleTests extends WordSpec with Matchers {
       console.project.path.resolve("overlays").toFile.list().size shouldBe numOverlayFilesBefore
     }
 
-    "store zip files for each overlay in project" in ConsoleFixture() { (console, codeDir) =>
+    "store directory for each overlay in project" in ConsoleFixture() { (console, codeDir) =>
       console.importCode(codeDir.toString)
       val overlayDir = console.project.path.resolve("overlays")
       overlayDir.toFile.list.toSet shouldBe Set("semanticcpg")
 
       val overlayFiles = overlayDir.toFile.listFiles()
       overlayFiles.foreach { file =>
-        isZipFile(File(file.getPath)) shouldBe true
+        File(file.getPath).isDirectory shouldBe true
       }
     }
   }
@@ -292,13 +290,6 @@ class ConsoleTests extends WordSpec with Matchers {
       console.importCode(codeDir.toString)
       console.cpg.help.contains(".all") shouldBe true
     }
-  }
-
-  private def isZipFile(file: File): Boolean = {
-    val bytes = file.bytes
-    Try {
-      bytes.next() == 'P' && bytes.next() == 'K'
-    }.getOrElse(false)
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -95,8 +95,6 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
   }
 
   override def probe(cpg: Cpg): Boolean = {
-    val methodDecoratorRan = cpg.graph.nodesByLabel(NodeTypes.METHOD_PARAMETER_OUT).hasNext
-    val containsEdgePassRan = cpg.graph.asScala.E.hasLabel(EdgeTypes.CONTAINS).exists()
-    methodDecoratorRan || containsEdgePassRan
+    cpg.graph.nodesByLabel(NodeTypes.METHOD_PARAMETER_OUT).hasNext
   }
 }


### PR DESCRIPTION
- use `--overflowdb` for fuzzyc by default, avoids serialization to proto and back
- remove expensive query that touches all edges in `Scpg::probe`
- ~~avoid memory spike when closing bin.zip for overlays. Apparently, the inverse proto overlays are not written out until `close` is called, and there is no flush method. I added the next best thing: a method that calls close and reopens the filesystem. Related reading: http://mail.openjdk.java.net/pipermail/nio-dev/2012-July/001763.html~~
- do not use zip to store undo information (serializedCpg) and use simple directories instead. It turned out that ZipFileSystem created large memory spikes on close and the zip operation itself is not free either.

**Update**: let me see if we can actually get around zipping. Since the use-case has changed (we are no longer looking to use the zip file to exchange CPGs across systems but only to bundle undo information), we may be fine not zipping at all and writing out directories instead.