### PR TITLE
Rename node start steps which still use plural to singular version.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -83,17 +83,31 @@ class NodeTypeStarters(cpg: Cpg) {
     namespaceBlock.name(name)
 
   /**
-    Traverse to all types, e.g., Set<String>
+  Traverse to all types, e.g., Set<String>
     */
   @Doc("All used types")
+  def typ: NodeSteps[nodes.Type] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TYPE).cast[nodes.Type])
+
+  /**
+    * Shorthand for `cpg.types.fullName(fullName)`
+    * */
+  def typ(fullName: String): NodeSteps[nodes.Type] =
+    typ.fullName(fullName)
+
+  /**
+    Traverse to all types, e.g., Set<String>
+    */
+  @deprecated("Use typ")
   def types: NodeSteps[nodes.Type] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.TYPE).cast[nodes.Type])
 
   /**
     * Shorthand for `cpg.types.fullName(fullName)`
     * */
+  @deprecated("Use typ")
   def types(fullName: String): NodeSteps[nodes.Type] =
-    types.fullName(fullName)
+    typ.fullName(fullName)
 
   /**
     Traverse to all declarations, e.g., Set<T>
@@ -224,14 +238,28 @@ class NodeTypeStarters(cpg: Cpg) {
     * Traverse to all return expressions
     */
   @Doc("All actual return parameters")
+  def ret: NodeSteps[nodes.Return] =
+    new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.RETURN).cast[nodes.Return])
+
+  /**
+    * Shorthand for `returns.code(code)`
+    * */
+  def ret(code: String): NodeSteps[nodes.Return] =
+    ret.code(code)
+
+  /**
+    * Traverse to all return expressions
+    */
+  @deprecated("Use ret")
   def returns: NodeSteps[nodes.Return] =
     new NodeSteps(scalaGraph.V.hasLabel(NodeTypes.RETURN).cast[nodes.Return])
 
   /**
     * Shorthand for `returns.code(code)`
     * */
+  @deprecated("Use ret")
   def returns(code: String): NodeSteps[nodes.Return] =
-    returns.code(code)
+    ret.code(code)
 
   /**
     * Traverse to all meta data entries

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/argumentcompat/ArgumentCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/argumentcompat/ArgumentCompat.scala
@@ -18,7 +18,7 @@ class ArgumentCompat(cpg: Cpg) extends CpgPass(cpg) {
       val diffGraph = DiffGraph.newBuilder
       val callIterator = cpg.call.toIterator()
       callIterator.foreach(addArgumentEdges(_, diffGraph))
-      val returnIterator = cpg.returns.toIterator()
+      val returnIterator = cpg.ret.toIterator()
       returnIterator.foreach(addArgumentEdges(_, diffGraph))
       Iterator(diffGraph.build())
     } else {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
@@ -127,7 +127,7 @@ class TypeTests extends WordSpec with Matchers {
     "ClassHierarchyTest for types" should {
       "have class Base as base class of class Derived" in {
         def queryResult: List[nodes.Type] =
-          fixture.cpg.types
+          fixture.cpg.typ
             .name(".*Derived")
             .baseType
             .name(".*Base")
@@ -138,7 +138,7 @@ class TypeTests extends WordSpec with Matchers {
 
       "have class Dervied as derived class of class Base" in {
         def queryResult: List[nodes.Type] =
-          fixture.cpg.types
+          fixture.cpg.typ
             .name(".*Base")
             .derivedType
             .name(".*Derived")
@@ -149,7 +149,7 @@ class TypeTests extends WordSpec with Matchers {
 
       "have classes Interface1, Interface2 and Object as base classes of class InterfaceImplementor" in {
         def queryResult: List[nodes.Type] =
-          fixture.cpg.types
+          fixture.cpg.typ
             .name(".*InterfaceImplementor")
             .baseType
             .toList
@@ -161,7 +161,7 @@ class TypeTests extends WordSpec with Matchers {
 
       "have class InterfaceImplementor as derived class of class Interface1" in {
         def queryResult: List[nodes.Type] =
-          fixture.cpg.types
+          fixture.cpg.typ
             .name(".*Interface1")
             .derivedType
             .name(".*InterfaceImplementor")
@@ -172,7 +172,7 @@ class TypeTests extends WordSpec with Matchers {
 
       "have class InterfaceImplementor as derived class of class Interface2" in {
         def queryResult: List[nodes.Type] =
-          fixture.cpg.types
+          fixture.cpg.typ
             .name(".*Interface2")
             .derivedType
             .name(".*InterfaceImplementor")
@@ -183,7 +183,7 @@ class TypeTests extends WordSpec with Matchers {
 
       "have Derived and Derived2 as transitive derived types of Base" in {
         def queryResult: List[nodes.Type] =
-          fixture.cpg.types
+          fixture.cpg.typ
             .name(".*Base")
             .derivedTypeTransitive
             .toList
@@ -193,7 +193,7 @@ class TypeTests extends WordSpec with Matchers {
 
       "have Base and Object as transitive base types of Derived" in {
         def queryResult: List[nodes.Type] =
-          fixture.cpg.types
+          fixture.cpg.typ
             .name(".*Derived")
             .baseTypeTransitive
             .toList


### PR DESCRIPTION
Renamed types to typ.
Renamed returns to return.

The plural versions still exist but are deprecated now.