### PR TITLE
RIP OverlaySP loader

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -43,15 +43,6 @@ object CpgLoader {
   def createIndexes(cpg: Cpg): Unit =
     new CpgLoader().createIndexes(cpg)
 
-  /**
-    * Load and apply overlays from archives to the given CPG.
-    *
-    * @param overlayFilenames filenames of proto archives
-    * @param cpg The CPG to apply overlays to
-    * */
-  def addOverlays(overlayFilenames: Seq[String], cpg: Cpg): Unit =
-    new CpgLoader().addOverlays(overlayFilenames, cpg)
-
   def addDiffGraphs(diffGraphFilenames: Seq[String], cpg: Cpg): Unit =
     new CpgLoader().addDiffGraphs(diffGraphFilenames, cpg)
 
@@ -84,12 +75,6 @@ private class CpgLoader {
 
   def createIndexes(cpg: Cpg): Unit =
     cpg.graph.indexManager.createNodePropertyIndex(NodeKeys.FULL_NAME.name)
-
-  def addOverlays(overlayFilenames: Seq[String], cpg: Cpg): Unit = {
-    overlayFilenames.foreach { overlayFilename =>
-      CpgOverlayLoader.load(overlayFilename, cpg)
-    }
-  }
 
   def addDiffGraphs(diffGraphFilenames: Seq[String], cpg: Cpg): Unit = {
     diffGraphFilenames.foreach { filename =>

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgOverlayLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgOverlayLoader.scala
@@ -21,24 +21,6 @@ import scala.collection.mutable.ArrayBuffer
 private[cpgloading] object CpgOverlayLoader {
   private val logger = LogManager.getLogger(getClass)
 
-  /**
-    * Load overlays stored in the file with the name `filename`.
-    */
-  def load(filename: String, baseCpg: Cpg): Unit = {
-    val applier = new CpgOverlayApplier(baseCpg.graph)
-    ProtoCpgLoader
-      .loadOverlays(filename)
-      .map { overlays =>
-        overlays.foreach(applier.applyDiff)
-      }
-      .recover {
-        case e: IOException =>
-          logger.error("Failed to load overlay from " + filename, e)
-          Nil
-      }
-      .get
-  }
-
   def loadInverse(filename: String, baseCpg: Cpg): Unit = {
     ProtoCpgLoader
       .loadDiffGraphs(filename)


### PR DESCRIPTION
Once https://github.com/ShiftLeftSecurity/codescience/pull/3797 is merged, there are no more components that make use of the old "sp.bin.zip" SP and so we can now remove the corresponding loader code to avoid confusion in the future.