### PR TITLE
Ocular/Joern WebSocket Server

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -63,7 +63,5 @@ libraryDependencies ++= Seq(
   "com.lihaoyi"          %% "ammonite"      % AmmoniteVersion cross CrossVersion.full,
   "com.lihaoyi" 	 %% "cask" 	    % CaskVersion,
   "io.shiftleft"         %% "fuzzyc2cpg"    % Versions.fuzzyc2cpg,
-  "org.scalatest"        %% "scalatest"     % ScalatestVersion % Test,
-  "com.lihaoyi"          %% "requests"          % "0.6.2" % Test,
-  "org.asynchttpclient"  % "async-http-client" % "2.5.2" % Test
+  "org.scalatest"        %% "scalatest"     % ScalatestVersion % Test
 )

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -62,6 +62,8 @@ libraryDependencies ++= Seq(
   "org.zeroturnaround"   %  "zt-zip"        % ZeroturnaroundVersion,
   "com.lihaoyi"          %% "ammonite"      % AmmoniteVersion cross CrossVersion.full,
   "com.lihaoyi" 	 %% "cask" 	    % CaskVersion,
+  "io.shiftleft"         %% "fuzzyc2cpg"    % Versions.fuzzyc2cpg,
   "org.scalatest"        %% "scalatest"     % ScalatestVersion % Test,
-  "io.shiftleft" %% "fuzzyc2cpg"            % Versions.fuzzyc2cpg,
+  "com.lihaoyi"          %% "requests"          % "0.6.2" % Test,
+  "org.asynchttpclient"  % "async-http-client" % "2.5.2" % Test
 )

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -45,6 +45,7 @@ scalacOptions ++= Seq(
 
 val ScoptVersion = "3.7.1"
 val BetterFilesVersion = "3.8.0"
+val CaskVersion = "0.6.7"
 val CatsVersion = "2.0.0"
 val CirceVersion = "0.12.2"
 val AmmoniteVersion = "1.8.1"
@@ -60,6 +61,7 @@ libraryDependencies ++= Seq(
   "io.circe"             %% "circe-parser"  % CirceVersion,
   "org.zeroturnaround"   %  "zt-zip"        % ZeroturnaroundVersion,
   "com.lihaoyi"          %% "ammonite"      % AmmoniteVersion cross CrossVersion.full,
+  "com.lihaoyi" 	 %% "cask" 	    % CaskVersion,
   "org.scalatest"        %% "scalatest"     % ScalatestVersion % Test,
   "io.shiftleft" %% "fuzzyc2cpg"            % Versions.fuzzyc2cpg,
 )

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -3,13 +3,16 @@ package io.shiftleft.console
 import ammonite.ops.pwd
 import ammonite.ops.Path
 import ammonite.util.{Colors, Res}
+
 import better.files._
+import io.shiftleft.console.embammonite.EmbeddedAmmonite
 
 case class Config(
     scriptFile: Option[Path] = None,
     params: Map[String, String] = Map.empty,
     additionalImports: List[Path] = Nil,
     nocolors: Boolean = false,
+    server: Boolean = false,
     command: Option[String] = None
 )
 
@@ -46,6 +49,10 @@ trait BridgeBase {
         .action((_, c) => c.copy(nocolors = true))
         .text("turn off colors")
 
+      opt[Unit]("server")
+        .action((_, c) => c.copy(server = true))
+        .text("run as HTTP server")
+
       opt[String]("command")
         .action((x, c) => c.copy(command = Some(x)))
         .text("select one of multiple @main methods")
@@ -58,74 +65,94 @@ trait BridgeBase {
   }
 
   protected def runAmmonite(config: Config, slProduct: SLProduct = OcularProduct): Unit = {
-    val additionalImportCode: List[String] =
-      config.additionalImports.flatMap { importScript =>
-        val file = importScript.toIO
-        assert(file.canRead, s"unable to read $file")
-        readScript(file.toScala)
-      }
-
-    val ammoniteColors =
-      if (config.nocolors) Colors.BlackWhite
-      else Colors.Default
-
     config.scriptFile match {
       case None =>
-        val configurePPrinterMaybe =
-          if (config.nocolors) ""
-          else """val originalPPrinter = repl.pprinter()
-                 |repl.pprinter.update(io.shiftleft.console.pprinter.create(originalPPrinter))
-                 |""".stripMargin
-
-        val replConfig = List(
-          "repl.prompt() = \"" + promptStr() + "\"",
-          configurePPrinterMaybe,
-          "banner()"
-        )
-        ammonite
-          .Main(
-            predefCode = predefPlus(additionalImportCode ++ replConfig ++ shutdownHooks),
-            welcomeBanner = None,
-            storageBackend = new StorageBackend(slProduct),
-            remoteLogging = false,
-            colors = ammoniteColors
-          )
-          .run()
-
+        if (config.server) {
+          startHttpServer(config)
+        } else {
+          startInteractiveShell(config, slProduct)
+        }
       case Some(scriptFile) =>
-        val isEncryptedScript = scriptFile.ext == "enc"
-        println(s"executing $scriptFile with params=${config.params}")
-        val scriptArgs: Seq[(String, Option[String])] = {
-          val commandArgs = config.command match {
-            case Some(command) => Seq(command -> None)
-            case _             => Nil
-          }
-          commandArgs ++ config.params.view.mapValues(Option.apply).toSeq
-        }
-        val actualScriptFile =
-          if (isEncryptedScript) decryptedScript(scriptFile)
-          else scriptFile
-        ammonite
-          .Main(
-            predefCode = predefPlus(additionalImportCode ++ shutdownHooks),
-            remoteLogging = false,
-            colors = ammoniteColors
-          )
-          .runScript(actualScriptFile, scriptArgs)
-          ._1 match {
-          case Res.Success(r) =>
-            println(s"script finished successfully")
-            println(r)
-          case Res.Failure(msg) =>
-            throw new AssertionError(s"script failed: $msg")
-          case Res.Exception(e, msg) =>
-            throw new AssertionError(s"script errored: $msg", e)
-          case _ => ???
-        }
-        /* minimizing exposure time by deleting the decrypted script straight away */
-        if (isEncryptedScript) actualScriptFile.toIO.delete
+        runScript(scriptFile, config)
     }
   }
+
+  private def startInteractiveShell(config: Config, slProduct: SLProduct) = {
+    val configurePPrinterMaybe =
+      if (config.nocolors) ""
+      else """val originalPPrinter = repl.pprinter()
+             |repl.pprinter.update(io.shiftleft.console.pprinter.create(originalPPrinter))
+             |""".stripMargin
+
+    val replConfig = List(
+      "repl.prompt() = \"" + promptStr() + "\"",
+      configurePPrinterMaybe,
+      "banner()"
+    )
+    ammonite
+      .Main(
+        predefCode = predefPlus(additionalImportCode(config) ++ replConfig ++ shutdownHooks),
+        welcomeBanner = None,
+        storageBackend = new StorageBackend(slProduct),
+        remoteLogging = false,
+        colors = ammoniteColors(config)
+      )
+      .run()
+  }
+
+  private def startHttpServer(config: Config): Unit = {
+    val predef = predefPlus(additionalImportCode(config))
+    val ammonite = new EmbeddedAmmonite(predef)
+    ammonite.start()
+
+    // TODO start server
+    ammonite.shutdown()
+  }
+
+  private def runScript(scriptFile: Path, config: Config) = {
+    val isEncryptedScript = scriptFile.ext == "enc"
+    println(s"executing $scriptFile with params=${config.params}")
+    val scriptArgs: Seq[(String, Option[String])] = {
+      val commandArgs = config.command match {
+        case Some(command) => Seq(command -> None)
+        case _             => Nil
+      }
+      commandArgs ++ config.params.view.mapValues(Option.apply).toSeq
+    }
+    val actualScriptFile =
+      if (isEncryptedScript) decryptedScript(scriptFile)
+      else scriptFile
+    ammonite
+      .Main(
+        predefCode = predefPlus(additionalImportCode(config) ++ shutdownHooks),
+        remoteLogging = false,
+        colors = ammoniteColors(config)
+      )
+      .runScript(actualScriptFile, scriptArgs)
+      ._1 match {
+      case Res.Success(r) =>
+        println(s"script finished successfully")
+        println(r)
+      case Res.Failure(msg) =>
+        throw new AssertionError(s"script failed: $msg")
+      case Res.Exception(e, msg) =>
+        throw new AssertionError(s"script errored: $msg", e)
+      case _ => ???
+    }
+    /* minimizing exposure time by deleting the decrypted script straight away */
+    if (isEncryptedScript) actualScriptFile.toIO.delete
+  }
+
+  private def additionalImportCode(config: Config): List[String] =
+    config.additionalImports.flatMap { importScript =>
+      val file = importScript.toIO
+      assert(file.canRead, s"unable to read $file")
+      readScript(file.toScala)
+    }
+
+  private def ammoniteColors(config: Config) =
+    if (config.nocolors) Colors.BlackWhite
+    else Colors.Default
 
   /**
     * Override this method to implement script decryption

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -3,9 +3,9 @@ package io.shiftleft.console
 import ammonite.ops.pwd
 import ammonite.ops.Path
 import ammonite.util.{Colors, Res}
-
 import better.files._
 import io.shiftleft.console.embammonite.EmbeddedAmmonite
+import io.shiftleft.console.wsserver.WebsocketServer
 
 case class Config(
     scriptFile: Option[Path] = None,
@@ -104,9 +104,11 @@ trait BridgeBase {
     val predef = predefPlus(additionalImportCode(config))
     val ammonite = new EmbeddedAmmonite(predef)
     ammonite.start()
-
-    // TODO start server
-    ammonite.shutdown()
+    Runtime.getRuntime.addShutdownHook(new Thread(() => {
+      ammonite.shutdown()
+    }))
+    val server = new WebsocketServer()
+    server.main(Array.empty)
   }
 
   private def runScript(scriptFile: Path, config: Config) = {

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -107,7 +107,7 @@ trait BridgeBase {
     Runtime.getRuntime.addShutdownHook(new Thread(() => {
       ammonite.shutdown()
     }))
-    val server = new WebsocketServer()
+    val server = new WebsocketServer(ammonite)
     server.main(Array.empty)
   }
 

--- a/console/src/main/scala/io/shiftleft/console/embammonite/EmbeddedAmmonite.scala
+++ b/console/src/main/scala/io/shiftleft/console/embammonite/EmbeddedAmmonite.scala
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.LogManager
   * Result of executing a query, containing in particular
   * output received on standard out and on standard error.
   * */
-class QueryResult(val out: String, val err: String)
+class QueryResult(val out: String, val err: String, val uuid: UUID)
 
 private[embammonite] case class Job(uuid: UUID, query: String, observer: QueryResult => Unit)
 

--- a/console/src/main/scala/io/shiftleft/console/embammonite/UserRunnable.scala
+++ b/console/src/main/scala/io/shiftleft/console/embammonite/UserRunnable.scala
@@ -28,7 +28,7 @@ class UserRunnable(queue: BlockingQueue[Job], writer: PrintWriter, reader: Buffe
           val stdoutPair = stdOutUpToMarker()
           val stdOutput = stdoutPair.get
           val errOutput = exhaustStderr()
-          val result = new QueryResult(stdOutput, errOutput)
+          val result = new QueryResult(stdOutput, errOutput, job.uuid)
           job.observer(result)
         }
       }

--- a/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
@@ -1,0 +1,18 @@
+package io.shiftleft.console.wsserver
+
+class WebsocketServer extends cask.MainRoutes {
+  @cask.websocket("/connect/:userName")
+  def showUserProfile(userName: String): cask.WebsocketResult = {
+    if (userName != "haoyi") cask.Response("", statusCode = 403)
+    else
+      cask.WsHandler { channel =>
+        cask.WsActor {
+          case cask.Ws.Text("") => channel.send(cask.Ws.Close())
+          case cask.Ws.Text(data) =>
+            channel.send(cask.Ws.Text(userName + " " + data))
+        }
+      }
+  }
+
+  initialize()
+}

--- a/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
@@ -38,7 +38,11 @@ class WebsocketServer(ammonite: EmbeddedAmmonite) extends cask.MainRoutes {
   def getResult(uuidStr: String): Obj = {
     val uuid = UUID.fromString(uuidStr)
     val result = resultMap.remove(uuid)
-    ujson.Obj("success" -> true, "uuid" -> result.uuid.toString, "out" -> result.out, "err" -> result.err)
+    if (result == null) {
+      ujson.Obj("success" -> false)
+    } else {
+      ujson.Obj("success" -> true, "uuid" -> result.uuid.toString, "out" -> result.out, "err" -> result.err)
+    }
   }
 
   initialize()

--- a/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
@@ -34,7 +34,7 @@ class WebsocketServer(ammonite: EmbeddedAmmonite) extends cask.MainRoutes {
     ujson.Obj("success" -> true, "uuid" -> uuid.toString)
   }
 
-  @cask.get("/result/:uuid")
+  @cask.get("/result/:uuidStr")
   def getResult(uuidStr: String): Obj = {
     val uuid = UUID.fromString(uuidStr)
     val result = resultMap.remove(uuid)

--- a/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
@@ -1,17 +1,16 @@
 package io.shiftleft.console.wsserver
 
 class WebsocketServer extends cask.MainRoutes {
+
   @cask.websocket("/connect/:userName")
-  def showUserProfile(userName: String): cask.WebsocketResult = {
-    if (userName != "haoyi") cask.Response("", statusCode = 403)
-    else
-      cask.WsHandler { channel =>
-        cask.WsActor {
-          case cask.Ws.Text("") => channel.send(cask.Ws.Close())
-          case cask.Ws.Text(data) =>
-            channel.send(cask.Ws.Text(userName + " " + data))
-        }
+  def handler(userName: String): cask.WebsocketResult = {
+    cask.WsHandler { channel =>
+      cask.WsActor {
+        case cask.Ws.Text("") => channel.send(cask.Ws.Close())
+        case cask.Ws.Text(data) =>
+          channel.send(cask.Ws.Text(userName + " " + data))
       }
+    }
   }
 
   initialize()

--- a/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
@@ -1,30 +1,44 @@
 package io.shiftleft.console.wsserver
 
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+import io.shiftleft.console.embammonite.{EmbeddedAmmonite, QueryResult}
 import ujson.Obj
 
-class WebsocketServer extends cask.MainRoutes {
+class WebsocketServer(ammonite: EmbeddedAmmonite) extends cask.MainRoutes {
 
   var openConnections = Set.empty[cask.WsChannelActor]
+  val resultMap = new ConcurrentHashMap[UUID, QueryResult]()
 
   @cask.websocket("/connect")
   def handler(): cask.WebsocketResult = {
     cask.WsHandler { connection =>
       connection.send(cask.Ws.Text("connected"))
       openConnections += connection
-      cask.WsActor { case cask.Ws.Close(_, _) => openConnections -= connection }
+      cask.WsActor {
+        case cask.Ws.Close(_, _) => openConnections -= connection
+      }
     }
   }
 
   @cask.postJson("/query")
   def postQuery(query: String): Obj = {
-    println("received: " + query)
-    ujson.Obj("success" -> true, "err" -> "")
+    val uuid = ammonite.queryAsync(query) { result =>
+      resultMap.put(result.uuid, result)
+      openConnections.foreach { connection =>
+        // Report on websocket connections that result is ready
+        connection.send(cask.Ws.Text(result.uuid.toString))
+      }
+    }
+    ujson.Obj("success" -> true, "uuid" -> uuid.toString)
   }
 
   @cask.get("/result/:uuid")
-  def getResult(uuid: String): Obj = {
-    println("Fetching result for: " + uuid)
-    ujson.Obj("success" -> true, "err" -> "")
+  def getResult(uuidStr: String): Obj = {
+    val uuid = UUID.fromString(uuidStr)
+    val result = resultMap.remove(uuid)
+    ujson.Obj("success" -> true, "uuid" -> result.uuid.toString, "out" -> result.out, "err" -> result.err)
   }
 
   initialize()

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -1,0 +1,24 @@
+package io.shiftleft.console.wsserver
+
+import org.scalatest.{Matchers, WordSpec}
+
+object Fixture {
+  def apply[T](example: cask.main.Main)(f: String => T): T = {
+    val server = io.undertow.Undertow.builder
+      .addHttpListener(8081, "localhost")
+      .setHandler(example.defaultHandler)
+      .build
+    server.start()
+    val res =
+      try f("http://localhost:8081")
+      finally server.stop()
+    res
+  }
+}
+
+class WebSocketServerTests extends WordSpec with Matchers {
+  "foo" should {
+    "bar" in Fixture(new WebsocketServer()) { _ =>
+      }
+  }
+}

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -1,5 +1,7 @@
 package io.shiftleft.console.wsserver
+import java.util.concurrent.atomic.AtomicInteger
 
+import org.asynchttpclient.ws.{WebSocket, WebSocketListener, WebSocketUpgradeHandler}
 import org.scalatest.{Matchers, WordSpec}
 
 object Fixture {
@@ -17,8 +19,49 @@ object Fixture {
 }
 
 class WebSocketServerTests extends WordSpec with Matchers {
-  "foo" should {
-    "bar" in Fixture(new WebsocketServer()) { _ =>
+  "WebsocketServer" should {
+    "allow connecting" in Fixture(new WebsocketServer()) { _ =>
+      @volatile var out = List.empty[String]
+      val closed = new AtomicInteger(0)
+      val client = org.asynchttpclient.Dsl.asyncHttpClient()
+      val ws = Seq.fill(2)(
+        client
+          .prepareGet("ws://localhost:8081/connect/haoyi")
+          .execute(new WebSocketUpgradeHandler.Builder()
+            .addWebSocketListener(new WebSocketListener() {
+              override def onTextFrame(payload: String, finalFragment: Boolean, rsv: Int): Unit = {
+                out.synchronized {
+                  out = payload :: out
+                }
+              }
+              def onOpen(websocket: WebSocket): Unit = ()
+
+              def onClose(websocket: WebSocket, code: Int, reason: String): Unit = {
+                closed.incrementAndGet()
+              }
+              def onError(t: Throwable): Unit = ()
+            })
+            .build())
+          .get())
+      try {
+        ws.foreach(_.sendTextFrame("hello"))
+        Thread.sleep(1500)
+        out.length shouldBe 2
+
+        ws.foreach(_.sendTextFrame("world"))
+
+        Thread.sleep(1500)
+        out.length shouldBe 4
+        closed.get() shouldBe 0
+
+        ws.foreach(_.sendTextFrame(""))
+
+        Thread.sleep(1500)
+        closed.get() shouldBe 2
+
+      } finally {
+        client.close()
       }
+    }
   }
 }

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -1,10 +1,24 @@
 package io.shiftleft.console.wsserver
-import java.util.concurrent.atomic.AtomicInteger
 
-import org.asynchttpclient.ws.{WebSocket, WebSocketListener, WebSocketUpgradeHandler}
 import org.scalatest.{Matchers, WordSpec}
+import scala.concurrent._, duration.Duration.Inf
+import castor.Context.Simple.global, cask.util.Logger.Console._
+
+class WebSocketServerTests extends WordSpec with Matchers {
+  "WebsocketServer" should {
+    "allow connecting via /connect" in Fixture(new WebsocketServer()) { host =>
+      val wsPromise = scala.concurrent.Promise[String]
+      cask.util.WsClient.connect(s"$host/connect") {
+        case cask.Ws.Text(msg) => wsPromise.success(msg)
+      }
+      val wsMsg = Await.result(wsPromise.future, Inf)
+      wsMsg shouldBe "connected"
+    }
+  }
+}
 
 object Fixture {
+
   def apply[T](example: cask.main.Main)(f: String => T): T = {
     val server = io.undertow.Undertow.builder
       .addHttpListener(8081, "localhost")
@@ -12,56 +26,7 @@ object Fixture {
       .build
     server.start()
     val res =
-      try f("http://localhost:8081")
-      finally server.stop()
+      try { f("http://localhost:8081") } finally server.stop()
     res
-  }
-}
-
-class WebSocketServerTests extends WordSpec with Matchers {
-  "WebsocketServer" should {
-    "allow connecting" in Fixture(new WebsocketServer()) { _ =>
-      @volatile var out = List.empty[String]
-      val closed = new AtomicInteger(0)
-      val client = org.asynchttpclient.Dsl.asyncHttpClient()
-      val ws = Seq.fill(2)(
-        client
-          .prepareGet("ws://localhost:8081/connect/haoyi")
-          .execute(new WebSocketUpgradeHandler.Builder()
-            .addWebSocketListener(new WebSocketListener() {
-              override def onTextFrame(payload: String, finalFragment: Boolean, rsv: Int): Unit = {
-                out.synchronized {
-                  out = payload :: out
-                }
-              }
-              def onOpen(websocket: WebSocket): Unit = ()
-
-              def onClose(websocket: WebSocket, code: Int, reason: String): Unit = {
-                closed.incrementAndGet()
-              }
-              def onError(t: Throwable): Unit = ()
-            })
-            .build())
-          .get())
-      try {
-        ws.foreach(_.sendTextFrame("hello"))
-        Thread.sleep(1500)
-        out.length shouldBe 2
-
-        ws.foreach(_.sendTextFrame("world"))
-
-        Thread.sleep(1500)
-        out.length shouldBe 4
-        closed.get() shouldBe 0
-
-        ws.foreach(_.sendTextFrame(""))
-
-        Thread.sleep(1500)
-        closed.get() shouldBe 2
-
-      } finally {
-        client.close()
-      }
-    }
   }
 }

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.console.wsserver
 
+import java.net.URLEncoder
 import java.util.UUID
 
 import org.scalatest.{Matchers, WordSpec}
@@ -15,23 +16,42 @@ import scala.util.Try
 class WebSocketServerTests extends WordSpec with Matchers {
   "WebsocketServer" should {
 
-    "allow connecting, posting a query and getting back a uuid" in Fixture() { host =>
+    "allow connecting, posting a query, and fetching result" in Fixture() { host =>
       var wsPromise = scala.concurrent.Promise[String]
       cask.util.WsClient.connect(s"$host/connect") {
         case cask.Ws.Text(msg) => wsPromise.success(msg)
       }
 
+      // Connect to websocket endpoint
+
       val wsMsg = Await.result(wsPromise.future, Inf)
       wsMsg shouldBe "connected"
 
+      // Post a query and make sure to get back a uuid
+
       wsPromise = scala.concurrent.Promise[String]
-      val response = requests.post(s"$host/query", data = ujson.Obj("query" -> "1").toString)
-      val jsonResponse = ujson.read(response.contents)
-      Try { UUID.fromString(jsonResponse("uuid").str) }.toOption shouldBe defined
+      val postResponse = requests.post(s"$host/query", data = ujson.Obj("query" -> "1").toString)
+      val jsonResponse = ujson.read(postResponse.contents)
+      val uuidFromPost = Try { UUID.fromString(jsonResponse("uuid").str) }.toOption match {
+        case Some(num) => num
+        case None      => fail
+      }
       jsonResponse("success").bool shouldBe true
 
+      // Wait until receiving the same uuid on the websocket
+
       val wsMsg2 = Await.result(wsPromise.future, Inf)
-      Try { UUID.fromString(wsMsg2) }.toOption shouldBe defined
+      Try { UUID.fromString(wsMsg2) }.toOption match {
+        case Some(num) => num shouldBe uuidFromPost
+        case None      => fail
+      }
+
+      // Fetch result using get
+
+      val uri = s"$host/result/${URLEncoder.encode(uuidFromPost.toString, "utf-8")}"
+      val getResponse = requests.get(uri)
+      val jsonGetResponse = ujson.read(getResponse.contents)
+      jsonGetResponse("out").str shouldBe "res0: Int = 1\n"
     }
 
   }

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -1,32 +1,58 @@
 package io.shiftleft.console.wsserver
 
+import java.util.UUID
+
 import org.scalatest.{Matchers, WordSpec}
-import scala.concurrent._, duration.Duration.Inf
-import castor.Context.Simple.global, cask.util.Logger.Console._
+
+import scala.concurrent._
+import duration.Duration.Inf
+import castor.Context.Simple.global
+import cask.util.Logger.Console._
+import io.shiftleft.console.embammonite.EmbeddedAmmonite
+
+import scala.util.Try
 
 class WebSocketServerTests extends WordSpec with Matchers {
   "WebsocketServer" should {
-    "allow connecting via /connect" in Fixture(new WebsocketServer()) { host =>
-      val wsPromise = scala.concurrent.Promise[String]
+
+    "allow connecting, posting a query and getting back a uuid" in Fixture() { host =>
+      var wsPromise = scala.concurrent.Promise[String]
       cask.util.WsClient.connect(s"$host/connect") {
         case cask.Ws.Text(msg) => wsPromise.success(msg)
       }
+
       val wsMsg = Await.result(wsPromise.future, Inf)
       wsMsg shouldBe "connected"
+
+      wsPromise = scala.concurrent.Promise[String]
+      val response = requests.post(s"$host/query", data = ujson.Obj("query" -> "1").toString)
+      val jsonResponse = ujson.read(response.contents)
+      Try { UUID.fromString(jsonResponse("uuid").str) }.toOption shouldBe defined
+      jsonResponse("success").bool shouldBe true
+
+      val wsMsg2 = Await.result(wsPromise.future, Inf)
+      Try { UUID.fromString(wsMsg2) }.toOption shouldBe defined
     }
+
   }
 }
 
 object Fixture {
 
-  def apply[T](example: cask.main.Main)(f: String => T): T = {
+  def apply[T]()(f: String => T): T = {
+    val ammonite = new EmbeddedAmmonite()
+    ammonite.start()
+    val ammServer = new WebsocketServer(ammonite)
     val server = io.undertow.Undertow.builder
       .addHttpListener(8081, "localhost")
-      .setHandler(example.defaultHandler)
+      .setHandler(ammServer.defaultHandler)
       .build
     server.start()
     val res =
-      try { f("http://localhost:8081") } finally server.stop()
+      try { f("http://localhost:8081") } finally {
+        server.stop()
+        ammonite.shutdown()
+      }
     res
   }
 }


### PR DESCRIPTION
A simple HTTP server that allows an Ocular/Joern instance to be remote controlled via HTTP. As queries can take a while to complete, we allow posting queries and coming back for results later. To ensure that the client does not need to poll, we use websockets to inform the client whenever new results are ready. The routes we offer are the following:

* POST: /query : enqueue a query. Returns a UUID
* GET: /result/:uuid : retrieve result with given uuid.
* WS: /connect: subscribe to the WebSocket to receive notifications for query completions. A notification simply consists of the query UUID, making it possible to match queries to reponses.
