### PR TITLE
Minor fix for CDG handling following CFG changes

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
@@ -32,7 +32,8 @@ class CdgPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
     postDomFrontiers.foreach {
       case (node, postDomFrontierNode) =>
         postDomFrontierNode match {
-          case _: nodes.Literal | _: nodes.Identifier | _: nodes.Call | _: nodes.MethodRef | _: nodes.Unknown => {
+          case _: nodes.Literal | _: nodes.Identifier | _: nodes.Call | _: nodes.MethodRef | _: nodes.Unknown |
+              _: nodes.ControlStructure | _: nodes.JumpTarget => {
             dstGraph.addEdgeInOriginal(postDomFrontierNode.asInstanceOf[nodes.StoredNode],
                                        node.asInstanceOf[nodes.StoredNode],
                                        EdgeTypes.CDG)


### PR DESCRIPTION
Control structures (goto) and jump targets are now also valid nodes in the CDG, so, don't warn.