### PR TITLE
Introduce `changeWorkspace`

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -26,7 +26,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
   def console: Console[T] = this
 
   protected var workspaceManager: WorkspaceManager[T] = _
-  changeWorkspace(config.install.rootPath.path.resolve("workspace").toString)
+  switchWorkspace(config.install.rootPath.path.resolve("workspace").toString)
   protected def workspacePathName: String = workspaceManager.getPath
 
   private val nameOfCpgInProject = "cpg.bin"
@@ -91,7 +91,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
       | workspace is first created.
       |""".stripMargin
   )
-  def changeWorkspace(pathName: String): Unit = {
+  def switchWorkspace(pathName: String): Unit = {
     if (workspaceManager != null) {
       report("Saving current workspace before changing workspace")
       workspaceManager.projects.foreach { p =>

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -25,8 +25,10 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
   def config: ConsoleConfig = _config
   def console: Console[T] = this
 
-  protected val workspacePathName: String = config.install.rootPath.path.resolve("workspace").toString
-  protected val workspaceManager = new WorkspaceManager[T](workspacePathName, loader)
+  protected var workspaceManager: WorkspaceManager[T] = _
+  changeWorkspace(config.install.rootPath.path.resolve("workspace").toString)
+  protected def workspacePathName: String = workspaceManager.getPath
+
   private val nameOfCpgInProject = "cpg.bin"
 
   implicit object ConsoleImageViewer extends ImageViewer {
@@ -77,6 +79,27 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
     "workspace"
   )
   def workspace: WorkspaceManager[T] = workspaceManager
+
+  @Doc(
+    "Close current workspace and open a different one",
+    """ | By default, the workspace in $INSTALL_DIR/workspace is used.
+      | This method allows specifying a different workspace directory
+      | via the `pathName` parameter.
+      | Before changing the workspace, the current workspace will be
+      | closed, saving any unsaved changes.
+      | If `pathName` points to a non-existing directory, then a new
+      | workspace is first created.
+      |""".stripMargin
+  )
+  def changeWorkspace(pathName: String): Unit = {
+    if (workspaceManager != null) {
+      report("Saving current workspace before changing workspace")
+      workspaceManager.projects.foreach { p =>
+        p.close
+      }
+    }
+    workspaceManager = new WorkspaceManager[T](pathName, loader)
+  }
 
   @Doc("Currently active project", "", "project")
   def project: T =

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -3,7 +3,7 @@ package io.shiftleft.console
 import java.io.FileOutputStream
 import java.util.zip.ZipOutputStream
 
-import better.files.Dsl.cp
+import better.files.Dsl._
 import better.files._
 import io.shiftleft.codepropertygraph.Cpg
 import org.scalatest.{Matchers, WordSpec}
@@ -326,7 +326,39 @@ class ConsoleTests extends WordSpec with Matchers {
       console.undo
       console.cpg.metaData.map(_.overlays).head.last shouldBe "semanticcpg"
     }
+  }
 
+  "changeWorkspace" should {
+
+    "create workspace if directory does not exist" in ConsoleFixture() { (console, _) =>
+      val otherWorkspaceDir = ("/tmp" / "workspace-doesNotExist")
+      try {
+        otherWorkspaceDir.exists shouldBe false
+        console.changeWorkspace(otherWorkspaceDir.path.toString)
+        otherWorkspaceDir.exists shouldBe true
+      } finally {
+        otherWorkspaceDir.delete()
+        otherWorkspaceDir.exists shouldBe false
+      }
+    }
+
+    "allow changing workspaces" in ConsoleFixture() { (console, codeDir) =>
+      val firstWorkspace = File(console.workspace.getPath)
+      File.usingTemporaryDirectory("console") { otherWorkspaceDir =>
+        console.importCode(codeDir.toString, "projectInFirstWorkspace")
+        console.workspace.numberOfProjects shouldBe 1
+        console.changeWorkspace(otherWorkspaceDir.path.toString)
+        console.workspace.numberOfProjects shouldBe 0
+
+        console.importCode(codeDir.toString, "projectInSecondWorkspace")
+        console.workspace.numberOfProjects shouldBe 1
+        console.project.name shouldBe "projectInSecondWorkspace"
+        console.changeWorkspace(firstWorkspace.path.toString)
+        console.workspace.numberOfProjects shouldBe 1
+        console.open("projectInFirstWorkspace")
+        console.project.name shouldBe "projectInFirstWorkspace"
+      }
+    }
   }
 
 }

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -328,13 +328,13 @@ class ConsoleTests extends WordSpec with Matchers {
     }
   }
 
-  "changeWorkspace" should {
+  "switchWorkspace" should {
 
     "create workspace if directory does not exist" in ConsoleFixture() { (console, _) =>
       val otherWorkspaceDir = ("/tmp" / "workspace-doesNotExist")
       try {
         otherWorkspaceDir.exists shouldBe false
-        console.changeWorkspace(otherWorkspaceDir.path.toString)
+        console.switchWorkspace(otherWorkspaceDir.path.toString)
         otherWorkspaceDir.exists shouldBe true
       } finally {
         otherWorkspaceDir.delete()
@@ -347,13 +347,13 @@ class ConsoleTests extends WordSpec with Matchers {
       File.usingTemporaryDirectory("console") { otherWorkspaceDir =>
         console.importCode(codeDir.toString, "projectInFirstWorkspace")
         console.workspace.numberOfProjects shouldBe 1
-        console.changeWorkspace(otherWorkspaceDir.path.toString)
+        console.switchWorkspace(otherWorkspaceDir.path.toString)
         console.workspace.numberOfProjects shouldBe 0
 
         console.importCode(codeDir.toString, "projectInSecondWorkspace")
         console.workspace.numberOfProjects shouldBe 1
         console.project.name shouldBe "projectInSecondWorkspace"
-        console.changeWorkspace(firstWorkspace.path.toString)
+        console.switchWorkspace(firstWorkspace.path.toString)
         console.workspace.numberOfProjects shouldBe 1
         console.open("projectInFirstWorkspace")
         console.project.name shouldBe "projectInFirstWorkspace"


### PR DESCRIPTION
Part of the work on ocular-server.

We were previously limited to a single workspace (located in the installation directory). For Ocular server, we want to be able to offer access to multiple workspaces and allow workers to change the workspace they are working on.
