### PR TITLE
Fix logging of pass start/end time

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -127,7 +127,7 @@ trait CpgPassBase {
   }
 
   protected def withStartEndTimesLogged[A](fun: => A): A = {
-    logger.debug(s"Start of enhancement: $name")
+    logger.info(s"Start of enhancement: $name")
     val startTime = System.currentTimeMillis
     try {
       fun


### PR DESCRIPTION
* In contrast to CpgPass, ParallelCpgPass previously did not log start and end time
* Start time was printed with level `DEBUG` while end time was printed with `INFO`. Now both use `INFO`.
