### PR TITLE
Select keys from a key pool when applying diffgraphs

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/KeyPool.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/KeyPool.scala
@@ -1,0 +1,27 @@
+package io.shiftleft.passes
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+  * A pool of long integers that serve as node ids.
+  * Using the method `next`, the pool provides the
+  * next id from the interval [first, last] in a
+  * thread-safe manner.
+  * */
+class KeyPool(val first: Long, val last: Long) {
+
+  /**
+    * Get next number in interval or raise if
+    * number is larger than `last`
+    * */
+  def next: Long = {
+    val n = cur.incrementAndGet()
+    if (n > last) {
+      throw new RuntimeException("Interval exhausted")
+    } else {
+      n
+    }
+  }
+
+  private val cur: AtomicLong = new AtomicLong(first - 1)
+}

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -38,7 +38,7 @@ class DiffGraphTest extends WordSpec with Matchers {
       diffBuilder.addEdgeProperty(x2y, EdgeKeyNames.LOCAL_NAME, "new edge attr")
       val diffGraph = diffBuilder.build()
       // apply diffgraph with undoable = true
-      val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, graph, true)
+      val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, graph, true, None)
       val inverseDiffGraph = appliedDiffGraph.inverseDiffGraph.get
       val changes = inverseDiffGraph.iterator.toList
       import DiffGraph.Change._
@@ -63,15 +63,15 @@ class DiffGraphTest extends WordSpec with Matchers {
       diffBuilder.addNode(createNewNode("b"))
       diffBuilder.addNode(createNewNode("c"))
       val threeNodes = diffBuilder.build()
-      val appliedDiff1 = DiffGraph.Applier.applyDiff(threeNodes, graph, true)
+      val appliedDiff1 = DiffGraph.Applier.applyDiff(threeNodes, graph, true, None)
       graph.nodeCount shouldBe 3
       DiffGraph.Applier.unapplyDiff(graph, appliedDiff1.inverseDiffGraph.get)
       graph.nodeCount shouldBe 0
-      DiffGraph.Applier.applyDiff(threeNodes, graph, false)
+      DiffGraph.Applier.applyDiff(threeNodes, graph, false, None)
       diffBuilder = DiffGraph.newBuilder
       makeEdgeBetweenExistingNodes(graph, diffBuilder, "a", "b")
       makeEdgeBetweenExistingNodes(graph, diffBuilder, "b", "c")
-      val appliedDiff2 = DiffGraph.Applier.applyDiff(diffBuilder.build(), graph, true)
+      val appliedDiff2 = DiffGraph.Applier.applyDiff(diffBuilder.build(), graph, true, None)
       graph.V.has(NodeKeysOdb.CODE -> "a").head.out(EdgeTypes.AST).property(NodeKeysOdb.CODE).head shouldBe "b"
       DiffGraph.Applier.unapplyDiff(graph, appliedDiff2.inverseDiffGraph.get)
       graph.V.has(NodeKeysOdb.CODE -> "a").head.out(EdgeTypes.AST).l shouldBe Nil
@@ -89,7 +89,7 @@ class DiffGraphTest extends WordSpec with Matchers {
       diffBuilder.addNode(newNodeB)
       diffBuilder.addEdge(newNodeA, newNodeB, EdgeTypes.AST)
       val diff = diffBuilder.build()
-      val appliedDiff = DiffGraph.Applier.applyDiff(diff, graph, true)
+      val appliedDiff = DiffGraph.Applier.applyDiff(diff, graph, true, None)
       graph.nodeCount shouldBe 2
       graph.edgeCount shouldBe 1
       DiffGraph.Applier.unapplyDiff(graph, appliedDiff.inverseDiffGraph.get)
@@ -107,7 +107,7 @@ class DiffGraphTest extends WordSpec with Matchers {
       diffBuilder.addNode(newNodeC)
       diffBuilder.addEdge(newNodeB, newNodeC, EdgeTypes.AST)
       val diff = diffBuilder.build()
-      val appliedDiff = DiffGraph.Applier.applyDiff(diff, graph, true)
+      val appliedDiff = DiffGraph.Applier.applyDiff(diff, graph, true, None)
       graph.nodeCount shouldBe 3
       graph.edgeCount shouldBe 2
       println(appliedDiff.inverseDiffGraph.get.iterator.toList)

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -5,7 +5,7 @@ import overflowdb._
 import overflowdb.traversal._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
-import io.shiftleft.passes.DiffGraph
+import io.shiftleft.passes.{DiffGraph, KeyPool}
 import org.scalatest.{Matchers, WordSpec}
 
 class DiffGraphTest extends WordSpec with Matchers {
@@ -76,6 +76,23 @@ class DiffGraphTest extends WordSpec with Matchers {
       DiffGraph.Applier.unapplyDiff(graph, appliedDiff2.inverseDiffGraph.get)
       graph.V.has(NodeKeysOdb.CODE -> "a").head.out(EdgeTypes.AST).l shouldBe Nil
       graph.V.has(NodeKeysOdb.CODE, "b").head.out(EdgeTypes.AST).l shouldBe Nil
+    }
+  }
+
+  "should choose keys from provided KeyPool" in {
+    withTestOdb { graph =>
+      val builder = DiffGraph.newBuilder
+      val firstNode: NewNode = createNewNode("a")
+      val secondNode: NewNode = createNewNode("b")
+      val thirdNode: NewNode = createNewNode("c")
+      builder.addNode(firstNode)
+      builder.addNode(secondNode)
+      builder.addNode(thirdNode)
+      val keyPool = Some(new KeyPool(20, 30))
+      val appliedGraph = DiffGraph.Applier.applyDiff(builder.build, graph, true, keyPool)
+      appliedGraph.nodeToGraphId(firstNode) shouldBe 20
+      appliedGraph.nodeToGraphId(secondNode) shouldBe 21
+      appliedGraph.nodeToGraphId(thirdNode) shouldBe 22
     }
   }
 


### PR DESCRIPTION
While it was already possible to make use of key pools in order to create CPGs with deterministic ids even when sub CPGs were created in parallel, this was restricted to the proto CPG. Enhancements that applied diffgraphs were previously unable to provide key pools, meaning that - upon applying the `semanticcpg` layer - keys were already non-deterministic.

With this PR, the DiffGraph.Applier can be made aware of the key pool it should choose ids from, and it honors this by passing ids to overflowdb accordingly. This is part of the work on `x2cpg` - a generic lib for efficient creation of code property graphs on multi-core systems.