### PR TITLE
Allow splitting keypools

### DIFF
--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
@@ -11,6 +11,29 @@ class KeyPoolTests extends WordSpec with Matchers {
       assertThrows[RuntimeException] { keyPool.next }
       assertThrows[RuntimeException] { keyPool.next }
     }
+
+    "allow splitting into multiple pools" in {
+      val keyPool = new IntervalKeyPool(1, 1000)
+      val pools = keyPool.split(11).toList
+      assertThrows[IllegalStateException] { keyPool.next }
+      pools.size shouldBe 11
+      // Pools should all have the same size
+      pools
+        .map { x =>
+          (x.last - x.first)
+        }
+        .distinct
+        .size shouldBe 1
+      // Pools should be pairwise disjoint
+      val keySets = pools.map { x =>
+        (x.first to x.last).toSet
+      }
+      keySets.combinations(2).foreach {
+        case List(x: Set[Long], y: Set[Long]) =>
+          x.intersect(y).isEmpty shouldBe true
+      }
+    }
+
   }
 
   "SequenceKeyPool" should {


### PR DESCRIPTION
As discussed, we don't want the caller of `AstCreationPass` to know in detail how the keypool is made use. At the same time, we would like the caller to tell the pass the id range in which the pass is allowed to operate at all. To solve this issue, we introduce a `split` method that allows a KeyPool to be split into multiple smaller pools.