### PR TITLE
Fix `Method::isStub` and `Method::isNotStub`

### DIFF
--- a/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
@@ -127,7 +127,7 @@ class CPGQLServerTests extends WordSpec with Matchers {
       getResultResponse("success").bool shouldBe true
       getResultResponse("uuid").str shouldBe queryResultWSMessage
       getResultResponse("stdout").str shouldBe ""
-      getResultResponse("stderr").str.length should not be(0)
+      getResultResponse("stderr").str.length should not be (0)
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Method.scala
@@ -83,15 +83,16 @@ class Method(val wrapped: NodeSteps[nodes.Method]) extends AnyVal {
 
   /**
     * Traverse only to methods that are stubs, e.g., their code is not available
+    * or the method body is empty.
     * */
   def isStub: NodeSteps[nodes.Method] =
-    new NodeSteps(raw.filter(_.not(_.out(EdgeTypes.CFG))))
+    new NodeSteps(raw.filter(_.not(_.out(EdgeTypes.CFG).filterNot(_.hasLabel(NodeTypes.METHOD_RETURN)))))
 
   /**
     * Traverse only to methods that are not stubs.
     * */
   def isNotStub: NodeSteps[nodes.Method] =
-    new NodeSteps(raw.filter(_.out(EdgeTypes.CFG)))
+    new NodeSteps(raw.filter(_.out(EdgeTypes.CFG).filterNot(_.hasLabel(NodeTypes.METHOD_RETURN))))
 
   /**
     * Traverse to external methods, that is, methods not present

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
@@ -58,9 +58,9 @@ class CMethodTests extends WordSpec with Matchers {
     }
   }
 
-  CodeToCpgFixture("int foo(); int bar() { return 0; }") { cpg =>
+  CodeToCpgFixture("int foo(); int bar() { return woo(); }") { cpg =>
     "should identify method as stub" in {
-      cpg.method.isStub.name.l shouldBe List("foo")
+      cpg.method.isStub.name.toSet shouldBe Set("foo", "woo")
       cpg.method.isNotStub.name.l shouldBe List("bar")
     }
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/CMethodTests.scala
@@ -9,12 +9,9 @@ import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
   * */
 class CMethodTests extends WordSpec with Matchers {
 
-  val code = """
-       int main(int argc, char **argv) {
-       }
-    """
-
-  CodeToCpgFixture(code) { cpg =>
+  CodeToCpgFixture("""
+      |int main(int argc, char **argv) {
+      |}""".stripMargin) { cpg =>
     "should return correct function/method name" in {
       cpg.method.name.toSet shouldBe Set("main")
     }
@@ -59,7 +56,13 @@ class CMethodTests extends WordSpec with Matchers {
       cpg.method.where(_.parameter.size == 2).name.l shouldBe List("main")
       cpg.method.where(_.parameter.size == 1).name.l shouldBe List()
     }
+  }
 
+  CodeToCpgFixture("int foo(); int bar() { return 0; }") { cpg =>
+    "should identify method as stub" in {
+      cpg.method.isStub.name.l shouldBe List("foo")
+      cpg.method.isNotStub.name.l shouldBe List("bar")
+    }
   }
 
 }


### PR DESCRIPTION
`isStub` and `isNotStub` were not working correctly and there were no tests. In particular, declarations such as `int malloc(size_t);` were not considered stubs because there was actually a control flow edge from the method to its formal return parameter. It looks like in the past, stubs did not have that edge. This PR updates `isStub`/`isNotStub` to work in both cases, and it includes a test to ensure this doesn't break in the future.
