### PR TITLE
return nodesteps instead of iterators

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -7,14 +7,16 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 
 class MethodMethods(val node: nodes.Method) extends AnyVal {
 
-  def parameter: Iterator[nodes.MethodParameterIn] =
-    node._methodParameterInViaAstOut
+  def parameter: NodeSteps[nodes.MethodParameterIn] =
+    // TODO once we use OdbTraversal, this will simply become `node._methodParameterInViaAstOut`
+    node.start.parameter
 
   def methodReturn: nodes.MethodReturn =
     node._methodReturnViaAstOut
 
-  def local: Iterator[nodes.Local] =
-    node._blockViaContainsOut.flatMap(_._localViaAstOut)
+  def local: NodeSteps[nodes.Local] =
+    // TODO once we use OdbTraversal, this will simply become `node._blockViaContainsOut.flatMap(_._localViaAstOut)`
+    node.start.local
 
   def controlStructure: NodeSteps[nodes.ControlStructure] =
     node.start.controlStructure

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -24,7 +24,8 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
       raw
         .out(EdgeTypes.AST)
         .hasLabel(NodeTypes.METHOD_PARAMETER_IN)
-        .cast[nodes.MethodParameterIn])
+        .cast[nodes.MethodParameterIn]
+    )
 
   /**
     * Traverse to formal return parameter


### PR DESCRIPTION
In an attempt to avoid unnecessary overhead I previously changed the
return type of `method.parameter` from `NodeSteps` to `Iterator`.
Given that it complicates things - the user now needs to call
`.start` explicitly, or we add a hard to understand implicit
conversion. Once we use overflowdb traversal, it won't have any
overhead any more, so, I'll change that back then.

re https://github.com/ShiftLeftSecurity/joern/pull/269