### PR TITLE
Rename `callOut` to `call` to be consistent

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -47,7 +47,7 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * Traverse to methods called by this method
     * */
   def callee(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] =
-    new OriginalMethod(wrapped).callOut.calledMethod(callResolver)
+    new OriginalMethod(wrapped).call.calledMethod(callResolver)
 
   /**
     * Incoming call sites
@@ -69,6 +69,6 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * Outgoing call sites to methods where fullName matches `regex`.
     * */
   def callOutRegex(regex: String)(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] =
-    new OriginalMethod(wrapped).callOut.filter(_.calledMethod.fullName(regex))
+    new OriginalMethod(wrapped).call.filter(_.calledMethod.fullName(regex))
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -58,12 +58,14 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * */
   def controlStructure(regex: String): NodeSteps[nodes.ControlStructure] =
     wrapped.ast.isControlStructure.code(regex)
+  @deprecated("Use `call`", "")
+  def callOut: NodeSteps[nodes.Call] = call
 
   /**
     * Outgoing call sites
     * */
   @Doc("Call sites (outgoing calls)")
-  def callOut: NodeSteps[nodes.Call] =
+  def call: NodeSteps[nodes.Call] =
     new NodeSteps(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
@@ -26,7 +26,7 @@ class CallGraphTests extends WordSpec with Matchers {
     }
 
     "should find three outgoing calls for main" in {
-      cpg.method.name("main").callOut.code.toSet shouldBe
+      cpg.method.name("main").call.code.toSet shouldBe
         Set("1+2", "add((1+2), 3)", "printf(\"%d\\n\", add((1+2), 3))")
     }
 


### PR DESCRIPTION
When traversing from a method to all of its `call` nodes, we currently need to use `callOut`. This is inconsistent as traversing to all nodes in the method of type `type` is achieved via the step `.type` in most other cases. Deprecating callOut to make the change backward compatible.