### PR TITLE
Handle exception

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -56,34 +56,40 @@ class CallLinker(cpg: Cpg) extends ParallelCpgPass[nodes.Call](cpg) {
       case DispatchTypes.DYNAMIC_DISPATCH =>
         val receiverIt = call._receiverOut
         if (receiverIt.hasNext) {
-          val receiver = receiverIt.next
-          receiver match {
-            case methodRefReceiver: nodes.MethodRef =>
-              Some(methodRefReceiver._refOut.onlyChecked.asInstanceOf[nodes.Method])
-            case _ =>
-              val receiverTypeDecl = receiver
-                ._evalTypeOut()
-                .onlyChecked
-                ._refOut
-                .onlyChecked
+          try {
+            val receiver = receiverIt.next
+            receiver match {
+              case methodRefReceiver: nodes.MethodRef =>
+                Some(methodRefReceiver._refOut.onlyChecked.asInstanceOf[nodes.Method])
+              case _ =>
+                val receiverTypeDecl = receiver
+                  ._evalTypeOut()
+                  .onlyChecked
+                  ._refOut
+                  .onlyChecked
 
-              val resolvedMethodOption = receiverTypeDecl._bindsOut.asScala.collectFirst {
-                case binding: nodes.Binding if binding.name == call.name && binding.signature == call.signature =>
-                  binding._refOut.onlyChecked.asInstanceOf[nodes.Method]
-              }
-              if (resolvedMethodOption.isDefined) {
-                dstGraph.addEdgeInOriginal(call, resolvedMethodOption.get, EdgeTypes.CALL)
-              } else {
-                /*
-                There is no binding that declares the VTable slot.
-                This is a valid possibility in message-passing style languages.
+                val resolvedMethodOption = receiverTypeDecl._bindsOut.asScala.collectFirst {
+                  case binding: nodes.Binding if binding.name == call.name && binding.signature == call.signature =>
+                    binding._refOut.onlyChecked.asInstanceOf[nodes.Method]
+                }
+                if (resolvedMethodOption.isDefined) {
+                  dstGraph.addEdgeInOriginal(call, resolvedMethodOption.get, EdgeTypes.CALL)
+                } else {
+                  /*
+                  There is no binding that declares the VTable slot.
+                  This is a valid possibility in message-passing style languages.
 
-                In JVM and .NET this should not happen -- place breakpoint or uncomment here when debugging frontends
-                logger.debug(
-                  s"Unable to link dynamic CALL with METHOD_FULL_NAME ${call.methodFullName}, NAME ${call.name}, " +
-                    s"SIGNATURE ${call.signature}, CODE ${call.code}")
-               */
-              }
+                  In JVM and .NET this should not happen -- place breakpoint or uncomment here when debugging frontends
+                  logger.debug(
+                    s"Unable to link dynamic CALL with METHOD_FULL_NAME ${call.methodFullName}, NAME ${call.name}, " +
+                      s"SIGNATURE ${call.signature}, CODE ${call.code}")
+                 */
+                }
+            }
+          } catch {
+            case exc: NoSuchElementException =>
+              logger.info("NoSuchElementException in CallLinker, previously swallowed by Gremlin")
+              logger.info(exc)
           }
         } else {
           logger.warn(s"Missing receiver edge on dynamic CALL ${call.code}")


### PR DESCRIPTION
Previously, Gremlin swallowed this exception. Now, we allow it and print an info.