### PR TITLE
Use overflowdb by default in `importCode.c`

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCLanguageFrontend.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCLanguageFrontend.scala
@@ -19,7 +19,7 @@ case class FuzzyCLanguageFrontend(config: FuzzyCFrontendConfig, rootPath: Path) 
                         outputPath: String = "cpg.bin.zip",
                         namespaces: List[String] = List()): Option[String] = {
     val fuzzyc2cpgsh = rootPath.resolve("fuzzyc2cpg.sh").toString
-    val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
+    val arguments = Seq(inputPath, "--output", outputPath, "--overflowdb") ++ config.cmdLineParams
     runShellCommand(fuzzyc2cpgsh, arguments).map(_ => outputPath)
   }
 


### PR DESCRIPTION
Part of #741: directly create overflowdb on `importCode.c` instead of first creating a proto.zip CPG and then converting it. This only affects Ocular and Joern.