### PR TITLE
Add basic auth logic for CPGQLServer

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -127,7 +127,11 @@ trait BridgeBase {
     Runtime.getRuntime.addShutdownHook(new Thread(() => {
       ammonite.shutdown()
     }))
-    val server = new CPGQLServer(ammonite, config.serverHost, config.serverPort, config.serverAuthUsername, config.serverAuthPassword)
+    val server = new CPGQLServer(ammonite,
+                                 config.serverHost,
+                                 config.serverPort,
+                                 config.serverAuthUsername,
+                                 config.serverAuthPassword)
     server.main(Array.empty)
   }
 

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -15,6 +15,8 @@ case class Config(
     server: Boolean = false,
     serverHost: String = "localhost",
     serverPort: Int = 8080,
+    serverAuthUsername: String = "",
+    serverAuthPassword: String = "",
     command: Option[String] = None
 )
 
@@ -62,6 +64,14 @@ trait BridgeBase {
       opt[Int]("server-port")
         .action((x, c) => c.copy(serverPort = x))
         .text("Port on which to expose the CPGQL server")
+
+      opt[String]("server-auth-username")
+        .action((x, c) => c.copy(serverAuthUsername = x))
+        .text("Basic auth username for the CPGQL server")
+
+      opt[String]("server-auth-password")
+        .action((x, c) => c.copy(serverAuthPassword = x))
+        .text("Basic auth password for the CPGQL server")
 
       opt[String]("command")
         .action((x, c) => c.copy(command = Some(x)))
@@ -117,7 +127,7 @@ trait BridgeBase {
     Runtime.getRuntime.addShutdownHook(new Thread(() => {
       ammonite.shutdown()
     }))
-    val server = new CPGQLServer(ammonite, config.serverHost, config.serverPort)
+    val server = new CPGQLServer(ammonite, config.serverHost, config.serverPort, config.serverAuthUsername, config.serverAuthPassword)
     server.main(Array.empty)
   }
 

--- a/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
@@ -12,9 +12,10 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
                   serverHost: String,
                   serverPort: Int,
                   serverAuthUsername: String = "",
-                  serverAuthPassword: String = "") extends cask.MainRoutes {
+                  serverAuthPassword: String = "")
+    extends cask.MainRoutes {
 
-  class basicAuth extends cask.RawDecorator{
+  class basicAuth extends cask.RawDecorator {
     def wrapFunction(ctx: Request, delegate: Delegate) = {
       val authString = try {
         val authHeader = ctx.exchange.getRequestHeaders.get("authorization").getFirst
@@ -31,10 +32,11 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
           Array("", "")
         }
       }
-      val isAuthorized = if (serverAuthUsername == "" && serverAuthPassword == "")
-        true
-      else
-        (user == serverAuthUsername && password == serverAuthPassword)
+      val isAuthorized =
+        if (serverAuthUsername == "" && serverAuthPassword == "")
+          true
+        else
+          (user == serverAuthUsername && password == serverAuthPassword)
       delegate(Map("isAuthorized" -> isAuthorized))
     }
   }
@@ -65,7 +67,7 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
   @basicAuth()
   @cask.postJson("/query")
   def postQuery(query: String)(isAuthorized: Boolean) = {
-    val res = if(!isAuthorized) {
+    val res = if (!isAuthorized) {
       unauthorizedResponse
     } else {
       val uuid = ammonite.queryAsync(query) { result =>
@@ -85,7 +87,7 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
   def getResult(uuidParam: String)(isAuthorized: Boolean) = {
     val res = if (!isAuthorized) {
       unauthorizedResponse
-    }  else {
+    } else {
       val uuid = try {
         UUID.fromString(uuidParam)
       } catch {
@@ -99,9 +101,9 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
           ujson.Obj("success" -> false, "err" -> "No result found for specified UUID")
         } else {
           ujson.Obj("success" -> true,
-            "uuid" -> resFromMap.uuid.toString,
-            "stdout" -> resFromMap.out,
-            "stderr" -> resFromMap.err)
+                    "uuid" -> resFromMap.uuid.toString,
+                    "stdout" -> resFromMap.out,
+                    "stderr" -> resFromMap.err)
         }
       }
       Response(finalRes, 200)
@@ -111,4 +113,3 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
 
   initialize()
 }
-

--- a/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
@@ -31,10 +31,10 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
           Array("", "")
         }
       }
-      val isAuthorized = {
-        (user == serverAuthUsername && password == serverAuthPassword) &&
-        (serverAuthUsername != "" && serverAuthPassword != "")
-      }
+      val isAuthorized = if (serverAuthUsername == "" && serverAuthPassword == "")
+        true
+      else
+        (user == serverAuthUsername && password == serverAuthPassword)
       delegate(Map("isAuthorized" -> isAuthorized))
     }
   }

--- a/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
@@ -1,12 +1,43 @@
 package io.shiftleft.console.cpgqlserver
 
+import java.util.Base64
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
-import io.shiftleft.console.embammonite.{EmbeddedAmmonite, QueryResult}
-import ujson.Obj
+import cask.model.{Request, Response}
 
-class CPGQLServer(ammonite: EmbeddedAmmonite, serverHost: String, serverPort: Int) extends cask.MainRoutes {
+import io.shiftleft.console.embammonite.{EmbeddedAmmonite, QueryResult}
+
+class CPGQLServer(ammonite: EmbeddedAmmonite,
+                  serverHost: String,
+                  serverPort: Int,
+                  serverAuthUsername: String = "",
+                  serverAuthPassword: String = "") extends cask.MainRoutes {
+
+  class basicAuth extends cask.RawDecorator{
+    def wrapFunction(ctx: Request, delegate: Delegate) = {
+      val authString = try {
+        val authHeader = ctx.exchange.getRequestHeaders.get("authorization").getFirst
+        val strippedHeader = authHeader.toString().replaceFirst("Basic ", "")
+        new String(Base64.getDecoder.decode(strippedHeader))
+      } catch {
+        case _: Exception => ""
+      }
+      val Array(user, password): Array[String] = {
+        val split = authString.split(":")
+        if (split.length == 2) {
+          Array(split(0).toString(), split(1).toString())
+        } else {
+          Array("", "")
+        }
+      }
+      val isAuthorized = {
+        (user == serverAuthUsername && password == serverAuthPassword) &&
+        (serverAuthUsername != "" && serverAuthPassword != "")
+      }
+      delegate(Map("isAuthorized" -> isAuthorized))
+    }
+  }
 
   override def port: Int = {
     serverPort
@@ -18,6 +49,7 @@ class CPGQLServer(ammonite: EmbeddedAmmonite, serverHost: String, serverPort: In
 
   var openConnections = Set.empty[cask.WsChannelActor]
   val resultMap = new ConcurrentHashMap[UUID, QueryResult]()
+  val unauthorizedResponse = Response(ujson.Obj(), 401, headers = Seq("WWW-Authenticate" -> "Basic"))
 
   @cask.websocket("/connect")
   def handler(): cask.WebsocketResult = {
@@ -30,38 +62,53 @@ class CPGQLServer(ammonite: EmbeddedAmmonite, serverHost: String, serverPort: In
     }
   }
 
+  @basicAuth()
   @cask.postJson("/query")
-  def postQuery(query: String): Obj = {
-    val uuid = ammonite.queryAsync(query) { result =>
-      resultMap.put(result.uuid, result)
-      openConnections.foreach { connection =>
-        // Report on websocket connections that result is ready
-        connection.send(cask.Ws.Text(result.uuid.toString))
+  def postQuery(query: String)(isAuthorized: Boolean) = {
+    val res = if(!isAuthorized) {
+      unauthorizedResponse
+    } else {
+      val uuid = ammonite.queryAsync(query) { result =>
+        resultMap.put(result.uuid, result)
+        openConnections.foreach { connection =>
+          // Report on websocket connections that result is ready
+          connection.send(cask.Ws.Text(result.uuid.toString))
+        }
       }
+      Response(ujson.Obj("success" -> true, "uuid" -> uuid.toString), 200)
     }
-    ujson.Obj("success" -> true, "uuid" -> uuid.toString)
+    res
   }
 
+  @basicAuth()
   @cask.get("/result/:uuidParam")
-  def getResult(uuidParam: String): Obj = {
-    var uuid: java.util.UUID = null
-    try {
-      uuid = UUID.fromString(uuidParam)
-    } catch {
-      case _: IllegalArgumentException =>
-        return ujson.Obj("success" -> false, "stderr" -> "UUID parameter is incorrectly formatted")
+  def getResult(uuidParam: String)(isAuthorized: Boolean) = {
+    val res = if (!isAuthorized) {
+      unauthorizedResponse
+    }  else {
+      val uuid = try {
+        UUID.fromString(uuidParam)
+      } catch {
+        case _: IllegalArgumentException => null
+      }
+      val finalRes = if (uuid == null) {
+        ujson.Obj("success" -> false, "err" -> "UUID parameter is incorrectly formatted")
+      } else {
+        val resFromMap = resultMap.remove(uuid)
+        if (resFromMap == null) {
+          ujson.Obj("success" -> false, "err" -> "No result found for specified UUID")
+        } else {
+          ujson.Obj("success" -> true,
+            "uuid" -> resFromMap.uuid.toString,
+            "stdout" -> resFromMap.out,
+            "stderr" -> resFromMap.err)
+        }
+      }
+      Response(finalRes, 200)
     }
-    if (uuid == null) {
-      return ujson.Obj("success" -> false, "stderr" -> "Internal Server Error")
-    }
-
-    val result = resultMap.remove(uuid)
-    if (result == null) {
-      ujson.Obj("success" -> false, "stderr" -> "No result found for specified UUID")
-    } else {
-      ujson.Obj("success" -> true, "uuid" -> result.uuid.toString, "stdout" -> result.out, "stderr" -> result.err)
-    }
+    res
   }
 
   initialize()
 }
+


### PR DESCRIPTION
This change introduces a security mechanism for the
CPGQLServer, namely basic authentication. CPGQL queries that are
executed by the server have access to a large range of system resources,
having a way to restrict their execution seems very useful in a lot of
situations.

The implementation is bare-bone, but does the job. A few caveats:
1. The `/connect` endpoint has not been secured, mostly because the
`cask` library does not yet provide a simple way of adding decorators to
WebSocket endpoints.
2. 401 responses do not return a body, simply because the `requests`
library returns an empty buffer for them, even though the HTTP standard
allows it.
3. The basic auth logic has been implemented by hand because the `cask`
library does not provide a decorator out of the box, and doing it using
the underlying `undertow` library would probably require too much code:
ihttps://github.com/undertow-io/undertow/blob/master/examples/src/main/java/io/undertow/examples/security/basic/BasicAuthServer.java