### PR TITLE
Have LayerCreator append overlayName automatically

### DIFF
--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -9,7 +9,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import org.scalatest.{Matchers, WordSpec}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.console.testing._
-import io.shiftleft.semanticcpg.Overlays
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, Scpg}
 
 import scala.util.Try
@@ -252,9 +251,7 @@ class ConsoleTests extends WordSpec with Matchers {
     override val overlayName: String = "fooname"
     override val description: String = "foodescr"
 
-    override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
-      Overlays.appendOverlayName(context.cpg, overlayName)
-    }
+    override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {}
     override def probe(cpg: Cpg): Boolean = false
   }
 

--- a/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengine/src/main/scala/io/shiftleft/dataflowengine/layers/dataflows/OssDataFlow.scala
@@ -32,7 +32,6 @@ class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
         pass.createApplySerializeAndStore(serializedCpg)
         serializedCpg.close()
     }
-    Overlays.appendOverlayName(cpg, OssDataFlow.overlayName)
   }
 
   override def probe(cpg: Cpg): Boolean = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
@@ -23,6 +23,7 @@ abstract class LayerCreator {
       logger.warn(s"The overlay $overlayName already exists - skipping creation")
     } else {
       create(context, serializeInverse)
+      Overlays.appendOverlayName(context.cpg, overlayName)
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -1,8 +1,7 @@
 package io.shiftleft.semanticcpg.layers
 
-import gremlin.scala.GraphAsScala
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Languages, NodeTypes}
+import io.shiftleft.codepropertygraph.generated.{Languages, NodeTypes}
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.Overlays
 import io.shiftleft.semanticcpg.passes.BindingMethodOverridesPass
@@ -50,8 +49,6 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
         pass.createApplySerializeAndStore(serializedCpg, serializeInverse)
         serializedCpg.close()
     }
-
-    Overlays.appendOverlayName(cpg, Scpg.overlayName)
   }
 
   private def createEnhancementExecList(cpg: Cpg, language: String): Iterator[CpgPassBase] = {


### PR DESCRIPTION
While writing the post about custom analyzers, I noticed that we rely on the analyzer to add the overlayName to the CPG's metadata block on completion. It's easy to forget this, and when one does, we see weird behavior down the line. With this PR, we add the name automatically to avoid this problem. A follow-up PR in `codescience` is required and up next.