### PR TITLE
Handle edge case of 0 keypool partitions

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/KeyPool.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/KeyPool.scala
@@ -46,12 +46,16 @@ class IntervalKeyPool(val first: Long, val last: Long) extends KeyPool {
     **/
   def split(numberOfPartitions: Int): Iterator[IntervalKeyPool] = {
     valid = false
-    val first = cur.get()
-    val k = (last - first) / numberOfPartitions
-    (1 to numberOfPartitions).map { i =>
-      val poolFirst = first + (i - 1) * k
-      new IntervalKeyPool(poolFirst, poolFirst + k - 1)
-    }.iterator
+    if (numberOfPartitions == 0) {
+      Iterator()
+    } else {
+      val curFirst = cur.get()
+      val k = (last - curFirst) / numberOfPartitions
+      (1 to numberOfPartitions).map { i =>
+        val poolFirst = curFirst + (i - 1) * k
+        new IntervalKeyPool(poolFirst, poolFirst + k - 1)
+      }.iterator
+    }
   }
 
   private val cur: AtomicLong = new AtomicLong(first - 1)

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
@@ -34,6 +34,11 @@ class KeyPoolTests extends WordSpec with Matchers {
       }
     }
 
+    "return empty iterator when asked to create 0 partitions" in {
+      val keyPool = new IntervalKeyPool(1, 1000)
+      keyPool.split(0) shouldBe Iterator()
+    }
+
   }
 
   "SequenceKeyPool" should {


### PR DESCRIPTION
When asking a key pool to be split into 0 partitions, we currently crash with a division by zero. This request occurs, e.g., when calling a pass that operates on all methods but there are 0 methods. The correct behavior is to return an iterator that returns 0 partitions, that is, the empty iterator.