### PR TITLE
Fix race condition in keypool distribution

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -50,7 +50,8 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "", keyPools: Opti
   private def enqueueInParallel(writer: Writer): Unit = {
     init()
     val it = new ParallelIteratorExecutor(partIterator).map { part =>
-      val keyPool = keyPools.map(_.next)
+      val keyPool = this synchronized { keyPools.map(_.next) }
+
       // Note: write.enqueue(runOnPart(part)) would be wrong because
       // it would terminate the writer as soon as a pass returns None
       // as None is used as a termination symbol for the queue


### PR DESCRIPTION
Calling `iterator.next` is not thread safe, so, we sometimes saw the same pool selected twice. Synchronizing access to avoid race.