### PR TITLE
freshen up `id` steps: we always use `Long` ids

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -23,6 +23,21 @@ class NodeSteps[NodeType <: nodes.StoredNode](raw: GremlinScala[NodeType]) exten
   )
   def label: Steps[String] = new Steps(raw.label)
 
+  @Doc("Traverse to ids of underlying nodes")
+  def id: Steps[Long] = new Steps(raw.map(_.id2))
+
+  @Doc("Filter: only keep node with given id")
+  def id(value: Long): Steps[NodeType] =
+    new Steps(raw.filterOnEnd(_.id2 == value))
+
+  @Doc("Filter: only keep nodes with given ids")
+  def id(values: Long*): Steps[NodeType] =
+    id(Set(values: _*))
+
+  @Doc("Filter: only keep nodes with given ids")
+  def id(values: Set[Long]): Steps[NodeType] =
+    new Steps(raw.filterOnEnd(node => values.contains(node.id2)))
+
   @Doc(
     "The source file this code is in",
     """

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -168,23 +168,6 @@ class Steps[A](val raw: GremlinScala[A]) {
     new Steps[A](raw.dedup())
 
   /**
-    * Traverse to ids of underlying objects
-    * */
-  def id: Steps[AnyRef] = new Steps(raw.id)
-
-  /**
-    Step that selects only the node with the given id.
-    */
-  def id(key: AnyRef)(implicit isElement: A <:< Element): Steps[A] =
-    new Steps[A](raw.hasId(key))
-
-  /**
-    Step that selects only nodes in the given id set `keys`.
-    */
-  def id(keys: Set[AnyRef])(implicit isElement: A <:< Element): Steps[A] =
-    new Steps[A](raw.hasId(P.within(keys)))
-
-  /**
     Repeat the given traversal. This step can be combined with the until and emit steps to
     provide a termination and emit criteria.
     */

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -42,7 +42,7 @@ class StepsTest extends WordSpec with Matchers {
       "providing one" in ExistingCpgFixture("splitmeup") { fixture =>
         // find an arbitrary method so we can find it again in the next step
         val method: nodes.Method = fixture.cpg.method.toList.head
-        val results: List[nodes.Method] = fixture.cpg.method.id(method.underlying.id).toList
+        val results: List[nodes.Method] = fixture.cpg.method.id(method.id2).toList
 
         results.size shouldBe 1
         results.head.underlying.id
@@ -51,7 +51,7 @@ class StepsTest extends WordSpec with Matchers {
       "providing multiple" in ExistingCpgFixture("splitmeup") { fixture =>
         // find two arbitrary methods so we can find it again in the next step
         val methods: Set[nodes.Method] = fixture.cpg.method.toList.take(2).toSet
-        val results: List[nodes.Method] = fixture.cpg.method.id(methods.map(_.id())).toList
+        val results: List[nodes.Method] = fixture.cpg.method.id(methods.map(_.id2)).toList
 
         results.size shouldBe 2
         results.toSet shouldBe methods.toSet


### PR DESCRIPTION
queries like `cpg.method.id(1L).l` compile now - thanks @ursachec for reporting!