### PR TITLE
Add `controlledBy`/`controls` method for CFG traversals

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -23,6 +23,22 @@ class CfgNodeMethods(val node: nodes.CfgNode) extends AnyVal {
     * CFG node is control-dependent.
     * */
   def controlledBy: NodeSteps[nodes.CfgNode] = {
+    expandCdg({ v =>
+      v._cdgIn().asScala
+    })
+  }
+
+  /**
+    * Recursively determine all nodes which this
+    * CFG node controls
+    * */
+  def controls: NodeSteps[nodes.CfgNode] = {
+    expandCdg({ v =>
+      v._cdgOut().asScala
+    })
+  }
+
+  private def expandCdg(expand: nodes.CfgNode => Iterator[nodes.StoredNode]) = {
     var controllingNodes = List.empty[nodes.CfgNode]
     var visited = Set.empty + node
     var worklist = node :: Nil
@@ -31,7 +47,7 @@ class CfgNodeMethods(val node: nodes.CfgNode) extends AnyVal {
       val vertex = worklist.head
       worklist = worklist.tail
 
-      vertex._cdgIn.asScala.foreach {
+      expand(vertex).foreach {
         case controllingNode: nodes.CfgNode =>
           if (!visited.contains(controllingNode)) {
             visited += controllingNode

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -2,6 +2,9 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
 
+import scala.jdk.CollectionConverters._
+import io.shiftleft.semanticcpg.language._
+
 class CfgNodeMethods(val node: nodes.CfgNode) extends AnyVal {
 
   /**
@@ -14,5 +17,30 @@ class CfgNodeMethods(val node: nodes.CfgNode) extends AnyVal {
       case expr: nodes.Expression               => expr.code
       case call: nodes.ImplicitCallBase         => call.code
     }
+
+  /**
+    * Recursively determine all nodes on which this
+    * CFG node is control-dependent.
+    * */
+  def controlledBy: NodeSteps[nodes.CfgNode] = {
+    var controllingNodes = List.empty[nodes.CfgNode]
+    var visited = Set.empty + node
+    var worklist = node :: Nil
+
+    while (worklist.nonEmpty) {
+      val vertex = worklist.head
+      worklist = worklist.tail
+
+      vertex._cdgIn.asScala.foreach {
+        case controllingNode: nodes.CfgNode =>
+          if (!visited.contains(controllingNode)) {
+            visited += controllingNode
+            controllingNodes = controllingNode :: controllingNodes
+            worklist = controllingNode :: worklist
+          }
+      }
+    }
+    controllingNodes.start
+  }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -67,4 +67,7 @@ class CfgNode[A <: nodes.CfgNode](val wrapped: NodeSteps[A]) extends AnyVal {
   def controlledBy: NodeSteps[nodes.CfgNode] =
     wrapped.flatMap(_.controlledBy)
 
+  def controls: NodeSteps[nodes.CfgNode] =
+    wrapped.flatMap(_.controls)
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -64,9 +64,15 @@ class CfgNode[A <: nodes.CfgNode](val wrapped: NodeSteps[A]) extends AnyVal {
     * Recursively determine all nodes on which any of
     * the nodes in this traversal are control dependent
     * */
+  @Doc("All nodes on which this node is control dependent")
   def controlledBy: NodeSteps[nodes.CfgNode] =
     wrapped.flatMap(_.controlledBy)
 
+  /**
+    * Recursively determine all nodes which are
+    * control dependent on this node
+    * */
+  @Doc("All nodes control dependent on this node")
   def controls: NodeSteps[nodes.CfgNode] =
     wrapped.flatMap(_.controls)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -60,4 +60,11 @@ class CfgNode[A <: nodes.CfgNode](val wrapped: NodeSteps[A]) extends AnyVal {
         .cast[nodes.CfgNode]
     )
 
+  /**
+    * Recursively determine all nodes on which any of
+    * the nodes in this traversal are control dependent
+    * */
+  def controlledBy: NodeSteps[nodes.CfgNode] =
+    wrapped.flatMap(_.controlledBy)
+
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgTests.scala
@@ -21,14 +21,12 @@ class CfgTests extends WordSpec with Matchers {
 
   CodeToCpgFixture(code) { cpg =>
     "should find that sink is control dependent on condition" in {
-      val controllers = cpg.call("sink").controlledBy.toSet
-      val controllerCalls = controllers.start.isCall.toSet()
-      controllers shouldBe controllerCalls
-      controllerCalls.map(_.code) should contain("y < 10")
-      controllerCalls.map(_.code) should contain("x < 10")
+      val controllers = cpg.call("sink").controlledBy.isCall.toSet
+      controllers.map(_.code) should contain("y < 10")
+      controllers.map(_.code) should contain("x < 10")
     }
     "should find that first if controls `sink`" in {
-      val controlled = cpg.controlStructure.condition.code("y < 10").controls.isCall.name("sink").l.size shouldBe 1
+      cpg.controlStructure.condition.code("y < 10").controls.isCall.name("sink").l.size shouldBe 1
     }
 
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgTests.scala
@@ -1,0 +1,32 @@
+package io.shiftleft.semanticcpg.language.types.expressions.generalizations
+
+import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
+import org.scalatest.{Matchers, WordSpec}
+import io.shiftleft.semanticcpg.language._
+
+class CfgTests extends WordSpec with Matchers {
+
+  val code =
+    """
+      | int foo(int y, int y) {
+      |  if (y < 10)
+      |    goto end;
+      |  if (x < 10) {
+      |    sink(x);
+      |  }
+      |  end:
+      |  printf("foo");
+      | }
+    """.stripMargin
+
+  CodeToCpgFixture(code) { cpg =>
+    "should find that sink is control dependent on condition" in {
+      val controllers = cpg.call("sink").controlledBy.toSet
+      val controllerCalls = controllers.start.isCall.toSet()
+      controllers shouldBe controllerCalls
+      controllerCalls.map(_.code) should contain("y < 10")
+      controllerCalls.map(_.code) should contain("x < 10")
+    }
+  }
+
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgTests.scala
@@ -27,6 +27,10 @@ class CfgTests extends WordSpec with Matchers {
       controllerCalls.map(_.code) should contain("y < 10")
       controllerCalls.map(_.code) should contain("x < 10")
     }
+    "should find that first if controls `sink`" in {
+      val controlled = cpg.controlStructure.condition.code("y < 10").controls.isCall.name("sink").l.size shouldBe 1
+    }
+
   }
 
 }


### PR DESCRIPTION
*This is part of work I am doing on exposing a useful language for CFG traversals, including traversals over the control dependence graph and dominator trees. These provide a more robust tool than AST traversals alone as they can take into account unstructured control flow. We do currently have some CFG-based filtering in conjunction with the data flow tracker, but these rely on data flows to be detected first, and hence, they can only be used when (a) a sufficient amount of policies is available, and (b) for languages where data-flow tracking works well.*

A utility method named `getControllingNodesFromCdg` was available in `io.shiftleft.dataflowengine`: getting controlling nodes from the CDG seems generally useful, and so, this PR adds it to the language as `controlledBy`. I have also added the counterpart `controls`, which walks CDG edhes in the opposite direction. Once this is merged, we can optionally remove the utility method in `io.shiftleft.dataflowengine`.