### PR TITLE
Resolve call sites for argument and returnUser steps.

### DIFF
--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
@@ -79,6 +79,7 @@ class CDataFlowTests extends CpgDataFlowTests {
         |}
       """.stripMargin
     ) { cpg =>
+      implicit val callResolver = NoResolve
       val source = cpg.identifier
       val sink = cpg.method.name("free").parameter.argument
       val flows = sink.reachableByFlows(source).l
@@ -124,6 +125,7 @@ class CDataFlowTests extends CpgDataFlowTests {
         | }
       """.stripMargin
     ) { cpg =>
+      implicit val callResolver = NoResolve
       val source = cpg.identifier.name("a")
       val sink = cpg.method.name("foo").parameter.argument
       val flows = sink.reachableByFlows(source).l
@@ -288,6 +290,7 @@ class CDataFlowTests extends CpgDataFlowTests {
         |    int z = foo(b);
         |  }
       """.stripMargin) { cpg =>
+      implicit val callResolver = NoResolve
       val source = cpg.identifier.name("a")
       val sink = cpg.method.name("foo").parameter.argument
       val flows = sink.reachableByFlows(source).l

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/DataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/DataFlowTests.scala
@@ -37,6 +37,7 @@ class DataFlowTests extends WordSpec with Matchers {
 
   "should find flows to arguments of `free`" in
     DataFlowCodeToCpgFixture(code) { cpg =>
+      implicit val callResolver = NoResolve
       val source = cpg.identifier
       val sink = cpg.method.name("free").parameter.argument
       sink.reachableByFlows(source).l.size shouldBe 5

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/FreeListDataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/FreeListDataFlowTests.scala
@@ -38,6 +38,7 @@ class FreeListDataFlowTests extends WordSpec with Matchers {
 
   "should find flows to arguments of `free`" in
     DataFlowCodeToCpgFixture(code) { cpg =>
+      implicit val callResolver = NoResolve
       val source = cpg.identifier
       val sink = cpg.method.name("free").parameter.argument
       sink.reachableByFlows(source).l.size shouldBe 5

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameter.scala
@@ -41,10 +41,10 @@ class MethodParameter(val wrapped: NodeSteps[nodes.MethodParameterIn]) extends A
   /**
     * Traverse to arguments (actual parameters) associated with this formal parameter
     * */
-  def argument: NodeSteps[nodes.Expression] = {
+  def argument(implicit callResolver: ICallResolver): NodeSteps[nodes.Expression] = {
     val trav = for {
       paramIn <- raw.toIterator
-      call <- paramIn._methodViaAstIn._callViaCallIn
+      call <- callResolver.getMethodCallsites(paramIn._methodViaAstIn)
       arg <- call._argumentOut.asScala.collect { case node: nodes.Expression with nodes.HasArgumentIndex => node }
       if arg.argumentIndex == paramIn.order
     } yield arg


### PR DESCRIPTION
Previously the argument and returnUser step only expanded to
argument/returnUser of static call sites and dynamic call sites which
statically asserted the corresponding interface/base class.