### PR TITLE
pass in code language instead of entire cpg to codedumper

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -2,13 +2,9 @@ package io.shiftleft.semanticcpg.codedumper
 
 import better.files.File
 import io.shiftleft.codepropertygraph.generated.{Languages, nodes}
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.NodeSteps
-import io.shiftleft.codepropertygraph.Cpg
-import overflowdb.{NodeRef, OdbGraph}
+import io.shiftleft.semanticcpg.language.{NodeSteps, _}
 import io.shiftleft.utils.{Source, SourceHighlighter}
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.Try
 
@@ -19,17 +15,9 @@ object CodeDumper {
   val arrow: CharSequence = "/* <=== */ "
 
   /**
-    * Evaluate the `step` and determine associated locations.
-    * Dump code at those locations
-    * */
-  def dump[NodeType <: nodes.StoredNode](step: NodeSteps[NodeType], highlight: Boolean = true): List[String] = {
-    step.location.l.map(dump(_, highlight))
-  }
-
-  /**
     * Dump string representation of code at given `location`.
     * */
-  private def dump(location: nodes.NewLocation, highlight: Boolean): String = {
+  def dump(location: nodes.NewLocation, language: Option[String], highlight: Boolean): String = {
     val filename = location.filename
 
     if (location.node.isEmpty) {
@@ -38,10 +26,6 @@ object CodeDumper {
     }
 
     val node = location.node.get
-    val language: Option[String] = {
-      val graph = node.asInstanceOf[NodeRef[_]].graph
-      new Cpg(graph).metaData.language.headOption
-    }
     if (language.isEmpty || !Set(Languages.C).contains(language.get)) {
       logger.info("dump not supported for this language or language not set in CPG")
       return ""

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/codedumper/CodeDumperTests.scala
@@ -2,9 +2,9 @@ package io.shiftleft.semanticcpg.codedumper
 
 import java.util.regex.Pattern
 
-import org.scalatest.{Matchers, WordSpec}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgFixture
+import org.scalatest.{Matchers, WordSpec}
 
 class CodeDumperTests extends WordSpec with Matchers {
 
@@ -16,23 +16,21 @@ class CodeDumperTests extends WordSpec with Matchers {
                 |}""".stripMargin
 
   CodeToCpgFixture(code) { cpg =>
+    val language = cpg.metaData.language.headOption
+
     "should return empty string for empty traversal" in {
-      CodeDumper
-        .dump(cpg.method.name("notinthere"), false)
-        .mkString("\n") shouldBe ""
+      cpg.method.name("notinthere").dump.mkString("\n") shouldBe ""
     }
 
     "should be able to dump complete function" in {
-      val query = cpg.method.name("my_func")
-      val code = CodeDumper.dump(query, false).mkString("\n")
+      val code = cpg.method.name("my_func").dumpRaw.mkString("\n")
       code should startWith("int my_func")
       code should include("foo(param1)")
       code should endWith("}")
     }
 
     "should dump method with arrow for expression (a call)" in {
-      val query = cpg.call.name("foo")
-      val code = CodeDumper.dump(query, false).mkString("\n")
+      val code = cpg.call.name("foo").dumpRaw.mkString("\n")
       code should startWith("int")
       code should include regex (".*" + "int x = foo" + ".*" + Pattern.quote(CodeDumper.arrow.toString) + ".*")
       code should endWith("}")


### PR DESCRIPTION
prerequisite for moving over to overflowdb-traversal which doesn't always
hold a reference to the graph