### PR TITLE
Introduce `Commit` pass

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Commit.scala
+++ b/console/src/main/scala/io/shiftleft/console/Commit.scala
@@ -20,10 +20,6 @@ class Commit(opts: CommitOptions) extends LayerCreator {
   override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
     val serializedCpg = initSerializedCpg(context.outputDir, "commit", 0)
     new CpgPass(context.cpg) {
-
-      /**
-        * Main method of enhancement - to be implemented by child class
-        **/
       override def run(): Iterator[DiffGraph] = Iterator(opts.diffGraphBuilder.build())
     }.createApplySerializeAndStore(serializedCpg, serializeInverse)
     opts.diffGraphBuilder = DiffGraph.newBuilder

--- a/console/src/main/scala/io/shiftleft/console/Commit.scala
+++ b/console/src/main/scala/io/shiftleft/console/Commit.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.console
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+
+object Commit {
+  val overlayName: String = "commit"
+  val description: String = "Apply current custom diffgraph"
+  def defaultOpts = new CommitOptions(DiffGraph.newBuilder)
+}
+
+class CommitOptions(var diffGraphBuilder: DiffGraph.Builder) extends LayerCreatorOptions
+
+class Commit(opts: CommitOptions) extends LayerCreator {
+
+  override val overlayName: String = Commit.overlayName
+  override val description: String = Commit.description
+
+  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+    val serializedCpg = initSerializedCpg(context.outputDir, "commit", 0)
+    new CpgPass(context.cpg) {
+
+      /**
+        * Main method of enhancement - to be implemented by child class
+        **/
+      override def run(): Iterator[DiffGraph] = Iterator(opts.diffGraphBuilder.build())
+    }.createApplySerializeAndStore(serializedCpg, serializeInverse)
+    opts.diffGraphBuilder = DiffGraph.newBuilder
+  }
+
+  override def probe(cpg: Cpg): Boolean = false
+}

--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -58,6 +58,10 @@ object Run {
         |}
         |
         |val opts = new OptsDynamic()
+        |
+        | import io.shiftleft.passes.DiffGraph
+        | implicit def _diffGraph : DiffGraph.Builder = opts.commit.diffGraphBuilder
+        | def diffGraph = _diffGraph
         |""".stripMargin
 
     val membersCode = layerCreatorTypeNames

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
@@ -17,7 +17,8 @@ class CfgDominatorFrontierTests extends WordSpec with Matchers {
       node.nodesIn("CFG").asScala
   }
 
-  private class TestDomTreeAdapter(immediateDominators: Map[NodeRef[_], NodeRef[_]]) extends DomTreeAdapter[NodeRef[_]] {
+  private class TestDomTreeAdapter(immediateDominators: Map[NodeRef[_], NodeRef[_]])
+      extends DomTreeAdapter[NodeRef[_]] {
     override def immediateDominator(cfgNode: NodeRef[_]): Option[NodeRef[_]] = {
       immediateDominators.get(cfgNode)
     }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
@@ -10,13 +10,17 @@ import org.scalatest.{Matchers, WordSpec}
 class MethodDecoratorPassTests extends WordSpec with Matchers {
   "MethodDecoratorTest" in EmptyGraphFixture { graph =>
     val method = graph + NodeTypes.METHOD
-    val parameterIn = graph.+(NodeTypes.METHOD_PARAMETER_IN,
-      NodeKeysOdb.CODE -> "p1",
-      NodeKeysOdb.ORDER -> 1,
-      NodeKeysOdb.NAME -> "p1",
-      NodeKeysOdb.EVALUATION_STRATEGY -> EvaluationStrategies.BY_REFERENCE,
-      NodeKeysOdb.TYPE_FULL_NAME -> "some.Type",
-      NodeKeysOdb.LINE_NUMBER -> 10).asInstanceOf[nodes.MethodParameterIn]
+    val parameterIn = graph
+      .+(
+        NodeTypes.METHOD_PARAMETER_IN,
+        NodeKeysOdb.CODE -> "p1",
+        NodeKeysOdb.ORDER -> 1,
+        NodeKeysOdb.NAME -> "p1",
+        NodeKeysOdb.EVALUATION_STRATEGY -> EvaluationStrategies.BY_REFERENCE,
+        NodeKeysOdb.TYPE_FULL_NAME -> "some.Type",
+        NodeKeysOdb.LINE_NUMBER -> 10
+      )
+      .asInstanceOf[nodes.MethodParameterIn]
     val evalType = graph + NodeTypes.TYPE
 
     method --- EdgeTypes.AST --> parameterIn


### PR DESCRIPTION
As requested by @itsacoderepo: there is a now a `diffGraph` on the Ocular/Joern shell. You can modify it and when you're done, invoke `run.commit`. This will apply the change to the active graph and reset the diffgraph to be empty.

Example:
```
importCode.c.fromString("int main() { }") 
diffGraph.addNode(new NewComment(None, "foo"))
run.commit
cpg.comment.l
```