### PR TITLE
Fix bug in handling of legacy `loadCpg`

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -187,7 +187,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
 
   protected def fixProjectNameAndComplainOnFix(name: String): String = {
     val projectName = Some(name)
-      .filter(_.contains(java.io.File.pathSeparator))
+      .filter(_.contains(java.io.File.separator))
       .map(deriveNameFromInputPath)
       .getOrElse(name)
     if (name != projectName) {


### PR DESCRIPTION
We were using `pathSeparator` as opposed to `separator` in code that detects when path names are passed as project names.