### PR TITLE
Remove noisy debug-like message printed to user.

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/WorkspaceManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/WorkspaceManager.scala
@@ -286,7 +286,6 @@ class WorkspaceManager[ProjectType <: Project](path: String, loader: WorkspaceLo
       report(s"CPG for project $name does not exist at ${baseCpgFilename(name)}, bailing out")
       None
     } else if (project(name).exists(_.cpg.isDefined)) {
-      report(s"project $name is already open. Making sure it is active.")
       setActiveProject(name)
       project(name)
     } else {


### PR DESCRIPTION
This message pops up when changing CPGs, e.g., it pops up when running `cpgs` queries multiple times. Removed it, because it seems noisy and doesn't increase usability.