### PR TITLE
Rename call step on expression to inCall.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -51,6 +51,13 @@ class Expression[NodeType <: nodes.Expression](val wrapped: NodeSteps[NodeType])
   /**
     * Traverse to surrounding call
     * */
+  def inCall: NodeSteps[nodes.Call] =
+    new NodeSteps(raw.repeat(_.in(EdgeTypes.ARGUMENT)).until(_.hasLabel(NodeTypes.CALL)).cast[nodes.Call])
+
+  /**
+    * Traverse to surrounding call
+    * */
+  @deprecated("Use inCall")
   def call: NodeSteps[nodes.Call] =
     new NodeSteps(raw.repeat(_.in(EdgeTypes.ARGUMENT)).until(_.hasLabel(NodeTypes.CALL)).cast[nodes.Call])
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
@@ -43,7 +43,7 @@ class CallGraphTests extends WordSpec with Matchers {
     }
 
     "should allow traversing from argument to call" in {
-      cpg.method.name("printf").callIn.argument.call.name.toSet shouldBe Set("printf")
+      cpg.method.name("printf").callIn.argument.inCall.name.toSet shouldBe Set("printf")
     }
 
   }


### PR DESCRIPTION
This is a preparation to "free" the step name call which we
will later use for traversing to calls nested in an expression.