### PR TITLE
Enforce `code` field for CFG nodes

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -81,7 +81,7 @@
         // Nodes of method declarations
 
         {"id" : 1, "name" : "METHOD",
-         "keys": ["NAME", "FULL_NAME", "IS_EXTERNAL", "SIGNATURE", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME",
+         "keys": ["CODE", "NAME", "FULL_NAME", "IS_EXTERNAL", "SIGNATURE", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME",
 		  "LINE_NUMBER", "COLUMN_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER_END", "ORDER", "FILENAME"],
          "comment" : "A method/function/procedure",
          "is": ["DECLARATION", "CFG_NODE", "AST_NODE"],
@@ -463,7 +463,7 @@
 
 	{"id" : 340, "name": "JUMP_TARGET",
 	 "comment" : "A jump target made explicit in the code using a label",
-	 "keys": ["NAME", "COLUMN_NUMBER", "LINE_NUMBER", "ORDER", "PARSER_TYPE_NAME", "ARGUMENT_INDEX", "INTERNAL_FLAGS"],
+	 "keys": ["CODE", "NAME", "COLUMN_NUMBER", "LINE_NUMBER", "ORDER", "PARSER_TYPE_NAME", "ARGUMENT_INDEX", "INTERNAL_FLAGS"],
 	 "is" : ["CFG_NODE", "AST_NODE"],
 	 "outEdges" : [
            {"edgeName": "CFG", "inNodes": [
@@ -524,7 +524,7 @@
       { "name" : "DECLARATION", "comment" : "", "hasKeys" : ["NAME"]},
       { "name" : "EXPRESSION", "comment" : "Expression as a specialisation of tracking point", "hasKeys" : ["CODE", "ORDER", "ARGUMENT_INDEX"], "extends" : ["TRACKING_POINT", "CFG_NODE", "AST_NODE"]},
       { "name" : "LOCAL_LIKE", "comment" : "Formal input parameters, locals, and identifiers", "hasKeys" : ["NAME"]},
-      { "name" : "CFG_NODE", "comment" : "Any node that can occur as part of a control flow graph", "hasKeys" : ["LINE_NUMBER", "COLUMN_NUMBER", "INTERNAL_FLAGS"], "extends": ["WITHIN_METHOD", "AST_NODE"]},
+      { "name" : "CFG_NODE", "comment" : "Any node that can occur as part of a control flow graph", "hasKeys" : ["LINE_NUMBER", "COLUMN_NUMBER", "INTERNAL_FLAGS", "CODE"], "extends": ["WITHIN_METHOD", "AST_NODE"]},
       { "name" : "TRACKING_POINT", "comment" : "Any node that can occur in a data flow", "hasKeys" : [], "extends": ["WITHIN_METHOD"]},
       { "name" : "WITHIN_METHOD", "comment" : "Any node that can exist in a method", "hasKeys" : []},
       { "name" : "AST_NODE", "comment": "Any node that can exist in an abstract syntax tree", "hasKeys" : ["ORDER"]},

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
@@ -21,7 +21,7 @@ class CpgValidatorTest extends WordSpec with Matchers {
       val validator = new CpgValidator(errorRegistry)
       cpg.graph + NodeTypes.METHOD
       validator.validate(cpg) shouldBe false
-      errorRegistry.getErrorCount shouldBe 10
+      errorRegistry.getErrorCount shouldBe 11
     }
   }
 }


### PR DESCRIPTION
*This is part of work I am doing on exposing a useful language for CFG traversals, including traversals over the control dependence graph and dominator trees. These provide a more robust tool than AST traversals alone as they can take into account unstructured control flow. We do currently have some CFG-based filtering in conjunction with the data flow tracker, but these rely on data flows to be detected first, and hence, they can only be used when (a) a sufficient amount of policies is available, and (b) for languages where data-flow tracking works well.*

We previously had two methods for raw CFG traversal: `cfgPrev` and `cfgNext`. Contrary to expectation, these were defined to return `Expressions` as opposed for `CfgNodes`. In a previous PR, I moved them to `CfgNodes`. It turns out now that some scripts assume that `CfgNodes` have a `code` field, and to my surprise, we did not enforce this earlier. It turns out that only two CFG nodes are missing this field: JUMP_TARGET (recently introduced and only used in the C frontend so far) and `METHOD`. 

For JUMP_TARGET, I will fill out this field in the C-frontend now. For methods, we can leave it empty for now and gradually place the method header or something similar there on a per-frontend basis. The code field is frontend-dependent anyway, being similar to parser-type-name.

This should also fix `ocular-latest-deps`.