### PR TITLE
Additional testing for `runAnalyzer`

### DIFF
--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -223,7 +223,7 @@ class ConsoleTests extends WordSpec with Matchers {
       console.project.path.resolve("overlays").toFile.list().size shouldBe numOverlayFilesBefore
     }
 
-    "store directory of zip files each overlay in project" in ConsoleFixture() { (console, codeDir) =>
+    "store directory of zip files for each overlay in project" in ConsoleFixture() { (console, codeDir) =>
       console.importCode(codeDir.toString)
       val overlayParentDir = console.project.path.resolve("overlays")
       overlayParentDir.toFile.list.toSet shouldBe Set("semanticcpg")

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -10,6 +10,8 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.console.testing._
 import io.shiftleft.semanticcpg.layers.Scpg
 
+import scala.util.Try
+
 class ConsoleTests extends WordSpec with Matchers {
 
   "importCode" should {
@@ -221,16 +223,27 @@ class ConsoleTests extends WordSpec with Matchers {
       console.project.path.resolve("overlays").toFile.list().size shouldBe numOverlayFilesBefore
     }
 
-    "store directory for each overlay in project" in ConsoleFixture() { (console, codeDir) =>
+    "store directory of zip files each overlay in project" in ConsoleFixture() { (console, codeDir) =>
       console.importCode(codeDir.toString)
-      val overlayDir = console.project.path.resolve("overlays")
-      overlayDir.toFile.list.toSet shouldBe Set("semanticcpg")
+      val overlayParentDir = console.project.path.resolve("overlays")
+      overlayParentDir.toFile.list.toSet shouldBe Set("semanticcpg")
 
-      val overlayFiles = overlayDir.toFile.listFiles()
-      overlayFiles.foreach { file =>
-        File(file.getPath).isDirectory shouldBe true
+      val overlayDirs = overlayParentDir.toFile.listFiles()
+      overlayDirs.foreach { dir =>
+        File(dir.getPath).isDirectory shouldBe true
+        File(dir.getPath).list.toList.foreach { file =>
+          Try { file.name.split("_").head.toInt }.isSuccess shouldBe true
+          isZipFile(file) shouldBe true
+        }
       }
     }
+  }
+
+  private def isZipFile(file: File): Boolean = {
+    val bytes = file.bytes
+    Try {
+      bytes.next() == 'P' && bytes.next() == 'K'
+    }.getOrElse(false)
   }
 
   "undo" should {


### PR DESCRIPTION
We now store zip files in directories for undo information, but the corresponding test only checked whether directories are successfully created. Improved the test to look at the directory content, verifying that each file name starts with "$number_" and that each file is a zip file.