### PR TITLE
Flush before creating indices

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -82,8 +82,10 @@ private class CpgLoader {
     cpg
   }
 
-  def createIndexes(cpg: Cpg): Unit =
+  def createIndexes(cpg: Cpg): Unit = {
+    cpg.graph.getStorage.getNodesMVMap.flushAndGetRoot()
     cpg.graph.indexManager.createNodePropertyIndex(NodeKeys.FULL_NAME.name)
+  }
 
   def addOverlays(overlayFilenames: Seq[String], cpg: Cpg): Unit = {
     overlayFilenames.foreach { overlayFilename =>


### PR DESCRIPTION
This seems to fix the `IllegalStateException`s we've been seeing.