### PR TITLE
astChilren: order nodes by `order` field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ name := "codepropertygraph"
 publish / skip := true
 
 // parsed by project/Utils.scala
-val fuzzyc2cpgVersion = "1.1.45"
+val fuzzyc2cpgVersion = "1.1.51"
 
 lazy val codepropertygraph = Projects.codepropertygraph
 lazy val protoBindings = Projects.protoBindings

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -49,7 +49,7 @@ class AstNode[A <: nodes.AstNode](val wrapped: NodeSteps[A]) extends AnyVal {
     * Direct children of node in the AST
     * */
   def astChildren: NodeSteps[nodes.AstNode] =
-    new NodeSteps(raw.out(EdgeTypes.AST).cast[nodes.AstNode])
+    new NodeSteps(raw.out(EdgeTypes.AST).cast[nodes.AstNode]).orderBy(_.order)
 
   /**
     * Parent AST node


### PR DESCRIPTION
While `astChildren` already returns nodes in the order they were added, and therefore, coincidentally, ordered by the `order` field, this is a property of the backend storage and it may change in the future. We want to guarantee users of `astChildren` that children are returned in the correct order, and therefore, I am adding an explicit ordering step. 