### PR TITLE
Allow JUMP_TARGET/CONTROL_STRUCTURE where UNKNOWN was allowed

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -105,7 +105,9 @@
               {"name": "METHOD_RETURN", "cardinality":"0-1:0-1"},
               {"name": "RETURN"},
               {"name": "BLOCK"},
-              {"name": "UNKNOWN"}
+	      {"name": "JUMP_TARGET"},
+	      {"name": "CONTROL_STRUCTURE"},
+	      {"name": "UNKNOWN"}
             ]
            }
          ]
@@ -207,6 +209,8 @@
               {"name": "METHOD_REF"},
               {"name": "RETURN"},
               {"name": "BLOCK"},
+	      {"name": "JUMP_TARGET"},
+	      {"name": "CONTROL_STRUCTURE"},
               {"name": "UNKNOWN"}
             ]
            }
@@ -225,7 +229,9 @@
              {"name": "METHOD_REF"},
              {"name": "RETURN"},
              {"name": "BLOCK"},
-             {"name": "UNKNOWN"}
+	     {"name": "JUMP_TARGET"},
+	     {"name": "CONTROL_STRUCTURE"},
+	     {"name": "UNKNOWN"}
            ]},
            {"edgeName": "AST", "inNodes": [
              {"name": "CALL"},
@@ -243,7 +249,9 @@
              {"name": "LITERAL", "cardinality": "0-1:0-1"},
              {"name": "METHOD_REF", "cardinality": "0-1:0-1"},
              {"name": "BLOCK", "cardinality": "0-1:0-1"},
-             {"name": "UNKNOWN"}
+             {"name": "JUMP_TARGET"},
+	     {"name": "CONTROL_STRUCTURE"},
+	     {"name": "UNKNOWN"}
            ]},
            {"edgeName": "ARGUMENT", "inNodes": [
              {"name": "CALL", "cardinality": "0-1:n"},
@@ -252,7 +260,9 @@
              {"name": "LITERAL", "cardinality": "0-1:n"},
              {"name": "METHOD_REF", "cardinality": "0-1:n"},
              {"name": "BLOCK", "cardinality": "0-1:n"},
-             {"name": "UNKNOWN"}
+	     {"name": "JUMP_TARGET"},
+	     {"name": "CONTROL_STRUCTURE"},
+	     {"name": "UNKNOWN"}
            ]}
          ]
         },
@@ -279,7 +289,9 @@
              {"name": "METHOD_RETURN"},
              {"name": "RETURN"},
              {"name": "BLOCK"},
-             {"name": "UNKNOWN"}
+	     {"name": "JUMP_TARGET"},
+	     {"name": "CONTROL_STRUCTURE"},
+	     {"name": "UNKNOWN"}
            ]}
          ]
         },
@@ -296,7 +308,9 @@
              {"name": "METHOD_REF"},
              {"name": "RETURN"},
              {"name": "BLOCK"},
-             {"name": "UNKNOWN"}
+	     {"name": "JUMP_TARGET"},
+	     {"name": "CONTROL_STRUCTURE"},
+	     {"name": "UNKNOWN"}
             ]}
           ]
         },
@@ -313,6 +327,7 @@
                {"name": "RETURN"},
                {"name": "BLOCK"},
                {"name": "UNKNOWN"},
+	       {"name": "JUMP_TARGET"},
                {"name": "CONTROL_STRUCTURE"}
              ]},
              {"edgeName": "CFG", "inNodes": [
@@ -325,7 +340,9 @@
                {"name": "METHOD_REF", "cardinality": "0-1:0-1"},
                {"name": "RETURN", "cardinality": "0-1:0-1"},
                {"name": "BLOCK", "cardinality": "0-1:0-1"},
-               {"name": "UNKNOWN"}
+	       {"name": "JUMP_TARGET"},
+	       {"name": "CONTROL_STRUCTURE"},
+	       {"name": "UNKNOWN"}
              ]}
          ]
         },
@@ -343,7 +360,8 @@
                {"name": "BLOCK", "cardinality": "1:n"},
                {"name": "LOCAL"},
                {"name": "UNKNOWN"},
-               {"name": "CONTROL_STRUCTURE"}
+	       {"name": "JUMP_TARGET"},
+	       {"name": "CONTROL_STRUCTURE"}
              ]},
              {"edgeName": "CFG", "inNodes": [
                {"name": "CALL"},
@@ -353,7 +371,9 @@
                {"name": "METHOD_REF"},
                {"name": "RETURN"},
                {"name": "BLOCK"},
-               {"name": "UNKNOWN"}
+	       {"name": "JUMP_TARGET"},
+	       {"name": "CONTROL_STRUCTURE"},
+	       {"name": "UNKNOWN"}
              ]}
          ]
         },
@@ -387,7 +407,9 @@
               {"name": "METHOD_RETURN"},
               {"name": "RETURN"},
               {"name": "BLOCK"},
-              {"name": "UNKNOWN"}
+	      {"name": "JUMP_TARGET"},
+	      {"name": "CONTROL_STRUCTURE"},
+	      {"name": "UNKNOWN"}
              ]}
           ]
         },
@@ -406,6 +428,7 @@
         {"name": "IDENTIFIER", "cardinality": "0-1:n"},
         {"name": "RETURN", "cardinality": "0-1:n"},
         {"name": "BLOCK", "cardinality": "0-1:n"},
+	{"name": "JUMP_TARGET"},
         {"name": "UNKNOWN"},
         {"name": "CONTROL_STRUCTURE"},
         {"name": "METHOD_REF", "cardinality": "1:n"}
@@ -418,7 +441,9 @@
         {"name": "BLOCK"},
         {"name": "METHOD_REF"},
         {"name": "CONTROL_STRUCTURE"},
+	{"name": "JUMP_TARGET"},
         {"name": "UNKNOWN"},
+        {"name": "CONTROL_STRUCTURE"},
         {"name": "ARRAY_INITIALIZER"}
      ] }
 	 ]
@@ -437,7 +462,9 @@
              {"name": "RETURN"},
              {"name": "METHOD_REF"},
              {"name": "BLOCK"},
-             {"name": "UNKNOWN"}
+	     {"name": "JUMP_TARGET"},
+	     {"name": "CONTROL_STRUCTURE"},
+	     {"name": "UNKNOWN"}
            ]}
 	 ]
 	},
@@ -457,7 +484,9 @@
              {"name": "RETURN"},
              {"name": "METHOD_REF"},
              {"name": "BLOCK"},
-             {"name": "UNKNOWN"}
+	     {"name": "JUMP_TARGET"},
+	     {"name": "CONTROL_STRUCTURE"},
+	     {"name": "UNKNOWN"}
              ]},
            {"edgeName": "AST", "inNodes": [
              {"name": "LITERAL"},
@@ -470,6 +499,7 @@
              {"name": "FIELD_IDENTIFIER"},
              {"name": "RETURN"},
              {"name": "BLOCK"},
+	     {"name": "JUMP_TARGET"},
              {"name": "UNKNOWN"},
              {"name": "CONTROL_STRUCTURE"}
            ]}

--- a/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
@@ -57,7 +57,7 @@
              {"name": "RETURN"},
              {"name": "BLOCK"},
              {"name": "METHOD_RETURN"},
-             {"name": "UNKNOWN"}
+	     {"name": "UNKNOWN"}
            ]}
          ]
         },
@@ -77,6 +77,8 @@
              {"name": "RETURN"},
              {"name": "BLOCK"},
              {"name": "METHOD"},
+	     {"name" : "CONTROL_STRUCTURE"},
+	     {"name" : "JUMP_TARGET"},
              {"name": "UNKNOWN"}
            ]}
         ]},
@@ -98,7 +100,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
             {"edgeName": "POST_DOMINATE", "inNodes": [
               {"name": "CALL"},
@@ -109,6 +113,8 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD"},
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
               {"name": "UNKNOWN"}
             ]},
             {"edgeName": "CDG", "inNodes": [
@@ -120,6 +126,8 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
               {"name": "UNKNOWN"}
             ]}
         ]},
@@ -156,7 +164,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
              {"edgeName": "POST_DOMINATE", "inNodes": [
               {"name": "CALL"},
@@ -167,7 +177,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
              {"edgeName": "CDG", "inNodes": [
               {"name": "CALL"},
@@ -178,7 +190,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]}
          ]
         },
@@ -198,7 +212,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
             {"edgeName": "POST_DOMINATE", "inNodes": [
               {"name": "CALL"},
@@ -209,7 +225,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
              {"edgeName": "CDG", "inNodes": [
               {"name": "CALL"},
@@ -220,7 +238,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]}
         ]},
         {"name" : "FIELD_IDENTIFIER", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"],
@@ -239,7 +259,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
             {"edgeName": "POST_DOMINATE", "inNodes": [
               {"name": "CALL"},
@@ -250,7 +272,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
             {"edgeName": "CDG", "inNodes": [
               {"name": "CALL"},
@@ -261,7 +285,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]}
         ]},
         {"name" : "METHOD_PARAMETER_IN",
@@ -286,7 +312,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
             {"edgeName": "POST_DOMINATE", "inNodes": [
               {"name": "CALL"},
@@ -297,7 +325,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]}
           ]
         },
@@ -316,7 +346,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
              {"edgeName": "POST_DOMINATE", "inNodes": [
               {"name": "CALL"},
@@ -327,7 +359,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
              {"edgeName": "CDG", "inNodes": [
               {"name": "CALL"},
@@ -338,7 +372,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]}
           ]
         },
@@ -360,7 +396,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
              {"edgeName": "POST_DOMINATE", "inNodes": [
               {"name": "CALL"},
@@ -371,7 +409,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]},
              {"edgeName": "CDG", "inNodes": [
               {"name": "CALL"},
@@ -382,7 +422,9 @@
               {"name": "RETURN"},
               {"name": "BLOCK"},
               {"name": "METHOD_RETURN"},
-              {"name": "UNKNOWN"}
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
+	      {"name": "UNKNOWN"}
             ]}
          ]
         },
@@ -402,7 +444,9 @@
                 {"name": "RETURN"},
                 {"name": "BLOCK"},
                 {"name": "METHOD_RETURN"},
-                {"name": "UNKNOWN"}
+		{"name" : "CONTROL_STRUCTURE"},
+	     	{"name" : "JUMP_TARGET"},
+		{"name": "UNKNOWN"}
               ]},
               {"edgeName": "POST_DOMINATE", "inNodes": [
                 {"name": "CALL"},
@@ -413,7 +457,9 @@
                 {"name": "RETURN"},
                 {"name": "BLOCK"},
                 {"name": "METHOD"},
-                {"name": "UNKNOWN"}
+		{"name" : "CONTROL_STRUCTURE"},
+	     	{"name" : "JUMP_TARGET"},
+		{"name": "UNKNOWN"}
               ]},
               {"edgeName": "CDG", "inNodes": [
                 {"name": "CALL"},
@@ -424,7 +470,9 @@
                 {"name": "RETURN"},
                 {"name": "BLOCK"},
                 {"name": "METHOD_RETURN"},
-                {"name": "UNKNOWN"}
+		{"name" : "CONTROL_STRUCTURE"},
+	     	{"name" : "JUMP_TARGET"},
+		{"name": "UNKNOWN"}
               ]}
             ]
         },

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -62,6 +62,8 @@
               {"name": "RETURN"},
               {"name": "METHOD_REF"},
               {"name": "BLOCK"},
+	      {"name" : "CONTROL_STRUCTURE"},
+	      {"name" : "JUMP_TARGET"},
               {"name": "UNKNOWN"}
             ]},
              {"edgeName": "SOURCE_FILE", "inNodes": [{"name": "FILE"}]}


### PR DESCRIPTION
Re: https://github.com/ShiftLeftSecurity/fuzzyc2cpg/pull/194
Re: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/785

Now that both labels and goto/continue/break/throw are no longer of type UNKNOWN, we need to allow these nodes to be involved in edges where UNKNOWN was used previously. It's quite possible we can further restrict the schema, but let's make sure it doesn't crash first.