### PR TITLE
Revert "Cleanup for call graph language (#798)"

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Call.scala
@@ -1,15 +1,14 @@
 package io.shiftleft.semanticcpg.language.callgraphextension
 
+import gremlin.scala.GremlinScala
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 
 class Call(val wrapped: NodeSteps[nodes.Call]) extends AnyVal {
-
-  @deprecated("Use callee", "")
-  def calledMethod(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] = callee
+  private def raw: GremlinScala[nodes.Call] = wrapped.raw
 
   /** The callee method */
-  def callee(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] = {
+  def calledMethod(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] = {
     new NodeSteps(wrapped.raw.flatMap { call =>
       callResolver.getCalledMethodsAsTraversal(call)
     })

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.semanticcpg.language.callgraphextension
 
 import gremlin.scala._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.help.Doc
+import io.shiftleft.semanticcpg.language.types.structure.{Method => OriginalMethod}
 
 class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
   private def raw: GremlinScala[nodes.Method] = wrapped.raw
@@ -47,7 +47,7 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * Traverse to methods called by this method
     * */
   def callee(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] =
-    call.callee(callResolver)
+    new OriginalMethod(wrapped).call.calledMethod(callResolver)
 
   /**
     * Incoming call sites
@@ -65,20 +65,10 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
   def calledBy(sourceTrav: Steps[nodes.Method])(implicit callResolver: ICallResolver): NodeSteps[nodes.Method] =
     caller(callResolver).calledByIncludingSink(sourceTrav)(callResolver)
 
-  @deprecated("Use call", "")
-  def callOut: NodeSteps[nodes.Call] = call
-
   /**
     * Outgoing call sites to methods where fullName matches `regex`.
     * */
-  def call(regex: String)(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] =
-    call.filter(_.callee.fullName(regex))
-
-  /**
-    * Outgoing call sites
-    * */
-  @Doc("Call sites (outgoing calls)")
-  def call: NodeSteps[nodes.Call] =
-    new NodeSteps(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call])
+  def callOutRegex(regex: String)(implicit callResolver: ICallResolver): NodeSteps[nodes.Call] =
+    new OriginalMethod(wrapped).call.filter(_.calledMethod.fullName(regex))
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -58,6 +58,15 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
     * */
   def controlStructure(regex: String): NodeSteps[nodes.ControlStructure] =
     wrapped.ast.isControlStructure.code(regex)
+  @deprecated("Use `call`", "")
+  def callOut: NodeSteps[nodes.Call] = call
+
+  /**
+    * Outgoing call sites
+    * */
+  @Doc("Call sites (outgoing calls)")
+  def call: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call])
 
   /**
     * The type declaration associated with this method, e.g., the class it is defined in.


### PR DESCRIPTION
This reverts commit d47f3465505ef6b28b4f670cb587ab6e73414f7a.
... because it isn't entirely backward compatible. Bringing in a fixed version tomorrow.