### PR TITLE
Allow outgoing CFG edges from CONTROL_STRUCTURE

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -445,7 +445,19 @@
         {"name": "UNKNOWN"},
         {"name": "CONTROL_STRUCTURE"},
         {"name": "ARRAY_INITIALIZER"}
-     ] }
+     ] },
+        {"edgeName" : "CFG", "inNodes" : [
+	{"name": "CALL"},
+        {"name": "IDENTIFIER"},
+        {"name": "FIELD_IDENTIFIER"},
+        {"name": "LITERAL"},
+        {"name": "RETURN"},
+        {"name": "METHOD_REF"},
+        {"name": "BLOCK"},
+	{"name": "JUMP_TARGET"},
+	{"name": "CONTROL_STRUCTURE"},
+	{"name": "UNKNOWN"}
+          ]}
 	 ]
 	},
 


### PR DESCRIPTION
As `goto`/`continue`/`break`/`throw` are now CONTROL_STRUCTUREs, we need to allow outgoing CFG edges.