### PR TITLE
Increase max size of result output in CPGQLServer

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/embammonite/EmbeddedAmmonite.scala
+++ b/console/src/main/scala/io/shiftleft/console/embammonite/EmbeddedAmmonite.scala
@@ -124,8 +124,8 @@ object EmbeddedAmmonite {
   val predef: String =
     """
       | class CustomFrontend extends ammonite.repl.AmmoniteFrontEnd() {
-      |   override def width = 100
-      |   override def height = 100
+      |   override def width = 65536
+      |   override def height = 65536
       |
       |  override def readLine(reader: java.io.Reader,
       |                        output: java.io.OutputStream,


### PR DESCRIPTION
This is more of a temporary usability quick fix than a clean solution,
but an improvement nonetheless. The size has been chosen heuristically.

Only tested manually using the following script:
```
#!/usr/bin/env bash

readonly ENDPOINT="localhost:8080"
readonly RESPONSE=$(curl -s -d '{"query": "val a = for (i <- 1 to 20000) yield { i.toString() + System.lineSeparator() }.toString()"}' ${ENDPOINT}/query)
readonly UUID=$(echo ${RESPONSE} | jq .uuid | sed -e 's|"||g')
sleep 2
readonly RESULT=$(curl -s ${ENDPOINT}/result/${UUID})
readonly RESULT_STDOUT=$(echo ${RESULT} | jq .stdout | rev)
readonly LAST_N_CHARS_STDOUT=$(echo ${RESULT_STDOUT:0:20} | rev)

echo $LAST_N_CHARS_STDOUT
```

Before the change:
```
$ ./test.sh
047\n\"\"\",\n...\n"
```

After the change:
```
$ ./test.sh
\"2000\n\"\"\"\n)\n"
```