### PR TITLE
Introduce CFG edge type

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -55,7 +55,8 @@
 
     "edgeKeys" : [
       {"id" : 6, "name" : "LOCAL_NAME", "comment" : "Local name of referenced CONTAINED node", "valueType" : "string", "cardinality" : "zeroOrOne"},
-      {"id" : 8, "name" : "INDEX", "comment" : "Index of referenced CONTAINED node (0 based) - used together with cardinality=list", "valueType" : "int", "cardinality" : "zeroOrOne"}
+      {"id" : 8, "name" : "INDEX", "comment" : "Index of referenced CONTAINED node (0 based) - used together with cardinality=list", "valueType" : "int", "cardinality" : "zeroOrOne"},
+      {"id" : 9, "name" : "CFG_EDGE_TYPE", "comment" : "Sub type of CFG edges to indicate under which condition control flow occurs", "valueType" : "string", "cardinality" : "one" }
     ],
 
     // Types of nodes
@@ -534,7 +535,7 @@
     "edgeTypes" : [
 
         {"id" : 3, "name" : "AST", "comment" : "Syntax tree edge" , "keys" : [] },
-        {"id" : 19, "name" : "CFG", "comment" : "Control flow edge", "keys" : [] },
+        {"id" : 19, "name" : "CFG", "comment" : "Control flow edge", "keys" : ["CFG_EDGE_TYPE"] },
 
         {"id" : 9, "name" : "CONTAINS_NODE", "keys" : ["LOCAL_NAME", "INDEX"], "comment" : "Membership relation for a compound object"},
         {"id" : 41, "name": "CAPTURED_BY", "comment" : "Connection between a captured LOCAL and the corresponding CLOSURE_BINDING", "keys": []},


### PR DESCRIPTION
As part of the work on sp2x, I've been looking into the AST to CFG conversion in fuzzyc2cpg, and I noticed that we are using the CFG edge type "Always", "True", "False", and "Case" to indicate under which condition a control flow edge is taken. We write this into proto but it never reaches ODB because the CPG spec does not support this key. This PR adds the missing key.

**Note** This indicates, btw, that the ProtoToCpg converter currently ignores edge properties or at least continues to operate even if an edge property cannot be set.