### PR TITLE
more neighbor accessor changes, driven by usage of `onlyChecked`

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -115,7 +115,7 @@
         },
         { "name": "METHOD_REF",
           "outEdges" : [
-            {"edgeName": "REF", "inNodes": [{"name": "METHOD"}]},
+            {"edgeName": "REF", "inNodes": [{"name": "METHOD", "cardinality": "n:1"}]},
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         },

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -80,7 +80,7 @@
               {"name": "METHOD_PARAMETER_OUT"},
               {"name": "METHOD_RETURN"}
             ]},
-            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
+            {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE", "cardinality": "n:1"}]},
             {"edgeName": "REACHING_DEF", "inNodes": [
               {"name": "CALL"},
               {"name": "RETURN"}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -11,10 +11,7 @@ class MethodMethods(val node: nodes.Method) extends AnyVal {
     node._methodParameterInViaAstOut
 
   def methodReturn: nodes.MethodReturn =
-    node._astOut.asScala
-      .collect { case mr: nodes.MethodReturn => mr }
-      .asJava
-      .onlyChecked
+    node._methodReturnViaAstOut
 
   def local: Iterator[nodes.Local] =
     node._blockViaContainsOut.flatMap(_._localViaAstOut)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -61,7 +61,8 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
           val receiver = receiverIt.next
           receiver match {
             case methodRefReceiver: nodes.MethodRef =>
-              Some(methodRefReceiver._refOut.onlyChecked.asInstanceOf[nodes.Method])
+              // TODO this doesn't do anything and may as well be dropped, no?
+              Option(methodRefReceiver._methodViaRefOut)
             case _ =>
               val receiverTypeDecl = receiver
                 ._evalTypeOut()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -72,7 +72,7 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
 
               val resolvedMethodOption = receiverTypeDecl._bindsOut.asScala.collectFirst {
                 case binding: nodes.Binding if binding.name == call.name && binding.signature == call.signature =>
-                  binding._refOut.onlyChecked.asInstanceOf[nodes.Method]
+                  binding._methodViaRefOut
               }
               if (resolvedMethodOption.isDefined) {
                 dstGraph.addEdgeInOriginal(call, resolvedMethodOption.get, EdgeTypes.CALL)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
@@ -41,8 +41,7 @@ class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
               parameterIn.columnNumber,
             )
 
-            val method =
-              parameterIn._astIn.onlyChecked.asInstanceOf[nodes.Method]
+            val method = parameterIn._methodViaAstIn
             if (parameterIn.typeFullName == null) {
               val evalType = parameterIn._evalTypeOut.onlyChecked
                 .asInstanceOf[nodes.Type]

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
@@ -43,8 +43,7 @@ class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
 
             val method = parameterIn._methodViaAstIn
             if (parameterIn.typeFullName == null) {
-              val evalType = parameterIn._evalTypeOut.onlyChecked
-                .asInstanceOf[nodes.Type]
+              val evalType = parameterIn._typeViaEvalTypeOut
               dstGraph.addEdgeToOriginal(parameterOut, evalType, EdgeTypes.EVAL_TYPE)
               if (!loggedMissingTypeFullName) {
                 logger.warn("Using deprecated CPG format with missing TYPE_FULL_NAME on METHOD_PARAMETER_IN nodes.")


### PR DESCRIPTION
* only refactoring in this PR, but there's some code that can simply be dropped by the looks of it (see new TODO)
* methodParamIn -> type
* methodRef -> method
* some other low hanging fruit