### PR TITLE
Light refactoring to allow test CPG generation from dir

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testfixtures/LanguageFrontend.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testfixtures/LanguageFrontend.scala
@@ -38,5 +38,5 @@ object LanguageFrontend {
     override val fileSuffix: String = ".c"
   }
 
-  val Fuzzyc: LanguageFrontend = new FuzzycFrontend
+  def Fuzzyc: LanguageFrontend = new FuzzycFrontend
 }


### PR DESCRIPTION
For the sample ocular extension, I need a test fixture that creates a CPG based on a directory of source files. To date, we only have a fixture to create CPGs from strings. The code constructs a temporary directory where it writes that string though, so, light refactoring allows us to make use of this code to obtain the desired Fixture.