### PR TITLE
Pass optimization

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -126,7 +126,7 @@ trait CpgPassBase {
   }
 
   protected def withStartEndTimesLogged[A](fun: => A): A = {
-    logger.debug(s"Start of enhancement: $name")
+    logger.info(s"Start of enhancement: $name")
     val startTime = System.currentTimeMillis
     try {
       fun

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -36,7 +36,9 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "") extends CpgPas
     writerThread.setName("Writer")
     writerThread.start()
     try {
-      f(writer)
+      withStartEndTimesLogged {
+        f(writer)
+      }
     } catch {
       case exception: Exception =>
         logger.warn(exception)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewMethodReturn}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, EvaluationStrategies, NodeTypes, nodes}
-import io.shiftleft.passes.{DiffGraph, ParallelCpgPass, ParallelIteratorExecutor}
+import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 
 import scala.jdk.CollectionConverters._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc
 
-import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
-import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 
 /**
@@ -12,34 +11,35 @@ import io.shiftleft.semanticcpg.language._
   * node, this pass creates a `TYPE_DECL` node. The `TYPE_DECL` is
   * considered external.
   */
-class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
+class TypeDeclStubCreator(cpg: Cpg) extends ParallelCpgPass[nodes.Type](cpg) {
 
   private var typeDeclFullNameToNode = Map[String, nodes.TypeDeclBase]()
 
-  override def run(): Iterator[DiffGraph] = {
+  override def init(): Unit = {
+    cpg.typeDecl
+      .sideEffect { typeDecl =>
+        typeDeclFullNameToNode += typeDecl.fullName -> typeDecl
+      }
+      .l()
+  }
+
+  override def partIterator: Iterator[nodes.Type] = cpg.types.iterator
+
+  override def runOnPart(typ: nodes.Type): Option[DiffGraph] = {
     val dstGraph = DiffGraph.newBuilder
 
-    init()
-
-    cpg.graph.V
-      .hasLabel(NodeTypes.TYPE)
-      .sideEffectWithTraverser { traverser =>
-        val typ = traverser.get.asInstanceOf[nodes.Type]
-        typeDeclFullNameToNode.get(typ.fullName) match {
-          case Some(_) =>
-          case None =>
-            val newTypeDecl = createTypeDeclStub(typ.name, typ.fullName)
-            typeDeclFullNameToNode += typ.fullName -> newTypeDecl
-            dstGraph.addNode(newTypeDecl)
-        }
-      }
-      .iterate()
-
-    Iterator(dstGraph.build())
+    typeDeclFullNameToNode.get(typ.fullName) match {
+      case Some(_) =>
+      case None =>
+        val newTypeDecl = createTypeDeclStub(typ.name, typ.fullName)
+        typeDeclFullNameToNode += typ.fullName -> newTypeDecl
+        dstGraph.addNode(newTypeDecl)
+    }
+    Some(dstGraph.build())
   }
 
   private def createTypeDeclStub(name: String, fullName: String): nodes.NewTypeDecl = {
-    new nodes.NewTypeDecl(
+    nodes.NewTypeDecl(
       name,
       fullName,
       isExternal = true,
@@ -49,9 +49,4 @@ class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
     )
   }
 
-  private def init(): Unit = {
-    cpg.typeDecl.sideEffect { typeDecl =>
-      typeDeclFullNameToNode += typeDecl.fullName -> typeDecl
-    }.exec
-  }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.passes.linking.calllinker
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, NodeTypes, nodes}
-import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.passes.{CpgPass, DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.Implicits._
 import org.apache.tinkerpop.gremlin.structure.Direction
@@ -12,18 +12,13 @@ import org.apache.logging.log4j.{LogManager, Logger}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
-class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
+class CallLinker(cpg: Cpg) extends ParallelCpgPass[nodes.Call](cpg) {
 
   import CallLinker._
 
   private val methodFullNameToNode = mutable.Map.empty[String, nodes.StoredNode]
 
-  /**
-    * Main method of enhancement - to be implemented by child class
-    **/
-  override def run(): Iterator[DiffGraph] = {
-    val dstGraph = DiffGraph.newBuilder
-
+  override def init(): Unit = {
     cpg.graph.V
       .hasLabel(NodeTypes.METHOD)
       .sideEffectWithTraverser { traverser =>
@@ -31,17 +26,23 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
         methodFullNameToNode.put(method.fullName, method)
       }
       .iterate()
+  }
 
-    cpg.call.toIterator().foreach { call =>
-      try {
-        linkCall(call, dstGraph)
-      } catch {
-        case exception: Exception =>
-          throw new RuntimeException(exception)
-      }
+  override def partIterator: Iterator[nodes.Call] = cpg.call.toIterator()
+
+  /**
+    * Main method of enhancement - to be implemented by child class
+    **/
+  override def runOnPart(call: nodes.Call): Option[DiffGraph] = {
+    val dstGraph = DiffGraph.newBuilder
+
+    try {
+      linkCall(call, dstGraph)
+    } catch {
+      case exception: Exception =>
+        throw new RuntimeException(exception)
     }
-
-    Iterator(dstGraph.build())
+    Some(dstGraph.build())
   }
 
   private def linkCall(call: nodes.Call, dstGraph: DiffGraph.Builder): Unit = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -30,9 +30,6 @@ class CallLinker(cpg: Cpg) extends ParallelCpgPass[nodes.Call](cpg) {
 
   override def partIterator: Iterator[nodes.Call] = cpg.call.toIterator()
 
-  /**
-    * Main method of enhancement - to be implemented by child class
-    **/
   override def runOnPart(call: nodes.Call): Option[DiffGraph] = {
     val dstGraph = DiffGraph.newBuilder
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/capturinglinker/CapturingLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/capturinglinker/CapturingLinker.scala
@@ -2,48 +2,45 @@ package io.shiftleft.semanticcpg.passes.linking.capturinglinker
 
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.Local
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
-import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import org.apache.logging.log4j.{LogManager, Logger}
+import io.shiftleft.semanticcpg.language._
 
 /**
   *
   * This pass has no other pass as prerequisite.
   */
-class CapturingLinker(cpg: Cpg) extends CpgPass(cpg) {
-  import CapturingLinker.logger
+class CapturingLinker(cpg: Cpg) extends ParallelCpgPass[nodes.Local](cpg) {
 
-  override def run(): Iterator[DiffGraph] = {
+  private val logger: Logger = LogManager.getLogger(classOf[CapturingLinker])
+
+  var idToClosureBinding: Map[String, nodes.ClosureBinding] = Map()
+
+  override def init(): Unit = {
+    idToClosureBinding = cpg.graph.V
+      .hasLabel(NodeTypes.CLOSURE_BINDING)
+      .collect {
+        case closureBinding: nodes.ClosureBinding =>
+          (closureBinding.closureBindingId.get, closureBinding)
+      }
+      .toMap
+  }
+
+  override def partIterator: Iterator[Local] = cpg.local.iterator
+
+  override def runOnPart(local: nodes.Local): Option[DiffGraph] = {
     val dstGraph = DiffGraph.newBuilder
 
-    val idToClosureBinding: Map[String, nodes.ClosureBinding] =
-      cpg.graph.V
-        .hasLabel(NodeTypes.CLOSURE_BINDING)
-        .collect {
-          case closureBinding: nodes.ClosureBinding =>
-            (closureBinding.closureBindingId.get, closureBinding)
-        }
-        .toMap
-
-    cpg.graph.V
-      .hasLabel(NodeTypes.LOCAL)
-      .sideEffect {
-        case local: nodes.Local =>
-          local.closureBindingId.foreach { closureBindingId =>
-            idToClosureBinding.get(closureBindingId) match {
-              case Some(closureBindingNode) =>
-                dstGraph.addEdgeInOriginal(local, closureBindingNode, EdgeTypes.CAPTURED_BY)
-              case None =>
-                logger.error(s"Missing CLOSURE_BINDING node or invalid closureBindingId=$closureBindingId")
-            }
-          }
-        case _ =>
+    local.closureBindingId.foreach { closureBindingId =>
+      idToClosureBinding.get(closureBindingId) match {
+        case Some(closureBindingNode) =>
+          dstGraph.addEdgeInOriginal(local, closureBindingNode, EdgeTypes.CAPTURED_BY)
+        case None =>
+          logger.error(s"Missing CLOSURE_BINDING node or invalid closureBindingId=$closureBindingId")
       }
-      .iterate()
-    Iterator(dstGraph.build())
+    }
+    Some(dstGraph.build())
   }
-}
-
-object CapturingLinker {
-  private val logger: Logger = LogManager.getLogger(classOf[CapturingLinker])
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/filecompat/FileNameCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/filecompat/FileNameCompat.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.passes.linking.filecompat
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 
 /**
@@ -13,22 +13,21 @@ import io.shiftleft.semanticcpg.language._
   * This pass should come after AST edges have been reconstructed, that
   * is, after Linker.  Is used by FileLinker.
   */
-class FileNameCompat(cpg: Cpg) extends CpgPass(cpg) {
-  override def run(): Iterator[DiffGraph] = {
-    val dstGraph = DiffGraph.newBuilder
+class FileNameCompat(cpg: Cpg) extends ParallelCpgPass[nodes.StoredNode with nodes.HasFilename](cpg) {
 
-    def updateDefaultFileName(node: nodes.StoredNode with nodes.HasFilename): Unit = {
-      if (node.filename == null) {
-        node.start.file.name.headOption().foreach { name =>
-          dstGraph.addNodeProperty(node, "FILENAME", name)
-        }
+  override def partIterator: Iterator[nodes.StoredNode with nodes.HasFilename] = {
+    cpg.namespaceBlock.toIterator() ++
+      cpg.typeDecl.toIterator() ++
+      cpg.method.toIterator()
+  }
+
+  override def runOnPart(node: nodes.StoredNode with nodes.HasFilename): Option[DiffGraph] = {
+    val dstGraph = DiffGraph.newBuilder
+    if (node.filename == null) {
+      node.start.file.name.headOption().foreach { name =>
+        dstGraph.addNodeProperty(node, "FILENAME", name)
       }
     }
-
-    cpg.namespaceBlock.toIterator().foreach(updateDefaultFileName)
-    cpg.typeDecl.toIterator().foreach(updateDefaultFileName)
-    cpg.method.toIterator().foreach(updateDefaultFileName)
-
-    Iterator(dstGraph.build())
+    Some(dstGraph.build())
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
@@ -1,12 +1,11 @@
 package io.shiftleft.semanticcpg.passes.methoddecorations
 
-import gremlin.scala._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
-import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
+import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.Cpg
 import org.apache.logging.log4j.{LogManager, Logger}
-import org.apache.tinkerpop.gremlin.structure.Direction
+import io.shiftleft.semanticcpg.language._
 
 /**
   * Adds a METHOD_PARAMETER_OUT for each METHOD_PARAMETER_IN to the graph and
@@ -17,52 +16,49 @@ import org.apache.tinkerpop.gremlin.structure.Direction
   * not provide method stubs.
   *
   */
-class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
+class MethodDecoratorPass(cpg: Cpg) extends ParallelCpgPass[nodes.MethodParameterIn](cpg) {
   import MethodDecoratorPass.logger
 
   private[this] var loggedDeprecatedWarning = false
   private[this] var loggedMissingTypeFullName = false
 
-  override def run() = {
+  override def partIterator: Iterator[nodes.MethodParameterIn] =
+    cpg.parameter.iterator
+
+  override def runOnPart(parameterIn: nodes.MethodParameterIn): Option[DiffGraph] = {
     val dstGraph = DiffGraph.newBuilder
 
-    cpg.graph.V
-      .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
-      .sideEffect {
-        case parameterIn: nodes.MethodParameterIn =>
-          if (!parameterIn._parameterLinkOut().hasNext) {
-            val parameterOut = new nodes.NewMethodParameterOut(
-              parameterIn.code,
-              parameterIn.order,
-              parameterIn.name,
-              parameterIn.evaluationStrategy,
-              parameterIn.typeFullName,
-              parameterIn.lineNumber,
-              parameterIn.columnNumber,
-            )
+    if (!parameterIn._parameterLinkOut().hasNext) {
+      val parameterOut = nodes.NewMethodParameterOut(
+        parameterIn.code,
+        parameterIn.order,
+        parameterIn.name,
+        parameterIn.evaluationStrategy,
+        parameterIn.typeFullName,
+        parameterIn.lineNumber,
+        parameterIn.columnNumber,
+      )
 
-            val method =
-              parameterIn._astIn.onlyChecked.asInstanceOf[nodes.Method]
-            if (parameterIn.typeFullName == null) {
-              val evalType = parameterIn._evalTypeOut.onlyChecked
-                .asInstanceOf[nodes.Type]
-              dstGraph.addEdgeToOriginal(parameterOut, evalType, EdgeTypes.EVAL_TYPE)
-              if (!loggedMissingTypeFullName) {
-                logger.warn("Using deprecated CPG format with missing TYPE_FULL_NAME on METHOD_PARAMETER_IN nodes.")
-                loggedMissingTypeFullName = true
-              }
-            }
-
-            dstGraph.addNode(parameterOut)
-            dstGraph.addEdgeFromOriginal(method, parameterOut, EdgeTypes.AST)
-            dstGraph.addEdgeFromOriginal(parameterIn, parameterOut, EdgeTypes.PARAMETER_LINK)
-          } else if (!loggedDeprecatedWarning) {
-            logger.warn("Using deprecated CPG format with PARAMETER_LINK edges")
-            loggedDeprecatedWarning = true
-          }
+      val method =
+        parameterIn._astIn.onlyChecked.asInstanceOf[nodes.Method]
+      if (parameterIn.typeFullName == null) {
+        val evalType = parameterIn._evalTypeOut.onlyChecked
+          .asInstanceOf[nodes.Type]
+        dstGraph.addEdgeToOriginal(parameterOut, evalType, EdgeTypes.EVAL_TYPE)
+        if (!loggedMissingTypeFullName) {
+          logger.warn("Using deprecated CPG format with missing TYPE_FULL_NAME on METHOD_PARAMETER_IN nodes.")
+          loggedMissingTypeFullName = true
+        }
       }
-      .iterate
-    Iterator(dstGraph.build())
+
+      dstGraph.addNode(parameterOut)
+      dstGraph.addEdgeFromOriginal(method, parameterOut, EdgeTypes.AST)
+      dstGraph.addEdgeFromOriginal(parameterIn, parameterOut, EdgeTypes.PARAMETER_LINK)
+    } else if (!loggedDeprecatedWarning) {
+      logger.warn("Using deprecated CPG format with PARAMETER_LINK edges")
+      loggedDeprecatedWarning = true
+    }
+    Some(dstGraph.build())
   }
 }
 


### PR DESCRIPTION
We have a few passes that create one large diff graph for the entire program in a single thread. The DiffGraph overhead is low at this point, but keeping graphs that grow with the size of the input will send us into OOMs (confirmed). Making use of the new ParallelCpgPass class to avoid this. This affects:

- TypeDeclStubCreator
- CallLinker
- CapturingLinker
- FileNameCompat
- MethodDecoratorPass

