### PR TITLE
Shorthand for looking up tags by name

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -273,4 +273,7 @@ class NodeTypeStarters(cpg: Cpg) {
   def tag: NodeSteps[nodes.Tag] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TAG).cast[nodes.Tag])
 
+  @Doc("All tags with given name")
+  def tag(name: String): NodeSteps[nodes.Tag] = tag.name(name)
+
 }


### PR DESCRIPTION
Minor improvement for tagging language: allow `cpg.tag("foo")` as a shorthand for `cpg.tag.name("foo")`