### PR TITLE
replace tinkerpop api with neighbor accessors / scala collections

### DIFF
--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Path.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/language/Path.scala
@@ -19,7 +19,7 @@ object Path {
 
         val trackedSymbol = trackingPoint match {
           case _: nodes.MethodParameterIn =>
-            val paramsPretty = method.parameter.l.sortBy(_.order).map(_.code).mkString(", ")
+            val paramsPretty = method.parameter.toList.sortBy(_.order).map(_.code).mkString(", ")
             s"$methodName($paramsPretty)"
           case _ => trackingPoint.cfgNode.repr
         }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -7,8 +7,8 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 
 class MethodMethods(val node: nodes.Method) extends AnyVal {
 
-  def parameter: NodeSteps[nodes.MethodParameterIn] =
-    node.start.parameter
+  def parameter: Iterator[nodes.MethodParameterIn] =
+    node._methodParameterInViaAstOut
 
   def methodReturn: nodes.MethodReturn =
     node._astOut.asScala
@@ -16,8 +16,8 @@ class MethodMethods(val node: nodes.Method) extends AnyVal {
       .asJava
       .onlyChecked
 
-  def local: NodeSteps[nodes.Local] =
-    node.start.local
+  def local: Iterator[nodes.Local] =
+    node._blockViaContainsOut.flatMap(_._localViaAstOut)
 
   def controlStructure: NodeSteps[nodes.ControlStructure] =
     node.start.controlStructure

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointToCfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointToCfgNode.scala
@@ -1,25 +1,21 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import gremlin.scala._
-import io.shiftleft.semanticcpg.utils.{ExpandTo, MemberAccess}
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
-import org.apache.tinkerpop.gremlin.structure.Direction
+import io.shiftleft.semanticcpg.utils.{ExpandTo, MemberAccess}
 
 import scala.jdk.CollectionConverters._
 
 // Adding a `private` here triggers an exception in the compiler.
 object TrackingPointMethodsBase {
-  def lastExpressionInBlock(block: nodes.Block): Option[nodes.Expression] = {
-    block
-      .vertices(Direction.OUT, EdgeTypes.AST)
-      .asScala
-      .filterNot(vertex => vertex.isInstanceOf[nodes.Local] || vertex.isInstanceOf[nodes.Method])
+  def lastExpressionInBlock(block: nodes.Block): Option[nodes.Expression] =
+    block._astOut.asScala
+      .collect {
+        case node: nodes.Expression if !node.isInstanceOf[nodes.Local] && !node.isInstanceOf[nodes.Method] => node
+      }
       .toVector
-      .sortBy(_.value2(NodeKeys.ORDER))
+      .sortBy(_.order)
       .lastOption
-      .asInstanceOf[Option[nodes.Expression]]
-  }
 }
 
 object TrackingPointToCfgNode {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MetaData.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MetaData.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language.NodeSteps
+import io.shiftleft.semanticcpg.language.{NodeSteps, Steps}
 
 /**
   * A meta data entry
@@ -14,6 +14,6 @@ class MetaData(val wrapped: NodeSteps[nodes.MetaData]) extends AnyVal {
     * Returns the programming language of the code for which this CPG was
     * generated from.
     * */
-  def language: GremlinScala[String] = raw.map(_.language)
+  def language: Steps[String] = wrapped.map(_.language)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -19,11 +19,11 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * */
   @Doc("All parameters")
   def parameter: NodeSteps[nodes.MethodParameterIn] =
-    new NodeSteps(
-      raw
-        .out(EdgeTypes.AST)
-        .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
-        .cast[nodes.MethodParameterIn])
+    // TODO once we use OdbTraversal, this will simply become `wrapped.flatMap(_.parameter)` - for now it's not that simple :(
+    new NodeSteps(raw
+      .out(EdgeTypes.AST)
+      .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
+      .cast[nodes.MethodParameterIn])
 
   /**
     * Traverse to formal return parameter

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -20,10 +20,11 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
   @Doc("All parameters")
   def parameter: NodeSteps[nodes.MethodParameterIn] =
     // TODO once we use OdbTraversal, this will simply become `wrapped.flatMap(_.parameter)` - for now it's not that simple :(
-    new NodeSteps(raw
-      .out(EdgeTypes.AST)
-      .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
-      .cast[nodes.MethodParameterIn])
+    new NodeSteps(
+      raw
+        .out(EdgeTypes.AST)
+        .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
+        .cast[nodes.MethodParameterIn])
 
   /**
     * Traverse to formal return parameter

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -72,7 +72,6 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
   def definingTypeDecl: NodeSteps[nodes.TypeDecl] =
     new NodeSteps(
       raw
-        .cast[nodes.StoredNode]
         .repeat(_.in(EdgeTypes.AST).cast[nodes.StoredNode])
         .until(_.hasLabel(NodeTypes.TYPE_DECL))
         .cast[nodes.TypeDecl])
@@ -84,7 +83,6 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
   def definingMethod: NodeSteps[nodes.Method] =
     new NodeSteps(
       raw
-        .cast[nodes.StoredNode]
         .repeat(_.in(EdgeTypes.AST).cast[nodes.StoredNode])
         .until(_.hasLabel(NodeTypes.METHOD))
         .cast[nodes.Method])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Type.scala
@@ -103,13 +103,11 @@ class Type(val wrapped: NodeSteps[nodes.Type]) extends AnyVal {
     new NodeSteps(
       raw
         .in(EdgeTypes.EVAL_TYPE)
-        .filterOnEnd(_.isInstanceOf[nodes.Expression])
-        .cast[nodes.Expression])
+        .collect { case node: nodes.Expression => node })
 
   def parameter: NodeSteps[nodes.MethodParameterIn] =
     new NodeSteps(
       raw
         .in(EdgeTypes.EVAL_TYPE)
-        .filterOnEnd(_.isInstanceOf[nodes.MethodParameterIn])
-        .cast[nodes.MethodParameterIn])
+        .collect { case node: nodes.MethodParameterIn => node })
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
@@ -35,7 +35,7 @@ class CallGraphTests extends WordSpec with Matchers {
     }
 
     "should find that argument '1+2' is passed to parameter 'x'" in {
-      cpg.parameter.name("x").argument().code.toSet shouldBe Set("1+2")
+      cpg.parameter.name("x").argument.code.toSet shouldBe Set("1+2")
     }
 
     "should allow traversing from argument to formal parameter" in {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MemberAccessLinkerTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MemberAccessLinkerTests.scala
@@ -1,21 +1,16 @@
 package io.shiftleft.semanticcpg.passes
 
-import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated._
+import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.scalatest.{Matchers, WordSpec}
 
 class MemberAccessLinkerTests extends WordSpec with Matchers {
 
   "have a reference to correct member" in ExistingCpgFixture("memberaccesslinker") { fixture =>
-    val queryResult: List[Vertex] = fixture.scalaGraph.V
-      .hasLabel(NodeTypes.CALL)
-      .has(NodeKeys.NAME -> Operators.indirectMemberAccess)
-      .out(EdgeTypes.REF)
-      .toList()
-    queryResult.size shouldBe 1
-    queryResult.head.label shouldBe NodeTypes.MEMBER
-    queryResult.head.value2(NodeKeys.NAME) shouldBe "aaa"
+    val members = fixture.cpg.call(Operators.indirectMemberAccess).referencedMember.l
+    members.size shouldBe 1
+    members.head.name shouldBe "aaa"
   }
 
 }


### PR DESCRIPTION
* replace tinkerpop sack traversal with standard for loop: Expression.parameter, MethodParameter.argument, MethodParameterOut.argument
* TrackingPointMethodsBase without tinkerpop
* some more easy refactorings away from tinkerpop
* wherever it's easily portable already, don't start traversals on node level