### PR TITLE
Ordering for `astChildren` + node method

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ name := "codepropertygraph"
 publish / skip := true
 
 // parsed by project/Utils.scala
-val fuzzyc2cpgVersion = "1.1.45"
+val fuzzyc2cpgVersion = "1.1.51"
 
 lazy val codepropertygraph = Projects.codepropertygraph
 lazy val protoBindings = Projects.protoBindings

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.Implicits.JavaIteratorDeco
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
 
 class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
@@ -19,6 +19,11 @@ class AstNodeMethods(val node: nodes.AstNode) extends AnyVal {
     * */
   def ast(predicate: nodes.AstNode => Boolean): NodeSteps[nodes.AstNode] =
     node.start.ast.where(predicate)
+
+  /**
+    * Ordered list of direct AST children
+    * */
+  def astChildren: NodeSteps[nodes.AstNode] = node.start.astChildren
 
   /**
     * All nodes of the abstract syntax tree rooted in this node,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -45,11 +45,13 @@ class AstNode[A <: nodes.AstNode](val wrapped: NodeSteps[A]) extends AnyVal {
   def astMinusRoot: NodeSteps[nodes.AstNode] =
     new NodeSteps(raw.repeat(_.out(EdgeTypes.AST)).emit.cast[nodes.AstNode])
 
+  import scala.jdk.CollectionConverters._
+
   /**
-    * Direct children of node in the AST
+    * Direct children of node in the AST. Siblings are ordered by their `order` fields
     * */
   def astChildren: NodeSteps[nodes.AstNode] =
-    new NodeSteps(raw.out(EdgeTypes.AST).cast[nodes.AstNode])
+    new NodeSteps(raw.flatMap(_._astOut().asScala.toList.start.cast[nodes.AstNode].orderBy(_.order).raw))
 
   /**
     * Parent AST node


### PR DESCRIPTION
Minor fixes for `astChildren`:
- `astChildren` was previously only defined on steps but not on nodes
- Ensure that siblings are ordered by `order`. Note that it is not enough to simply order the entire pipe, we want to order children per parent.