### PR TITLE
Expose `isMethod` on `AstNode` class

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -41,6 +41,8 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
 
   def isMethodRef: Boolean = node.isInstanceOf[nodes.MethodRef]
 
+  def isMethod: Boolean = node.isInstanceOf[nodes.Method]
+
   def isBlock: Boolean = node.isInstanceOf[nodes.Block]
 
   @Doc("Depth of the abstract syntax tree")


### PR DESCRIPTION
Instances of `AstNode` can be of type `nodes.Method`, but the class
itself does not expose the usual _is-_ method on it.