### PR TITLE
Add node type step for control structures

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -33,7 +33,7 @@ class NodeTypeStarters(cpg: Cpg) {
   def comment(code: String): NodeSteps[nodes.Comment] =
     comment.code(code)
 
-@Doc("All control structures (source-based frontends)")
+  @Doc("All control structures (source-based frontends)")
   def controlStructure: NodeSteps[nodes.ControlStructure] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -32,7 +32,8 @@ class NodeTypeStarters(cpg: Cpg) {
     * */
   def comment(code: String): NodeSteps[nodes.Comment] =
     comment.code(code)
-  @Doc("All control structures (source-based frontends)")
+
+@Doc("All control structures (source-based frontends)")
   def controlStructure: NodeSteps[nodes.ControlStructure] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -32,6 +32,9 @@ class NodeTypeStarters(cpg: Cpg) {
     * */
   def comment(code: String): NodeSteps[nodes.Comment] =
     comment.code(code)
+  @Doc("All control structures (source-based frontends)")
+  def controlStructure: NodeSteps[nodes.ControlStructure] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.CONTROL_STRUCTURE).cast[nodes.ControlStructure])
 
   /**
     Traverse to all source files


### PR DESCRIPTION
`cpg.method.controlStructure` was possible before, but we were missing `cpg.controlStructure`.