### PR TITLE
restore LIST-append behavior for setProperty

### DIFF
--- a/project/meta-build.sbt
+++ b/project/meta-build.sbt
@@ -1,6 +1,6 @@
 libraryDependencies ++= Seq(
   "com.github.pathikrit" %% "better-files" % "3.8.0",
-  "io.shiftleft" %% "overflowdb-codegen" % "1.24",
+  "io.shiftleft" %% "overflowdb-codegen" % "1.25",
 )
 
 resolvers += Resolver.bintrayRepo("shiftleft", "maven")


### PR DESCRIPTION
It appears that I missed at least one use of the old setProperty uses that depended on the LIST-append behavior. This restores this old behavior, so that we can deprecate it without haste in the nebulous future.