### PR TITLE
publishLocal script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you have cloned it already, additionally run `git lfs pull` (from within the 
 
 Additional build-time dependencies are automatically downloaded as
 part of the build process. To build and install into your local Maven
-cache, issue the command `sbt publishM2`.
+cache, issue the command `./publishLocal.sh`.
 
 This command will install the following artifacts:
 

--- a/publishLocal.sh
+++ b/publishLocal.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+# As explained in schema-extender/build.sbt, schema-extender is a separate sbt build inside this
+# repository. Both are usually published from travis, but if you want to publish locally and use
+# it in joern or ocular, you must also locally publish both. This script does exactly that.
+
+sbt publishM2
+cd schema-extender
+sbt publishM2
+cd ..
+


### PR DESCRIPTION
As explained in schema-extender/build.sbt, schema-extender is a separate sbt build inside this
repository. Both are usually published from travis, but if you want to publish locally and use
it in joern or ocular, you must also locally publish both. This script does exactly that.