### PR TITLE
Embedded Ammonite Shell and Tests

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/embammonite/EmbeddedAmmonite.scala
+++ b/console/src/main/scala/io/shiftleft/console/embammonite/EmbeddedAmmonite.scala
@@ -1,0 +1,154 @@
+package io.shiftleft.console.embammonite
+
+import java.io.{BufferedReader, InputStreamReader, PipedInputStream, PipedOutputStream, PrintWriter}
+import java.util.UUID
+import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, Semaphore}
+
+import ammonite.util.Colors
+import org.apache.logging.log4j.LogManager
+
+/**
+  * Result of executing a query, containing in particular
+  * output received on standard out and on standard error.
+  * */
+class QueryResult(val out: String, val err: String)
+
+private[embammonite] case class Job(uuid: UUID, query: String, observer: QueryResult => Unit)
+
+class EmbeddedAmmonite(predef: String = "") {
+
+  private val logger = LogManager.getLogger(this.getClass)
+
+  val jobQueue: BlockingQueue[Job] = new LinkedBlockingQueue[Job]()
+
+  val (inStream, toStdin) = pipePair()
+  val (fromStdout, outStream) = pipePair()
+  val (fromStderr, errStream) = pipePair()
+
+  val writer = new PrintWriter(toStdin)
+  val reader = new BufferedReader(new InputStreamReader(fromStdout))
+  val errReader = new BufferedReader(new InputStreamReader(fromStderr))
+
+  val userThread = new Thread(new UserRunnable(jobQueue, writer, reader, errReader))
+
+  val shellThread = new Thread(() => {
+    val ammoniteShell =
+      ammonite
+        .Main(
+          predefCode = EmbeddedAmmonite.predef + predef,
+          welcomeBanner = None,
+          remoteLogging = false,
+          colors = Colors.BlackWhite,
+          inputStream = inStream,
+          outputStream = outStream,
+          errorStream = errStream
+        )
+    ammoniteShell.run()
+  })
+
+  private def pipePair(): (PipedInputStream, PipedOutputStream) = {
+    val out = new PipedOutputStream()
+    val in = new PipedInputStream()
+    in.connect(out)
+    (in, out)
+  }
+
+  /**
+    * Start the embedded ammonite shell
+    * */
+  def start(): Unit = {
+    shellThread.start()
+    userThread.start()
+  }
+
+  /**
+    * Submit query `q` to shell and call `observer` when
+    * the result is ready.
+    * */
+  def queryAsync(q: String)(observer: QueryResult => Unit): UUID = {
+    val uuid = UUID.randomUUID()
+    jobQueue.add(Job(uuid, q, observer))
+    uuid
+  }
+
+  /**
+    * Submit query `q` to the shell and return result.
+    * */
+  def query(q: String): QueryResult = {
+    val mutex = new Semaphore(0)
+    var result: QueryResult = null
+    queryAsync(q) { r =>
+      result = r
+      mutex.release()
+    }
+    mutex.acquire()
+    result
+  }
+
+  /**
+    * Shutdown the embedded ammonite shell and
+    * associated threads.
+    * */
+  def shutdown(): Unit = {
+    shutdownShellThread()
+    logger.info("Shell terminated gracefully")
+    shutdownWriterThread()
+
+    def shutdownWriterThread(): Unit = {
+      jobQueue.add(Job(null, null, null))
+      userThread.join()
+    }
+    def shutdownShellThread(): Unit = {
+      writer.println("exit")
+      writer.close()
+      shellThread.join()
+    }
+  }
+
+}
+
+object EmbeddedAmmonite {
+
+  /* The standard frontend attempts to query /dev/tty
+      in multiple places, e.g., to query terminal dimensions.
+      This does not work in intellij tests
+      (see https://github.com/lihaoyi/Ammonite/issues/276)
+      The below hack overrides the default frontend with
+      a custom frontend that does not require /dev/tty.
+      This also enables us to disable terminal echo
+      by passing a `displayTransform` that returns
+      an empty string on all input.
+   */
+
+  val predef: String =
+    """
+      | class CustomFrontend extends ammonite.repl.AmmoniteFrontEnd() {
+      |   override def width = 100
+      |   override def height = 100
+      |
+      |  override def readLine(reader: java.io.Reader,
+      |                        output: java.io.OutputStream,
+      |                        prompt: String,
+      |                        colors: ammonite.util.Colors,
+      |                        compilerComplete: (Int, String) => (Int, Seq[String], Seq[String]),
+      |                        history: IndexedSeq[String]) = {
+      |
+      |  val writer = new java.io.OutputStreamWriter(output)
+      |
+      | val multilineFilter = ammonite.terminal.Filter.action(
+      |   ammonite.terminal.SpecialKeys.NewLine,
+      |   ti => ammonite.interp.Parsers.split(ti.ts.buffer.mkString).isEmpty
+      | ){
+      |   case ammonite.terminal.TermState(rest, b, c, _) => ammonite.terminal.filters.BasicFilters.injectNewLine(b, c, rest)
+      | }
+      |
+      |  val allFilters = ammonite.terminal.Filter.merge(extraFilters, multilineFilter, ammonite.terminal.filters.BasicFilters.all)
+      |
+      |  new ammonite.terminal.LineReader(width, prompt, reader, writer, allFilters, displayTransform = { (x: Vector[Char], i: Int) => (fansi.Str(""), i) } )
+      |  .readChar(ammonite.terminal.TermState(ammonite.terminal.LazyList.continually(reader.read()), Vector.empty, 0, ""), 0)
+      | }
+      |}
+      | repl.frontEnd() = new CustomFrontend()
+      |
+      |""".stripMargin
+}

--- a/console/src/main/scala/io/shiftleft/console/embammonite/UserRunnable.scala
+++ b/console/src/main/scala/io/shiftleft/console/embammonite/UserRunnable.scala
@@ -1,0 +1,91 @@
+package io.shiftleft.console.embammonite
+
+import java.io.{BufferedReader, PrintWriter}
+import java.util.UUID
+import java.util.concurrent.BlockingQueue
+
+import org.apache.logging.log4j.LogManager
+
+import scala.util.Try
+
+class UserRunnable(queue: BlockingQueue[Job], writer: PrintWriter, reader: BufferedReader, errReader: BufferedReader)
+    extends Runnable {
+
+  private val logger = LogManager.getLogger(this.getClass)
+
+  private val magicEchoSeq: Seq[Char] = List(27, 91, 57, 57, 57, 57, 68, 27, 91, 48, 74, 64, 32).map(_.toChar)
+  private val endMarker = """.*END: ([0-9a-f\-]+)""".r
+
+  override def run(): Unit = {
+    try {
+      var terminate = false;
+      while (!(terminate && queue.isEmpty)) {
+        val job = queue.take()
+        if (isTerminationMarker(job)) {
+          terminate = true
+        } else {
+          sendQueryToAmmonite(job)
+          val stdoutPair = stdOutUpToMarker()
+          val stdOutput = stdoutPair.get
+          val errOutput = exhaustStderr()
+          val result = new QueryResult(stdOutput, errOutput)
+          job.observer(result)
+        }
+      }
+    } catch {
+      case _: InterruptedException =>
+        logger.info("Interrupted WriterThread")
+    }
+    logger.info("WriterThread terminated gracefully")
+  }
+
+  private def isTerminationMarker(job: Job): Boolean = {
+    job.uuid == null && job.query == null
+  }
+
+  private def sendQueryToAmmonite(job: Job): Unit = {
+    writer.println(job.query.trim)
+    writer.println(s""""END: ${job.uuid}"""")
+    writer.println(s"""throw new RuntimeException("END: ${job.uuid}")""")
+    writer.flush()
+  }
+
+  private def stdOutUpToMarker(): Option[String] = {
+    var currentOutput: String = ""
+    var line = reader.readLine()
+    while (line != null) {
+      if (!line.startsWith(magicEchoSeq) && !line.isEmpty) {
+        val uuid = uuidFromLine(line)
+        if (uuid.isEmpty) {
+          currentOutput += line + "\n"
+        } else {
+          return Some(currentOutput)
+        }
+      }
+      line = reader.readLine()
+    }
+    None
+  }
+
+  private def uuidFromLine(line: String): Iterator[UUID] = {
+    endMarker.findAllIn(line).matchData.flatMap { m =>
+      Try { UUID.fromString(m.group(1)) }.toOption
+    }
+  }
+
+  private def exhaustStderr(): String = {
+    var currentOutput = ""
+    var line = errReader.readLine()
+    while (line != null) {
+      val uuid = uuidFromLine(line)
+      if (uuid.isEmpty) {
+        currentOutput += line
+      } else {
+        return currentOutput
+      }
+      line = errReader.readLine()
+    }
+    currentOutput
+  }
+
+}

--- a/console/src/test/scala/io/shiftleft/console/embammonite/EmbeddedAmmoniteTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/embammonite/EmbeddedAmmoniteTests.scala
@@ -1,0 +1,41 @@
+package io.shiftleft.console.embammonite
+
+import java.util.concurrent.Semaphore
+
+import org.scalatest.{Matchers, WordSpec}
+
+class EmbeddedAmmoniteTests extends WordSpec with Matchers {
+
+  "EmbeddedAmmoniteShell" should {
+    "start and shutdown without hanging" in {
+      val shell = new EmbeddedAmmonite()
+      shell.start()
+      shell.shutdown()
+    }
+
+    "execute a command synchronously" in {
+      val shell = new EmbeddedAmmonite()
+      shell.start()
+      val result = shell.query("def foo() = {\n1\n}\n foo()")
+      result.out shouldBe
+        """defined function foo
+          |res1: Int = 1
+          |""".stripMargin
+      shell.shutdown()
+    }
+
+    "execute a command asynchronously" in {
+      val shell = new EmbeddedAmmonite()
+      val mutex = new Semaphore(0)
+      shell.start()
+      shell.queryAsync("val x = 0") { result =>
+        result.out shouldBe "x: Int = 0\n"
+        mutex.release()
+      }
+      mutex.acquire()
+      shell.shutdown()
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR introduces an embedded ammonite shell in `io.shiftleft.console`. The shell is internally controlled by holding a pipe to ammonite's stdin and pipes from its stdout and stderr. From the user perspective, queries can be submitted to the shell and results are returned (synchronous mode), however, it is also possible to submit a query and invoke a method once the result is ready (asynchronous mode). Please see the unit tests for usage examples.

**Assumptions:**
- We assume that a single embedded Ammonite shell services only a single user at once. Anything else seems to ask for trouble as it would be equivalent to multiple users typing on the same terminal - interleaving commands while the shell holds only a single state.
- We do however want to allow this user to post a sequence of commands, e.g., via HTTP, and then process results as they become available.

**Design**
- Ammonite is started in a thread and we keep pipes to stdin and from stdout and stderr to communicate with it
- A second thread - the UserThread - holds these pipes and blocks on a queue.
- Upon calls to `.queryAsync`, a job is placed in the queue, which the UserThread then fetches and services - performing the necessary communication with Ammonite via pipes. Upon completion, it calls the `observer` passed to `.queryAsync`
- For convenience, we also offer `query`, which blocks until `queryAsync` has completed, then fetches the result and returns it to the caller.

**Some things you may find interesting**
- With the default ammonite frontend, an embedded shell cannot be run in environments where `/dev/tty` is not properly configured, e.g., in certain containers and in IntelliJ tests. The solution is to provide a custom ammonite frontend, which we do via predef
- Ammonite does not allow disabling terminal echo, however, we can disable it by replacing the `displayTransform` in our custom frontend with a function that swallows its input
- With the default frontend and redirected stdin, ctrl+c is not received on the shell. This problem can be fixed by spawning a separate thread that listens on stdin and then sends SIGINT to ammonite, a route I initially followed. Upon replacing the default frontend, however, this problem no longer existed.
