### PR TITLE
Move over `KeyPoolCreator` from fuzzyc2cpg

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/KeyPool.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/KeyPool.scala
@@ -80,3 +80,21 @@ class SequenceKeyPool(seq: Seq[Long]) extends KeyPool {
     }
   }
 }
+
+object KeyPoolCreator {
+
+  /**
+    * Divide the keyspace into n intervals and return
+    * a list of corresponding key pools.
+    * */
+  def obtain(n: Long, minValue: Long = 0, maxValue: Long = Long.MaxValue): List[IntervalKeyPool] = {
+    val nIntervals = Math.max(n, 1)
+    val intervalLen: Long = (maxValue - minValue) / nIntervals
+    List.range(0, nIntervals).map { i =>
+      val first = i * intervalLen + minValue
+      val last = first + intervalLen - 1
+      new IntervalKeyPool(first, last)
+    }
+  }
+
+}

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
@@ -51,4 +51,21 @@ class KeyPoolTests extends WordSpec with Matchers {
     }
   }
 
+  "KeyPoolCreator" should {
+    "split into n pools and honor minimum value" in {
+      val minValue = 10
+      val pools = KeyPoolCreator.obtain(3, minValue)
+      pools.size shouldBe 3
+      pools match {
+        case List(pool1, pool2, pool3) =>
+          pool1.first shouldBe minValue
+          pool1.last should be < pool2.first
+          pool2.last should be < pool3.first
+          pool3.last shouldBe Long.MaxValue - 1
+        case _ => fail
+      }
+    }
+
+  }
+
 }


### PR DESCRIPTION
All KeyPool code is in `codepropertygraph`, except for a handy utility method called `KeyPools.obtain`. Copied this one over from fuzzyc because I need it in other frontends, also added missing test.