### PR TITLE
Catch exception on `/result` endpoint

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
@@ -40,7 +40,8 @@ class WebsocketServer(ammonite: EmbeddedAmmonite) extends cask.MainRoutes {
     try {
       uuid = UUID.fromString(uuidParam)
     } catch {
-      case _: IllegalArgumentException => return ujson.Obj("success" -> false, "err" -> "UUID parameter is incorrectly formatted")
+      case _: IllegalArgumentException =>
+        return ujson.Obj("success" -> false, "err" -> "UUID parameter is incorrectly formatted")
     }
     if (uuid == null) {
       return ujson.Obj("success" -> false, "err" -> "Internal Server Error")

--- a/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
@@ -34,9 +34,18 @@ class WebsocketServer(ammonite: EmbeddedAmmonite) extends cask.MainRoutes {
     ujson.Obj("success" -> true, "uuid" -> uuid.toString)
   }
 
-  @cask.get("/result/:uuidStr")
-  def getResult(uuidStr: String): Obj = {
-    val uuid = UUID.fromString(uuidStr)
+  @cask.get("/result/:uuidParam")
+  def getResult(uuidParam: String): Obj = {
+    var uuid: java.util.UUID = null
+    try {
+      uuid = UUID.fromString(uuidParam)
+    } catch {
+      case _: IllegalArgumentException => return ujson.Obj("success" -> false, "err" -> "UUID parameter is incorrectly formatted")
+    }
+    if (uuid == null) {
+      return ujson.Obj("success" -> false, "err" -> "Internal Server Error")
+    }
+
     val result = resultMap.remove(uuid)
     if (result == null) {
       ujson.Obj("success" -> false)

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -78,7 +78,7 @@ class WebSocketServerTests extends WordSpec with Matchers {
     Await.result(wsPromise.future, Duration(100, SECONDS))
     val jsonGetResponse = getResponse(host, "INCORRECTLY_FORMATTED_UUID_PARAM")
     jsonGetResponse("success").bool shouldBe false
-    jsonGetResponse("err").str.length should not equal(0)
+    jsonGetResponse("err").str.length should not equal (0)
   }
 
 }

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -21,8 +21,8 @@ class WebSocketServerTests extends WordSpec with Matchers {
     ujson.read(postResponse.contents)
   }
 
-  def getResponse(host: String, uuid: UUID): Value = {
-    val uri = s"$host/result/${URLEncoder.encode(uuid.toString, "utf-8")}"
+  def getResponse(host: String, uuidParam: String): Value = {
+    val uri = s"$host/result/${URLEncoder.encode(uuidParam, "utf-8")}"
     val getResponse = requests.get(uri)
     ujson.read(getResponse.contents)
   }
@@ -55,7 +55,7 @@ class WebSocketServerTests extends WordSpec with Matchers {
         case None      => fail
       }
 
-      val jsonGetResponse = getResponse(host, uuidFromPost)
+      val jsonGetResponse = getResponse(host, uuidFromPost.toString)
       jsonGetResponse("out").str shouldBe "res0: Int = 1\n"
     }
   }
@@ -66,8 +66,19 @@ class WebSocketServerTests extends WordSpec with Matchers {
       case cask.Ws.Text(msg) => wsPromise.success(msg)
     }
     Await.result(wsPromise.future, Duration(100, SECONDS))
-    val jsonGetResponse = getResponse(host, UUID.randomUUID())
+    val jsonGetResponse = getResponse(host, UUID.randomUUID().toString)
     jsonGetResponse("success").bool shouldBe false
+  }
+
+  "return a valid JSON response when calling /result with incorrectly-formatted UUID parameter" in Fixture() { host =>
+    val wsPromise = scala.concurrent.Promise[String]
+    cask.util.WsClient.connect(s"$host/connect") {
+      case cask.Ws.Text(msg) => wsPromise.success(msg)
+    }
+    Await.result(wsPromise.future, Duration(100, SECONDS))
+    val jsonGetResponse = getResponse(host, "INCORRECTLY_FORMATTED_UUID_PARAM")
+    jsonGetResponse("success").bool shouldBe false
+    jsonGetResponse("err").str.length should not equal(0)
   }
 
 }


### PR DESCRIPTION
Without the change, the endpoint throws if called with a path parameter
that does not parse correctly as a java.util.UUID.