### PR TITLE
Allow running custom write queries via `run(query)`

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -23,6 +23,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
 
   private val _config = new ConsoleConfig()
   def config: ConsoleConfig = _config
+  def console: Console[T] = this
 
   protected val workspacePathName: String = config.install.rootPath.path.resolve("workspace").toString
   protected val workspaceManager = new WorkspaceManager[T](workspacePathName, loader)
@@ -528,8 +529,6 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
 
   protected def report(string: String): Unit = System.err.println(string)
 
-  // This is only public because we can't use the dynamically
-  // created `run` in unit tests.
   def _runAnalyzer(overlayCreators: LayerCreator*): Cpg = {
 
     overlayCreators.foreach { creator =>

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -317,4 +317,16 @@ class ConsoleTests extends WordSpec with Matchers {
     }
   }
 
+  "runCustomQuery" should {
+    "allow running a custom query" in ConsoleFixture() { (console, codeDir) =>
+      console.importCode(codeDir.toString)
+      Run.runCustomQuery(console, console.cpg.method.newTagNode("mytag"))
+      console.cpg.tag.name("mytag").method.name.toSet should contain("main")
+      console.cpg.metaData.map(_.overlays).head.last shouldBe "custom"
+      console.undo
+      console.cpg.metaData.map(_.overlays).head.last shouldBe "semanticcpg"
+    }
+
+  }
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewNodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewNodeSteps.scala
@@ -7,10 +7,14 @@ import io.shiftleft.codepropertygraph.generated.EdgeKeys
 import io.shiftleft.passes.DiffGraph
 import org.apache.logging.log4j.{LogManager, Logger}
 
-class NewNodeSteps[A <: NewNode](override val raw: GremlinScala[A]) extends Steps[A](raw) {
+trait HasStoreMethod {
+  def store()(implicit diffBuilder: DiffGraph.Builder): Unit
+}
+
+class NewNodeSteps[A <: NewNode](override val raw: GremlinScala[A]) extends Steps[A](raw) with HasStoreMethod {
   import NewNodeSteps.logger
 
-  def store()(implicit diffBuilder: DiffGraph.Builder): Unit =
+  override def store()(implicit diffBuilder: DiffGraph.Builder): Unit =
     raw.sideEffect(storeRecursively).iterate()
 
   private def storeRecursively(newNode: NewNode)(implicit diffBuilder: DiffGraph.Builder): Unit = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewTagNodePair.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewTagNodePair.scala
@@ -5,9 +5,9 @@ import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, Node, StoredNode
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.passes.{DiffGraph}
 
-class NewTagNodePair[NodeType <: Node](raw: GremlinScala[nodes.NewTagNodePair]) {
+class NewTagNodePair[NodeType <: Node](raw: GremlinScala[nodes.NewTagNodePair]) extends HasStoreMethod {
 
-  def store()(implicit diffGraph: DiffGraph.Builder): Unit = {
+  override def store()(implicit diffGraph: DiffGraph.Builder): Unit = {
     raw.toList.foreach { tagNodePair =>
       val tag = tagNodePair.tag
       val tagValue = tagNodePair.node


### PR DESCRIPTION
Currently, the only way of editing the graph was by writing a complete extension, which would then appear in the list of extensions returned by `run`. If one wants to only quickly tag some nodes on the shell via `cpg.method.newTagNode()`, that would not work because a more complex dance is necessary to create the layer and store the undo information. This PR fixes that by offering `run(query)` where query just needs to have a `store` method, e.g., it is an instance of `NewNodeSteps` or of `NewTagNodePair`. Follow-up PR in the documentation is on its way.