### PR TITLE
Exclusion for classes exposed by `run`

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -43,6 +43,7 @@ object Run {
       .getSubTypesOf(classOf[LayerCreator])
       .asScala
       .filterNot(t => t.isAnonymousClass || t.isLocalClass || t.isMemberClass || t.isSynthetic)
+      .filterNot(t => t.getName.startsWith("io.shiftleft.console.Run"))
       .toList
       .map(t => (t.getSimpleName.toLowerCase, t.getName))
       .filter(t => !exclude.contains(t._2))


### PR DESCRIPTION
(fix for ocular-latest. Not 100% sure why the `isAnonymousClass` doesn't apply, possibly due to proguard)