### PR TITLE
KeyPool support for `CpgPass` and `ParallelCpgPass`

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
@@ -39,6 +39,8 @@ class ProtoToCpg(overflowConfig: OdbConfig = OdbConfig.withoutOverflow) {
   // TODO use centralised string interner everywhere, maybe move to odb core - keep in mind strong references / GC.
   implicit private val interner: StringInterner = StringInterner.makeStrongInterner()
 
+  def graph : OdbGraph = odbGraph
+
   def addNodes(nodes: JCollection[Node]): Unit =
     addNodes(nodes.asScala)
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
@@ -39,7 +39,7 @@ class ProtoToCpg(overflowConfig: OdbConfig = OdbConfig.withoutOverflow) {
   // TODO use centralised string interner everywhere, maybe move to odb core - keep in mind strong references / GC.
   implicit private val interner: StringInterner = StringInterner.makeStrongInterner()
 
-  def graph : OdbGraph = odbGraph
+  def graph: OdbGraph = odbGraph
 
   def addNodes(nodes: JCollection[Node]): Unit =
     addNodes(nodes.asScala)

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -31,7 +31,7 @@ import scala.concurrent.duration.DurationLong
   *
   * @param cpg the source CPG this pass traverses
   */
-abstract class CpgPass(cpg: Cpg, outName: String = "") extends CpgPassBase {
+abstract class CpgPass(cpg: Cpg, outName: String = "", keyPool: Option[KeyPool] = None) extends CpgPassBase {
 
   /**
     * Main method of enhancement - to be implemented by child class
@@ -43,7 +43,7 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") extends CpgPassBase {
     */
   override def createAndApply(): Unit =
     withStartEndTimesLogged {
-      run().foreach(diffGraph => DiffGraph.Applier.applyDiff(diffGraph, cpg))
+      run().foreach(diffGraph => DiffGraph.Applier.applyDiff(diffGraph, cpg, undoable = false, keyPool))
     }
 
   /**
@@ -53,7 +53,7 @@ abstract class CpgPass(cpg: Cpg, outName: String = "") extends CpgPassBase {
   def createApplyAndSerialize(inverse: Boolean = false): Iterator[GeneratedMessageV3] =
     withStartEndTimesLogged {
       val overlays = run().map { diffGraph =>
-        val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, cpg, inverse)
+        val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, cpg, inverse, keyPool)
         serialize(appliedDiffGraph, inverse)
       }
       overlays

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/KeyPool.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/KeyPool.scala
@@ -1,14 +1,26 @@
 package io.shiftleft.passes
 
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 
 /**
   * A pool of long integers that serve as node ids.
   * Using the method `next`, the pool provides the
-  * next id from the interval [first, last] in a
-  * thread-safe manner.
+  * next id in a thread-safe manner.
   * */
-class KeyPool(val first: Long, val last: Long) {
+trait KeyPool {
+
+  /**
+    * Returns the next id from the key pool
+    * */
+  def next: Long
+
+}
+
+/**
+  A key pool that returns the integers of the interval
+  [first, last] in a thread-safe manner.
+  * */
+class IntervalKeyPool(val first: Long, val last: Long) extends KeyPool {
 
   /**
     * Get next number in interval or raise if
@@ -17,11 +29,30 @@ class KeyPool(val first: Long, val last: Long) {
   def next: Long = {
     val n = cur.incrementAndGet()
     if (n > last) {
-      throw new RuntimeException("Interval exhausted")
+      throw new RuntimeException("Pool exhausted")
     } else {
       n
     }
   }
 
   private val cur: AtomicLong = new AtomicLong(first - 1)
+}
+
+/**
+  * A key pool that returns elements of `seq`
+  * in order in a thread-safe manner.
+  * */
+class SequenceKeyPool(seq: Seq[Long]) extends KeyPool {
+
+  val seqLen: Int = seq.size
+  var cur = new AtomicInteger(-1)
+
+  override def next: Long = {
+    val i = cur.incrementAndGet()
+    if (i >= seqLen) {
+      throw new RuntimeException("Pool exhausted")
+    } else {
+      seq(i)
+    }
+  }
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -15,7 +15,7 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "", keyPools: Opti
 
   def partIterator: Iterator[T]
 
-  def runOnPart(part: T): Option[DiffGraph]
+  def runOnPart(part: T): Iterator[DiffGraph]
 
   override def createAndApply(): Unit = {
     withWriter() { writer =>

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -6,7 +6,8 @@ import io.shiftleft.codepropertygraph.Cpg
 import org.apache.logging.log4j.{LogManager, Logger}
 import org.slf4j.LoggerFactory
 
-abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "") extends CpgPassBase {
+abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "", keyPools: Option[Iterator[KeyPool]] = None)
+    extends CpgPassBase {
 
   private val logger: Logger = LogManager.getLogger(classOf[ParallelCpgPass[T]])
 
@@ -41,7 +42,7 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "") extends CpgPas
       case exception: Exception =>
         logger.warn(exception)
     } finally {
-      writer.enqueue(None)
+      writer.enqueue(None, None)
       writerThread.join()
     }
   }
@@ -49,10 +50,11 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "") extends CpgPas
   private def enqueueInParallel(writer: Writer): Unit = {
     init()
     val it = new ParallelIteratorExecutor(partIterator).map { part =>
+      val keyPool = keyPools.map(_.next)
       // Note: write.enqueue(runOnPart(part)) would be wrong because
       // it would terminate the writer as soon as a pass returns None
       // as None is used as a termination symbol for the queue
-      runOnPart(part).foreach(diffGraph => writer.enqueue(Some(diffGraph)))
+      runOnPart(part).foreach(diffGraph => writer.enqueue(Some(diffGraph), keyPool))
     }
     consume(it)
   }
@@ -65,12 +67,14 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "") extends CpgPas
 
   private class Writer(serializedCpg: SerializedCpg, prefix: String, inverse: Boolean) extends Runnable {
 
+    case class DiffGraphAndKeyPool(diffGraph: Option[DiffGraph], keyPool: Option[KeyPool])
+
     private val logger = LoggerFactory.getLogger(getClass)
 
-    private val queue = new LinkedBlockingQueue[Option[DiffGraph]]
+    private val queue = new LinkedBlockingQueue[DiffGraphAndKeyPool]
 
-    def enqueue(diffGraph: Option[DiffGraph]): Unit = {
-      queue.put(diffGraph)
+    def enqueue(diffGraph: Option[DiffGraph], keyPool: Option[KeyPool]): Unit = {
+      queue.put(DiffGraphAndKeyPool(diffGraph, keyPool))
     }
 
     override def run(): Unit = {
@@ -79,15 +83,15 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "") extends CpgPas
         var index: Int = 0
         while (!terminate) {
           queue.take() match {
-            case Some(diffGraph) =>
-              val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, cpg, inverse)
+            case DiffGraphAndKeyPool(Some(diffGraph), keyPool) =>
+              val appliedDiffGraph = DiffGraph.Applier.applyDiff(diffGraph, cpg, inverse, keyPool)
               if (!serializedCpg.isEmpty) {
                 val overlay = serialize(appliedDiffGraph, inverse)
                 val name = generateOutFileName(prefix, outName, index)
                 index += 1
                 store(overlay, name, serializedCpg)
               }
-            case None =>
+            case DiffGraphAndKeyPool(None, _) =>
               logger.info("Shutting down WriterThread")
               terminate = true
           }

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -5,7 +5,7 @@ import overflowdb._
 import overflowdb.traversal._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
-import io.shiftleft.passes.{DiffGraph, KeyPool}
+import io.shiftleft.passes.{DiffGraph, IntervalKeyPool}
 import org.scalatest.{Matchers, WordSpec}
 
 class DiffGraphTest extends WordSpec with Matchers {
@@ -88,7 +88,7 @@ class DiffGraphTest extends WordSpec with Matchers {
       builder.addNode(firstNode)
       builder.addNode(secondNode)
       builder.addNode(thirdNode)
-      val keyPool = Some(new KeyPool(20, 30))
+      val keyPool = Some(new IntervalKeyPool(20, 30))
       val appliedGraph = DiffGraph.Applier.applyDiff(builder.build, graph, true, keyPool)
       appliedGraph.nodeToGraphId(firstNode) shouldBe 20
       appliedGraph.nodeToGraphId(secondNode) shouldBe 21

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgPassTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgPassTests.scala
@@ -1,0 +1,54 @@
+package io.shiftleft.passes
+
+import better.files.File
+import io.shiftleft.SerializedCpg
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.jdk.CollectionConverters._
+
+class CpgPassTests extends WordSpec with Matchers {
+
+  private object Fixture {
+    def apply(keyPool: Option[KeyPool] = None)(f: (Cpg, CpgPassBase) => Unit): Unit = {
+      val cpg = Cpg.emptyCpg
+      class MyPass(cpg: Cpg) extends CpgPass(cpg, "MyPass", keyPool) {
+        override def run(): Iterator[DiffGraph] = {
+          val diffGraph1 = DiffGraph.newBuilder
+          val diffGraph2 = DiffGraph.newBuilder
+          diffGraph1.addNode(nodes.NewFile(name = "foo"))
+          diffGraph2.addNode(nodes.NewFile(name = "bar"))
+          Iterator(diffGraph1.build(), diffGraph2.build())
+        }
+      }
+      val pass = new MyPass(cpg)
+      f(cpg, pass)
+    }
+  }
+
+  "CpgPass" should {
+    "allow creating and applying result of pass" in Fixture() { (cpg, pass) =>
+      pass.createAndApply()
+      cpg.graph.V().asScala.map(_.label).toSet shouldBe Set("FILE")
+    }
+
+    "produce a serialized inverse CPG" in Fixture() { (_, pass) =>
+      File.usingTemporaryFile("pass", ".zip") { file =>
+        file.delete()
+        val filename = file.path.toString
+        val serializedCpg = new SerializedCpg(filename)
+        pass.createApplySerializeAndStore(serializedCpg, true)
+        serializedCpg.close()
+        file.exists shouldBe true
+        file.size should not be 0
+      }
+    }
+
+    "take into account KeyPool for createAndApply" in Fixture(Some(new IntervalKeyPool(100, 120))) { (cpg, pass) =>
+      pass.createAndApply()
+      cpg.graph.V.asScala.map(_.id2()).toSet shouldBe Set(100, 101)
+    }
+  }
+
+}

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
@@ -1,0 +1,26 @@
+package io.shiftleft.passes
+
+import org.scalatest.{Matchers, WordSpec}
+
+class KeyPoolTests extends WordSpec with Matchers {
+
+  "IntervalKeyPool" should {
+    "return [first, ..., last] and then raise" in {
+      val keyPool = new IntervalKeyPool(10, 19)
+      List.range(0, 10).map(_ => keyPool.next) shouldBe List.range(10, 20)
+      assertThrows[RuntimeException] { keyPool.next }
+      assertThrows[RuntimeException] { keyPool.next }
+    }
+  }
+
+  "SequenceKeyPool" should {
+    "return elements of sequence one by one and then raise" in {
+      val seq = List[Long](1, 2, 3)
+      val keyPool = new SequenceKeyPool(seq)
+      List.range(0, 3).map(_ => keyPool.next) shouldBe seq
+      assertThrows[RuntimeException] { keyPool.next }
+      assertThrows[RuntimeException] { keyPool.next }
+    }
+  }
+
+}

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/ParallelCpgPassTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/ParallelCpgPassTests.scala
@@ -1,0 +1,62 @@
+package io.shiftleft.passes
+
+import better.files.File
+import io.shiftleft.SerializedCpg
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.jdk.CollectionConverters._
+
+class ParallelCpgPassTests extends WordSpec with Matchers {
+
+  private object Fixture {
+    def apply(keyPools: Option[Iterator[KeyPool]] = None)(f: (Cpg, CpgPassBase) => Unit): Unit = {
+      val cpg = Cpg.emptyCpg
+      class MyPass(cpg: Cpg) extends ParallelCpgPass[String](cpg, "MyPass", keyPools) {
+        override def partIterator: Iterator[String] = {
+          Iterator("foo", "bar")
+        }
+
+        override def runOnPart(part: String): Option[DiffGraph] = {
+          val diffGraph = DiffGraph.newBuilder
+          diffGraph.addNode(nodes.NewFile(name = part))
+          Some(diffGraph.build())
+        }
+      }
+      val pass = new MyPass(cpg)
+      f(cpg, pass)
+    }
+  }
+
+  "ParallelCpgPass" should {
+    "allow creating and applying result of pass" in Fixture() { (cpg, pass) =>
+      pass.createAndApply()
+      cpg.graph.V().asScala.map(_.property("NAME").value().toString).toSet shouldBe Set("foo", "bar")
+    }
+
+    "produce a serialized inverse CPG" in Fixture() { (_, pass) =>
+      File.usingTemporaryFile("pass", ".zip") { file =>
+        file.delete()
+        val filename = file.path.toString
+        val serializedCpg = new SerializedCpg(filename)
+        pass.createApplySerializeAndStore(serializedCpg, true)
+        serializedCpg.close()
+        file.exists shouldBe true
+        file.size should not be 0
+      }
+    }
+
+    val keyPools = Iterator(
+      new IntervalKeyPool(10, 20),
+      new IntervalKeyPool(30, 40)
+    )
+
+    "take into account KeyPools for createAndApply" in Fixture(Some(keyPools)) { (cpg, pass) =>
+      pass.createAndApply()
+      cpg.graph.V.asScala.map(_.id2()).toSet shouldBe Set(10, 30)
+    }
+
+  }
+
+}

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/ParallelCpgPassTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/ParallelCpgPassTests.scala
@@ -18,10 +18,10 @@ class ParallelCpgPassTests extends WordSpec with Matchers {
           Iterator("foo", "bar")
         }
 
-        override def runOnPart(part: String): Option[DiffGraph] = {
+        override def runOnPart(part: String): Iterator[DiffGraph] = {
           val diffGraph = DiffGraph.newBuilder
           diffGraph.addNode(nodes.NewFile(name = part))
-          Some(diffGraph.build())
+          Iterator(diffGraph.build())
         }
       }
       val pass = new MyPass(cpg)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -19,7 +19,7 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
 
   override def partIterator: Iterator[nodes.Method] = cpg.method.toIterator()
 
-  override def runOnPart(method: nodes.Method): Option[DiffGraph] = {
+  override def runOnPart(method: nodes.Method): Iterator[DiffGraph] = {
     val dstGraph = DiffGraph.newBuilder
     val worklist = mutable.Set.empty[nodes.CfgNode]
     var out = Map.empty[nodes.StoredNode, Set[nodes.StoredNode]].withDefaultValue(Set.empty[nodes.StoredNode])
@@ -62,7 +62,7 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
     }
 
     addReachingDefEdge(dstGraph, method, out, in)
-    Some(dstGraph.build())
+    Iterator(dstGraph.build())
   }
 
   /** Pruned DDG, i.e., two call assignment nodes are adjacent if a

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
@@ -14,7 +14,7 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
 
   override def partIterator: Iterator[nodes.Method] = cpg.method.toIterator()
 
-  override def runOnPart(method: nodes.Method): Option[DiffGraph] = {
+  override def runOnPart(method: nodes.Method): Iterator[DiffGraph] = {
     val cfgAdapter = new CpgCfgAdapter()
     val dominatorCalculator = new CfgDominator(cfgAdapter)
 
@@ -29,7 +29,7 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
     val cfgNodeToPostImmediateDominator = postDominatorCalculator.calculate(method.methodReturn)
     addPostDomTreeEdges(dstGraph, cfgNodeToPostImmediateDominator)
 
-    Some(dstGraph.build())
+    Iterator(dstGraph.build())
   }
 
   private def addDomTreeEdges(dstGraph: DiffGraph.Builder, cfgNodeToImmediateDominator: Map[Node, Node]): Unit = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
@@ -19,7 +19,7 @@ class CdgPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
 
   override def partIterator: Iterator[Method] = cpg.method.toIterator()
 
-  override def runOnPart(method: nodes.Method): Option[DiffGraph] = {
+  override def runOnPart(method: nodes.Method): Iterator[DiffGraph] = {
 
     val dominanceFrontier = new CfgDominatorFrontier(new ReverseCpgCfgAdapter, new CpgPostDomTreeAdapter)
 
@@ -44,7 +44,7 @@ class CdgPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
               s" number of outgoing CFG edges from $nodeLabel node: ${postDomFrontierNode.outE(EdgeTypes.CFG).asScala.size}")
         }
     }
-    Some(dstGraph.build())
+    Iterator(dstGraph.build())
   }
 }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/containsedges/ContainsEdgePass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/containsedges/ContainsEdgePass.scala
@@ -18,7 +18,7 @@ class ContainsEdgePass(cpg: Cpg) extends ParallelCpgPass[nodes.AstNode](cpg) {
   override def partIterator: Iterator[nodes.AstNode] =
     cpg.graph.nodes(sourceTypes: _*).asScala.map(_.asInstanceOf[nodes.AstNode])
 
-  override def runOnPart(source: nodes.AstNode): Option[DiffGraph] = {
+  override def runOnPart(source: nodes.AstNode): Iterator[DiffGraph] = {
     val dstGraph = DiffGraph.newBuilder
 
     source.start
@@ -29,7 +29,7 @@ class ContainsEdgePass(cpg: Cpg) extends ParallelCpgPass[nodes.AstNode](cpg) {
       }
       .iterate()
 
-    Some(dstGraph.build())
+    Iterator(dstGraph.build())
   }
 }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -39,7 +39,7 @@ class MethodStubCreator(cpg: Cpg) extends ParallelCpgPass[(NameAndSignature, Int
 
   // TODO bring in Receiver type. Just working on name and comparing to full name
   // will only work for C because in C, name always equals full name.
-  override def runOnPart(part: (NameAndSignature, Int)): Option[DiffGraph] = {
+  override def runOnPart(part: (NameAndSignature, Int)): Iterator[DiffGraph] = {
     val name = part._1.name
     val signature = part._1.signature
     val parameterCount = part._2
@@ -50,7 +50,7 @@ class MethodStubCreator(cpg: Cpg) extends ParallelCpgPass[(NameAndSignature, Int
         createMethodStub(name, name, signature, parameterCount, dstGraph)
       case _ =>
     }
-    Some(dstGraph.build())
+    Iterator(dstGraph.build())
   }
 
   private def createMethodStub(name: String,


### PR DESCRIPTION
* Improvements + tests for KeyPools
* KeyPool support for `CpgPass` and `ParallelCpgPass`
* Tests for `CpgPass` and `ParallelCpgPass`
* Have `ParallelCpgPass::runOnPart` return `Iterator[DiffGraph]` as opposed to `Option[DiffGraph]`
* Allow obtaining graph from `ProtoToCpg`

Related to https://github.com/ShiftLeftSecurity/fuzzyc2cpg/pull/202
Minor adaptions in `codescience` necessary to account for `ParallelCpgPass::runOnPart` signature change => turns out none are required.