### PR TITLE
Follow up on #870

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
@@ -12,7 +12,7 @@ object Implicits {
       if (iterator.hasNext) {
         val res = iterator.next
         if (iterator.hasNext) {
-          logger.error("iterator was expected to have exactly one element, but it actually has more")
+          logger.warn("iterator was expected to have exactly one element, but it actually has more")
         }
         res
       } else { throw new NoSuchElementException() }
@@ -40,7 +40,7 @@ object Implicits {
       if (iterator.hasNext) {
         val res = iterator.next
         if (iterator.hasNext) {
-          logger.error("iterator was expected to have exactly one element, but it actually has more")
+          logger.warn("iterator was expected to have exactly one element, but it actually has more")
         }
         res
       } else { throw new NoSuchElementException() }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/capturinglinker/CapturingLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/capturinglinker/CapturingLinker.scala
@@ -33,7 +33,7 @@ class CapturingLinker(cpg: Cpg) extends CpgPass(cpg) {
           case Some(closureBindingNode) =>
             dstGraph.addEdgeInOriginal(local, closureBindingNode, EdgeTypes.CAPTURED_BY)
           case None =>
-            logger.error(s"Missing CLOSURE_BINDING node or invalid closureBindingId=$closureBindingId")
+            logger.warn(s"Missing CLOSURE_BINDING node or invalid closureBindingId=$closureBindingId")
         }
       }
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -231,7 +231,7 @@ object Linker {
       } else {
         srcNode.out(edgeType).property(NodeKeysOdb.FULL_NAME).nextOption match {
           case Some(dstFullName) => srcNode.property(dstFullNameKey, dstFullName)
-          case None              => logger.error(s"Missing outgoing edge of type ${edgeType} from node ${srcNode}")
+          case None              => logger.warn(s"Missing outgoing edge of type ${edgeType} from node ${srcNode}")
         }
         if (!loggedDeprecationWarning) {
           logger.warn(


### PR DESCRIPTION
More ERROR -> WARN logging downgrade (prev
https://github.com/ShiftLeftSecurity/codepropertygraph/pull/870).
Since logging is now fixed, we see those regularly but we also continue
the analysis.