### PR TITLE
Introduce `X2Cpg` and `newEmptyCpg` specifically

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/X2Cpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/X2Cpg.scala
@@ -13,7 +13,7 @@ object X2Cpg {
     * Create an empty CPG, backed by the file at `optionalOutputPath` or
     * in-memory if `optionalOutputPath` is empty.
     * */
-  def initCpg(optionalOutputPath: Option[String]): Cpg = {
+  def newEmptyCpg(optionalOutputPath: Option[String] = None): Cpg = {
     val odbConfig = optionalOutputPath
       .map { outputPath =>
         val outFile = File(outputPath)

--- a/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/X2Cpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/X2Cpg.scala
@@ -1,0 +1,36 @@
+package io.shiftleft.x2cpg
+
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import org.slf4j.LoggerFactory
+import overflowdb.{OdbConfig, OdbGraph}
+
+object X2Cpg {
+
+  private val logger = LoggerFactory.getLogger(X2Cpg.getClass)
+
+  /**
+    * Create an empty CPG, backed by the file at `optionalOutputPath` or
+    * in-memory if `optionalOutputPath` is empty.
+    * */
+  def initCpg(optionalOutputPath: Option[String]): Cpg = {
+    val odbConfig = optionalOutputPath
+      .map { outputPath =>
+        val outFile = File(outputPath)
+        if (outputPath != "" && outFile.exists) {
+          logger.info("Output file exists, removing: " + outputPath)
+          outFile.delete()
+        }
+        OdbConfig.withDefaults.withStorageLocation(outputPath)
+      }
+      .getOrElse {
+        OdbConfig.withDefaults()
+      }
+
+    val graph = OdbGraph.open(odbConfig,
+                              io.shiftleft.codepropertygraph.generated.nodes.Factories.allAsJava,
+                              io.shiftleft.codepropertygraph.generated.edges.Factories.allAsJava)
+    new Cpg(graph)
+  }
+
+}

--- a/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
@@ -21,6 +21,7 @@ class X2CpgTests extends WordSpec with Matchers {
       val cpg = X2Cpg.newEmptyCpg(Some(file.path.toString))
       file.exists shouldBe true
       file.size should not be 0
+      cpg.close()
     }
 
     "overwrite existing file to create empty CPG" in {

--- a/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
@@ -1,0 +1,39 @@
+package io.shiftleft.x2cpg
+
+import org.scalatest.{Matchers, WordSpec}
+import better.files.File
+
+class X2CpgTests extends WordSpec with Matchers {
+
+  "initCpg" should {
+
+    "create an empty in-memory CPG when no output path is given" in {
+      val cpg = X2Cpg.newEmptyCpg(None)
+      cpg.graph.V.hasNext shouldBe false
+      cpg.graph.E.hasNext shouldBe false
+      cpg.close()
+    }
+
+    "create file if it does not exist" in {
+      val file = File.newTemporaryFile("x2cpg")
+      file.delete()
+      file.exists shouldBe false
+      val cpg = X2Cpg.newEmptyCpg(Some(file.path.toString))
+      file.exists shouldBe true
+      file.size should not be 0
+    }
+
+    "overwrite existing file to create empty CPG" in {
+      File.usingTemporaryFile("x2cpg") { file =>
+        file.exists shouldBe true
+        file.size shouldBe 0
+        val cpg = X2Cpg.newEmptyCpg(Some(file.path.toString))
+        cpg.graph.V.hasNext shouldBe false
+        cpg.graph.E.hasNext shouldBe false
+        file.exists shouldBe true
+        file.size should not be 0
+        cpg.close()
+      }
+    }
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.codedumper
 
 import better.files.File
 import io.shiftleft.codepropertygraph.generated.{Languages, nodes}
-import io.shiftleft.semanticcpg.language.{NodeSteps, _}
+import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.Try

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -3,7 +3,6 @@ package io.shiftleft.semanticcpg.codedumper
 import better.files.File
 import io.shiftleft.codepropertygraph.generated.{Languages, nodes}
 import io.shiftleft.semanticcpg.language.{NodeSteps, _}
-import io.shiftleft.utils.{Source, SourceHighlighter}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.Try

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/SourceHighlighter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/SourceHighlighter.scala
@@ -1,9 +1,9 @@
-package io.shiftleft.utils
+package io.shiftleft.semanticcpg.codedumper
 
 import better.files.File
 import io.shiftleft.codepropertygraph.generated.Languages
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
+
 import scala.sys.process.Process
 
 /** language must be one of io.shiftleft.codepropertygraph.generated.Languages


### PR DESCRIPTION
As work on the PHP frontend starts by a third party, I am starting to bundle reusable frontend components into a small library named `x2cpg`. This PR brings in `newEmptyCpg`, which creates a new empty CPG, optionally backed by a file. Also moved `SourceHighlighter` to the `codedumper` package because that is the only place where it is used.