### PR TITLE
Introduce `JUMP_TARGET` node type for labels

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -424,6 +424,24 @@
 	 ]
 	},
 
+	{"id" : 340, "name": "JUMP_TARGET",
+	 "comment" : "A jump target made explicit in the code using a label",
+	 "keys": ["NAME", "COLUMN_NUMBER", "LINE_NUMBER", "ORDER", "PARSER_TYPE_NAME", "ARGUMENT_INDEX", "INTERNAL_FLAGS"],
+	 "is" : ["CFG_NODE", "AST_NODE"],
+	 "outEdges" : [
+           {"edgeName": "CFG", "inNodes": [
+             {"name": "CALL"},
+             {"name": "IDENTIFIER"},
+             {"name": "FIELD_IDENTIFIER"},
+             {"name": "LITERAL"},
+             {"name": "RETURN"},
+             {"name": "METHOD_REF"},
+             {"name": "BLOCK"},
+             {"name": "UNKNOWN"}
+           ]}
+	 ]
+	},
+
         // This is the "catch-all-others" node type.
 
         {"id" : 44, "name": "UNKNOWN",

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -47,6 +47,13 @@ class NodeTypeStarters(cpg: Cpg) {
     file.name(name)
 
   /**
+    * Traverse to all jump targets
+    * */
+  @Doc("All jump targets, i.e., labels")
+  def jumpTarget: NodeSteps[nodes.JumpTarget] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.JUMP_TARGET).cast[nodes.JumpTarget])
+
+  /**
     Traverse to all namespaces, e.g., packages in Java.
     */
   @Doc("All namespaces")


### PR DESCRIPTION
Labels are currently of type `UNKNOWN`, which is misleading. This became particularly apparent as I was writing the AST post. I tried to introduce a `LABEL` type, but that conflicts with gremlin. However, `JUMP_TARGET` is just as good, so, let's go with that.