### PR TITLE
Tweak wsserver responses

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/wsserver/WebsocketServer.scala
@@ -41,17 +41,17 @@ class WebsocketServer(ammonite: EmbeddedAmmonite) extends cask.MainRoutes {
       uuid = UUID.fromString(uuidParam)
     } catch {
       case _: IllegalArgumentException =>
-        return ujson.Obj("success" -> false, "err" -> "UUID parameter is incorrectly formatted")
+        return ujson.Obj("success" -> false, "stderr" -> "UUID parameter is incorrectly formatted")
     }
     if (uuid == null) {
-      return ujson.Obj("success" -> false, "err" -> "Internal Server Error")
+      return ujson.Obj("success" -> false, "stderr" -> "Internal Server Error")
     }
 
     val result = resultMap.remove(uuid)
     if (result == null) {
-      ujson.Obj("success" -> false, "err" -> "No result found for specified UUID")
+      ujson.Obj("success" -> false, "stderr" -> "No result found for specified UUID")
     } else {
-      ujson.Obj("success" -> true, "uuid" -> result.uuid.toString, "out" -> result.out, "err" -> result.err)
+      ujson.Obj("success" -> true, "uuid" -> result.uuid.toString, "stdout" -> result.out, "stderr" -> result.err)
     }
   }
 

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -54,9 +54,9 @@ class WebSocketServerTests extends WordSpec with Matchers {
         val UUIDResponse = postQueryResponse("uuid").str
         val getResultResponse = getResponse(host, UUIDResponse)
         getResultResponse.obj.keySet should contain("success")
-        getResultResponse.obj.keySet should contain("err")
+        getResultResponse.obj.keySet should contain("stderr")
         getResultResponse("success").bool shouldBe false
-        getResultResponse("err").str.length should not be (0)
+        getResultResponse("stderr").str.length should not be (0)
     }
 
     "allow fetching the result of a completed query using its UUID" in Fixture() { host =>
@@ -75,8 +75,9 @@ class WebSocketServerTests extends WordSpec with Matchers {
 
       val getResultResponse = getResponse(host, queryUUID)
       getResultResponse.obj.keySet should contain("success")
-      getResultResponse("out").str shouldBe "res0: Int = 1\n"
       getResultResponse("uuid").str shouldBe queryResultWSMessage
+      getResultResponse("stdout").str shouldBe "res0: Int = 1\n"
+      getResultResponse("stderr").str shouldBe ""
     }
 
     "write a well-formatted message to a websocket connection when a query has finished evaluation" in Fixture() {
@@ -97,8 +98,9 @@ class WebSocketServerTests extends WordSpec with Matchers {
 
         val getResultResponse = getResponse(host, queryUUID)
         getResultResponse.obj.keySet should contain("success")
-        getResultResponse("out").str shouldBe "res0: Int = 1\n"
         getResultResponse("uuid").str shouldBe queryResultWSMessage
+        getResultResponse("stdout").str shouldBe "res0: Int = 1\n"
+        getResultResponse("stderr").str shouldBe ""
     }
 
     "write a well-formatted message to a websocket connection when a query failed evaluation" in Fixture() { host =>
@@ -119,8 +121,8 @@ class WebSocketServerTests extends WordSpec with Matchers {
       val getResultResponse = getResponse(host, queryUUID)
       getResultResponse.obj.keySet should contain("success")
       getResultResponse("success").bool shouldBe true
-      getResultResponse("out").str shouldBe ""
       getResultResponse("uuid").str shouldBe queryResultWSMessage
+      getResultResponse("stdout").str shouldBe ""
     }
   }
 
@@ -132,7 +134,7 @@ class WebSocketServerTests extends WordSpec with Matchers {
     Await.result(webSocketTextMsg.future, Duration(100, SECONDS))
     val getResultResponse = getResponse(host, UUID.randomUUID().toString)
     getResultResponse.obj.keySet should contain("success")
-    getResultResponse.obj.keySet should contain("err")
+    getResultResponse.obj.keySet should contain("stderr")
     getResultResponse("success").bool shouldBe false
   }
 
@@ -144,9 +146,9 @@ class WebSocketServerTests extends WordSpec with Matchers {
     Await.result(webSocketTextMsg.future, Duration(100, SECONDS))
     val getResultResponse = getResponse(host, "INCORRECTLY_FORMATTED_UUID_PARAM")
     getResultResponse.obj.keySet should contain("success")
-    getResultResponse.obj.keySet should contain("err")
+    getResultResponse.obj.keySet should contain("stderr")
     getResultResponse("success").bool shouldBe false
-    getResultResponse("err").str.length should not equal (0)
+    getResultResponse("stderr").str.length should not equal (0)
   }
 }
 

--- a/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/wsserver/WebSocketServerTests.scala
@@ -98,6 +98,8 @@ class WebSocketServerTests extends WordSpec with Matchers {
 
         val getResultResponse = getResponse(host, queryUUID)
         getResultResponse.obj.keySet should contain("success")
+        getResultResponse.obj.keySet should contain("stdout")
+        getResultResponse.obj.keySet should contain("stderr")
         getResultResponse("uuid").str shouldBe queryResultWSMessage
         getResultResponse("stdout").str shouldBe "res0: Int = 1\n"
         getResultResponse("stderr").str shouldBe ""
@@ -120,9 +122,12 @@ class WebSocketServerTests extends WordSpec with Matchers {
 
       val getResultResponse = getResponse(host, queryUUID)
       getResultResponse.obj.keySet should contain("success")
+      getResultResponse.obj.keySet should contain("stdout")
+      getResultResponse.obj.keySet should contain("stderr")
       getResultResponse("success").bool shouldBe true
       getResultResponse("uuid").str shouldBe queryResultWSMessage
       getResultResponse("stdout").str shouldBe ""
+      getResultResponse("stderr").str.length should not be(0)
     }
   }
 


### PR DESCRIPTION
Makes it clearer that the strings returned refer to the output of STDOUT
and STDERR.