### PR TITLE
Allow tagging files

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -38,7 +38,8 @@
                 {"edgeName": "CONTAINS", "inNodes": [
               {"name": "TYPE_DECL"},
               {"name": "METHOD"}
-            ]}
+		]},
+	     {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]}
             ]
         },
         { "name": "METHOD",

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Tag.scala
@@ -81,4 +81,13 @@ class Tag(val wrapped: NodeSteps[nodes.Tag]) extends AnyVal {
         .order(By((x: Vertex) => x.id))
         .cast[nodes.Local])
 
+  def file: NodeSteps[nodes.File] =
+    new NodeSteps(
+      raw
+        .in(EdgeTypes.TAGGED_BY)
+        .hasLabel(NodeTypes.FILE)
+        .order(By((x: Vertex) => x.id))
+        .cast[nodes.File]
+    )
+
 }


### PR DESCRIPTION
While writing the sample extension, I noticed that we currently do not yet allow tagging files. This PR fixes that.