### PR TITLE
Decrease memory usage of SerializedCpg

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -29,9 +29,10 @@ class SerializedCpg extends AutoCloseable {
   @throws[URISyntaxException]
   @throws[IOException]
   private[this] def initZipFilesystem(filename: String): Unit = {
-    val env = new util.HashMap[String, String]
+    val env = new util.HashMap[String, AnyRef]
     // This ensures that the file is created if it does not exist
     env.put("create", "true")
+    env.put("useTempFile", java.lang.Boolean.TRUE)
     val fileUri = new File(filename).toURI
     val outputUri = new URI("jar:" + fileUri.getScheme, null, fileUri.getPath, null)
     zipFileSystem = FileSystems.newFileSystem(outputUri, env)

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
@@ -34,7 +34,7 @@ case class Project(projectFile: ProjectFile, var path: Path, var cpg: Option[Cpg
     File(path.resolve("overlays")).list.map(_.name).toList
   }
 
-  def overlayFiles: List[File] = {
+  def overlayDirs: List[File] = {
     val overlayDir = File(path.resolve("overlays"))
     appliedOverlays.map(o => overlayDir / o)
   }

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/WorkspaceManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/WorkspaceManager.scala
@@ -215,7 +215,7 @@ class WorkspaceManager[ProjectType <: Project](path: String, loader: WorkspaceLo
 
   def projectExistsForCpg(baseCpg: Cpg): Boolean = projectByCpg(baseCpg).isDefined
 
-  def getNextOverlayFilename(baseCpg: Cpg, overlayName: String): String = {
+  def getNextOverlayDirName(baseCpg: Cpg, overlayName: String): String = {
     val project = projectByCpg(baseCpg).get
     val overlayDirectory = File(overlayDirByProjectName(project.name))
 

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -10,8 +10,6 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.console.testing._
 import io.shiftleft.semanticcpg.layers.Scpg
 
-import scala.util.Try
-
 class ConsoleTests extends WordSpec with Matchers {
 
   "importCode" should {
@@ -223,14 +221,14 @@ class ConsoleTests extends WordSpec with Matchers {
       console.project.path.resolve("overlays").toFile.list().size shouldBe numOverlayFilesBefore
     }
 
-    "store zip files for each overlay in project" in ConsoleFixture() { (console, codeDir) =>
+    "store directory for each overlay in project" in ConsoleFixture() { (console, codeDir) =>
       console.importCode(codeDir.toString)
       val overlayDir = console.project.path.resolve("overlays")
       overlayDir.toFile.list.toSet shouldBe Set("semanticcpg")
 
       val overlayFiles = overlayDir.toFile.listFiles()
       overlayFiles.foreach { file =>
-        isZipFile(File(file.getPath)) shouldBe true
+        File(file.getPath).isDirectory shouldBe true
       }
     }
   }
@@ -292,13 +290,6 @@ class ConsoleTests extends WordSpec with Matchers {
       console.importCode(codeDir.toString)
       console.cpg.help.contains(".all") shouldBe true
     }
-  }
-
-  private def isZipFile(file: File): Boolean = {
-    val bytes = file.bytes
-    Try {
-      bytes.next() == 'P' && bytes.next() == 'K'
-    }.getOrElse(false)
   }
 
 }

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.dataflowengine.layers.dataflows
 
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengine.passes.propagateedges.PropagateEdgePass
 import io.shiftleft.dataflowengine.passes.reachingdef.ReachingDefPass
@@ -22,10 +23,11 @@ class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
 
   override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
     val cpg = context.cpg
-    val serializedCpg = context.serializedCpg
+    val serializedCpg = context.outputDir.map(new SerializedCpg(_)).getOrElse(new SerializedCpg())
     val semantics = new SemanticsLoader(opts.semanticsFilename).load()
     val enhancementExecList = Iterator(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
     enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
+    serializedCpg.close()
   }
 
   override def probe(cpg: Cpg): Boolean = {

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.dataflowengine.layers.dataflows
 
-import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengine.passes.propagateedges.PropagateEdgePass
 import io.shiftleft.dataflowengine.passes.reachingdef.ReachingDefPass
-import io.shiftleft.dataflowengine.semanticsloader.{Semantics, SemanticsLoader}
+import io.shiftleft.dataflowengine.semanticsloader.SemanticsLoader
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
 object OssDataFlow {
@@ -23,11 +22,15 @@ class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
 
   override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
     val cpg = context.cpg
-    val serializedCpg = context.outputDir.map(new SerializedCpg(_)).getOrElse(new SerializedCpg())
+
     val semantics = new SemanticsLoader(opts.semanticsFilename).load()
     val enhancementExecList = Iterator(new PropagateEdgePass(cpg, semantics), new ReachingDefPass(cpg))
-    enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg))
-    serializedCpg.close()
+    enhancementExecList.zipWithIndex.foreach {
+      case (pass, index) =>
+        val serializedCpg = initSerializedCpg(context.outputDir, pass.name, index)
+        pass.createApplySerializeAndStore(serializedCpg)
+        serializedCpg.close()
+    }
   }
 
   override def probe(cpg: Cpg): Boolean = {

--- a/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
+++ b/dataflowengine/src/test/scala/io/shiftleft/dataflowengine/language/DataFlowCodeToCpgFixture.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.dataflowengine.language
 
-import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengine.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
@@ -14,7 +13,7 @@ object DataFlowCodeToCpgFixture {
     new CodeToCpgFixture(frontend).buildCpg(sourceCode, passes)(fun)
 
   private def passes(cpg: Cpg): Unit = {
-    val context = new LayerCreatorContext(cpg, new SerializedCpg())
+    val context = new LayerCreatorContext(cpg)
     new Scpg().run(context)
     val options = new OssDataFlowOptions("dataflowengine/src/test/resources/default.semantics")
     new OssDataFlow(options).run(context)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
@@ -1,5 +1,7 @@
 package io.shiftleft.semanticcpg.layers
 
+import better.files.File
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import org.apache.logging.log4j.LogManager
 import io.shiftleft.semanticcpg.Overlays
@@ -21,6 +23,13 @@ abstract class LayerCreator {
       logger.warn(s"The overlay $overlayName already exists - skipping creation")
     } else {
       create(context, serializeInverse)
+    }
+  }
+
+  protected def initSerializedCpg(outputDir: Option[String], passName: String, index: Int): SerializedCpg = {
+    outputDir match {
+      case Some(dir) => new SerializedCpg((File(dir) / s"${index}_$passName").path.toAbsolutePath.toString)
+      case None      => new SerializedCpg()
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.layers
 
-import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import org.apache.logging.log4j.LogManager
 import io.shiftleft.semanticcpg.Overlays
@@ -37,5 +36,5 @@ abstract class LayerCreator {
 
 }
 
-class LayerCreatorContext(val cpg: Cpg, val serializedCpg: SerializedCpg = new SerializedCpg()) {}
+class LayerCreatorContext(val cpg: Cpg, val outputDir: Option[String] = None) {}
 class LayerCreatorOptions()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.semanticcpg.layers
 
 import gremlin.scala.GraphAsScala
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Languages, NodeTypes}
 import io.shiftleft.passes.CpgPass
@@ -39,7 +40,7 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
 
   override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
     val cpg = context.cpg
-    val serializedCpg = context.serializedCpg
+    val serializedCpg = context.outputDir.map(new SerializedCpg(_)).getOrElse(new SerializedCpg())
     val language = cpg.metaData.language
       .headOption()
       .getOrElse(throw new Exception("Meta node missing."))
@@ -47,6 +48,7 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
     val enhancementExecList = createEnhancementExecList(cpg, language)
     enhancementExecList.foreach(_.createApplySerializeAndStore(serializedCpg, serializeInverse))
     Overlays.appendOverlayName(cpg, Scpg.overlayName)
+    serializedCpg.close()
   }
 
   private def createEnhancementExecList(cpg: Cpg, language: String): Iterator[CpgPass] = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
@@ -19,7 +19,7 @@ object CodeToCpgFixture {
     new CodeToCpgFixture(frontend).buildCpg(sourceCode, passes)(fun)
 
   private def createEnhancements(cpg: Cpg): Unit = {
-    val context = new LayerCreatorContext(cpg, new SerializedCpg())
+    val context = new LayerCreatorContext(cpg)
     new Scpg().run(context)
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testfixtures/ExistingCpgFixture.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testfixtures/ExistingCpgFixture.scala
@@ -9,7 +9,7 @@ private class ExistingCpgFixture(projectName: String) {
   private val config = CpgLoaderConfig.withoutOverflow
   private val cpgFilename = s"resources/testcode/cpgs/$projectName/cpg.bin.zip"
   lazy val cpg = CpgLoader.load(cpgFilename, config)
-  val context = new LayerCreatorContext(cpg, new SerializedCpg())
+  val context = new LayerCreatorContext(cpg)
   new Scpg().run(context)
   implicit val graph: Graph = cpg.graph
   lazy val scalaGraph: ScalaGraph = graph

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreatorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreatorTests.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.layers
 
-import io.shiftleft.SerializedCpg
 import io.shiftleft.semanticcpg.Overlays
 import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.{Matchers, WordSpec}
@@ -11,7 +10,7 @@ class EnhancedBaseCreatorTests extends WordSpec with Matchers {
 
     "add name of overlay to metadata field" in {
       val cpg = MockCpg().withMetaData().cpg
-      val context = new LayerCreatorContext(cpg, new SerializedCpg())
+      val context = new LayerCreatorContext(cpg)
       new Scpg().run(context)
       Overlays.appliedOverlays(cpg) shouldBe List(Scpg.overlayName)
     }


### PR DESCRIPTION
This is a replacement for this PR https://github.com/ShiftLeftSecurity/codepropertygraph/commit/4b0da0bfb7f40522668059e3df86a819fad2995f which I ended up reverting. The main problem we were seeing is that the ZipFileSystem encapsulated by `SerializedCpg` cached overlays in RAM until `close` was called. The initial fix was to remove ZipFilesystem altogether and instead, simply write out loose files. Given that we only use these files for undo information in Ocular, this was now an option. However, this meant that deleting projects from the workspace became very slow as many small files needed to be deleted.

This PR brings in an alternative approach: on the one hand, we pass the undocumented option `useTempFile` to ZipFileSystem (see https://stackoverflow.com/questions/23858706/zipping-a-huge-folder-by-using-a-zipfilesystem-results-in-outofmemoryerror) so that ram consumption is no longer unbounded. On the other hand, we keep the zip-approach, but create one zip per pass. That way, we do not have to create one gigantic zip file at the end of layer creation but do so in chunks.

