### PR TITLE
Round of cleanups for ReachingDefPass

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -11,25 +11,44 @@ import io.shiftleft.semanticcpg.utils.MemberAccess
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
+/**
+  * A pass that calculates reaching definitions ("data dependencies").
+  * */
 class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
 
   import DataFlowFrameworkHelper._
 
+  private case class Solution(in: Map[nodes.CfgNode, Set[nodes.StoredNode]],
+                              out: Map[nodes.CfgNode, Set[nodes.StoredNode]])
+
   override def partIterator: Iterator[nodes.Method] = cpg.method.toIterator()
 
   override def runOnPart(method: nodes.Method): Iterator[DiffGraph] = {
+    val solution = calculateMopSolution(method)
+    val dstGraph = addReachingDefEdges(method, solution)
+    Iterator(dstGraph.build())
+  }
 
+  /**
+    * Calculate fix point solution via a standard work list algorithm.
+    * The result is given by two maps: `in`` and `out`. These maps associate
+    * all CFG nodes with the set of definitions at node entry and node
+    * exit respectively.
+    * */
+  private def calculateMopSolution(method: nodes.Method): Solution = {
     val entryNode = method
     val exitNode = method.methodReturn
     val allCfgNodes = method.cfgNode.toList ++ List(entryNode, exitNode)
 
-    val nodeToGens = methodToGenMap(method).withDefaultValue(Set.empty[nodes.StoredNode])
-    val nodeToKills = methodToKillMap(method).withDefaultValue(Set.empty[nodes.StoredNode])
+    // Gen[n]: the definitions generated at node n
+    // Kill[n]: the definitions killed at node n
+    val gen = initGen(method).withDefaultValue(Set.empty[nodes.StoredNode])
+    val kill = initKill(method).withDefaultValue(Set.empty[nodes.StoredNode])
 
     // Out[n] = GEN[n] for all n in `allCfgNodes`
     var out: Map[nodes.CfgNode, Set[nodes.StoredNode]] =
       allCfgNodes
-        .map(cfgNode => cfgNode -> nodeToGens(cfgNode))
+        .map(cfgNode => cfgNode -> gen(cfgNode))
         .toMap
 
     // In[n] = empty for all n in `allCfgNodes`
@@ -40,44 +59,54 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
     val worklist = mutable.Set.empty[nodes.CfgNode]
     worklist ++= allCfgNodes
     while (worklist.nonEmpty) {
-      val currentCfgNode = worklist.head
-      worklist -= currentCfgNode
+      val n = worklist.head
+      worklist -= n
 
-      val inSet = currentCfgNode.start.cfgPrev
+      // IN[n] = Union(OUT[i]) for all predecessors i
+
+      val inSet = n.start.cfgPrev
         .map(out)
         .reduceOption((x, y) => x.union(y))
         .getOrElse(Set.empty[nodes.StoredNode])
+      in += n -> inSet
 
-      in += currentCfgNode -> inSet
+      val oldSize = out(n).size
 
-      val oldSize = out(currentCfgNode).size
-      val gens = nodeToGens(currentCfgNode)
-      val kills = nodeToKills(currentCfgNode)
+      // OUT[n] = GEN[n] + IN[n] \ KILL[N]
+      out += n -> gen(n).union(inSet.diff(kill(n)))
 
-      out += currentCfgNode -> gens.union(inSet.diff(kills))
-      val newSize = out(currentCfgNode).size
-
-      if (oldSize != newSize)
-        worklist ++= currentCfgNode.start.cfgNext.l
+      if (oldSize != out(n).size)
+        worklist ++= n.start.cfgNext.l
     }
+    Solution(in, out)
+  }
 
-    val dstGraph = DiffGraph.newBuilder
-    addReachingDefEdges(dstGraph, method, out, in)
-    Iterator(dstGraph.build())
+  def initGen(method: nodes.Method): Map[nodes.StoredNode, Set[nodes.StoredNode]] = {
+    method.start.call.map { call =>
+      call -> getGensOfCall(call)
+    }.toMap
+  }
+
+  def initKill(method: nodes.Method): Map[nodes.StoredNode, Set[nodes.StoredNode]] = {
+    method.start.call.map { call =>
+      val gens = getGensOfCall(call)
+      call -> kills(gens)
+    }.toMap
   }
 
   /** Pruned DDG, i.e., two call assignment nodes are adjacent if a
     * reaching definition edge reaches a node where the definition is used.
     * The final representation makes it straightforward to build def-use/use-def chains */
-  private def addReachingDefEdges(dstGraph: DiffGraph.Builder,
-                                  method: nodes.Method,
-                                  outSet: Map[nodes.CfgNode, Set[nodes.StoredNode]],
-                                  inSet: Map[nodes.CfgNode, Set[nodes.StoredNode]]): Unit = {
+  private def addReachingDefEdges(method: nodes.Method, solution: Solution): DiffGraph.Builder = {
 
+    val dstGraph = DiffGraph.newBuilder
     def addEdge(fromNode: nodes.StoredNode, toNode: nodes.StoredNode, variable: String = ""): Unit = {
       val properties = List((EdgeKeyNames.VARIABLE, variable))
       dstGraph.addEdgeInOriginal(fromNode, toNode, EdgeTypes.REACHING_DEF, properties)
     }
+
+    val in = solution.in
+    val out = solution.out
 
     // Add edges from formal input parameters to all nodes they
     // are used in. This assumes that formal parameters cannot
@@ -98,13 +127,13 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
                 returnNode.astChildren.headOption().map(_.asInstanceOf[nodes.CfgNode].code).getOrElse("")))
 
     // Now look at `out` for each node
-    outSet.foreach {
+    out.foreach {
       case (call: nodes.Call, outDefs) =>
         handleCall(call, outDefs)
       case (ret: nodes.Return, _) =>
         ret.astChildren.foreach { returnExpr =>
           val localRef = reference(returnExpr)
-          inSet(ret)
+          in(ret)
             .filter(inElement => localRef == reference(inElement))
             .toList
             .flatMap { filteredInElement =>
@@ -116,13 +145,13 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
       case _ => // ignore
     }
 
-    def handleCall(call: Call, outDefs: Set[StoredNode]) = {
+    def handleCall(call: Call, outDefs: Set[StoredNode]): Unit = {
       val usesInExpression = getUsesOfCall(call)
       val localRefsUses = usesInExpression.map(reference).filter(_.isDefined)
 
       // Create edge from entry point to all nodes that are not
       // reached by any other definitions.
-      if (inSet(call).isEmpty) {
+      if (in(call).isEmpty) {
         addEdge(method, call)
       }
 
@@ -149,7 +178,7 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
 
       if (isOperationAndAssignment(call)) {
         val localRefGens = getGensOfCall(call).map(reference)
-        inSet(call)
+        in(call)
           .filter(inElement => localRefGens.contains(reference(inElement)))
           .foreach { filteredInElement =>
             getExpressionFromGen(filteredInElement).foreach(x =>
@@ -170,7 +199,7 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
   }
 
   private def reference(node: nodes.StoredNode): Option[nodes.StoredNode] =
-    node._refOut.nextOption
+    node._refOut().nextOption
 
   private def isOperationAndAssignment(call: nodes.Call): Boolean = {
     call.name match {
@@ -213,13 +242,15 @@ object DataFlowFrameworkHelper {
 
   def getGensOfCall(call: nodes.StoredNode): Set[nodes.StoredNode] = {
     val methodParamOutsOrder = callToMethodParamOut(call)
-      .filter(methPO => methPO._propagateIn.hasNext)
+      .filter(methPO => methPO._propagateIn().hasNext)
       .map(_.asInstanceOf[nodes.HasOrder].order.toInt)
-    filterArgumentIndex(call._argumentOut.asScala.toList, methodParamOutsOrder).toSet
+    filterArgumentIndex(call._argumentOut().asScala.toList, methodParamOutsOrder).toSet
   }
 
   def getUsesOfCall(expr: nodes.StoredNode): Set[nodes.StoredNode] = {
-    expr._argumentOut.asScala
+    expr
+      ._argumentOut()
+      .asScala
       .filter(!getGensOfCall(expr).contains(_))
       .toSet
   }
@@ -231,13 +262,13 @@ object DataFlowFrameworkHelper {
   /** Returns a set of nodes that are killed by the passed nodes */
   def killsVertices(node: nodes.StoredNode): Set[nodes.StoredNode] = {
 
-    val localRefIt = node._refOut.asScala
+    val localRefIt = node._refOut().asScala
 
     if (!localRefIt.hasNext) {
       Set()
     } else {
       val localRef = localRefIt.next
-      localRef._refIn.asScala.filter(_.id2 != node.id2).toSet
+      localRef._refIn().asScala.filter(_.id2 != node.id2).toSet
     }
   }
 
@@ -245,22 +276,9 @@ object DataFlowFrameworkHelper {
     node.map(v => killsVertices(v)).fold(Set())((v1, v2) => v1.union(v2))
   }
 
-  def methodToGenMap(method: nodes.Method): Map[nodes.StoredNode, Set[nodes.StoredNode]] = {
-    method.start.call.map { call =>
-      call -> getGensOfCall(call)
-    }.toMap
-  }
-
-  def methodToKillMap(method: nodes.Method): Map[nodes.StoredNode, Set[nodes.StoredNode]] = {
-    method.start.call.map { call =>
-      val gens = getGensOfCall(call)
-      call -> kills(gens)
-    }.toMap
-  }
-
   def getOperation(node: nodes.StoredNode): Option[nodes.StoredNode] = {
     node match {
-      case identifier: nodes.Identifier => identifier._argumentIn.nextOption.flatMap(getOperation)
+      case identifier: nodes.Identifier => identifier._argumentIn().nextOption.flatMap(getOperation)
       case _: nodes.Call                => Some(node)
       case _: nodes.Return              => Some(node)
       case _                            => None

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/tests/ReachingDefPassTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/tests/ReachingDefPassTests.scala
@@ -1,5 +1,0 @@
-package io.shiftleft.dataflowengineoss.tests
-
-import io.shiftleft.dataflowengineoss.language.DataFlowCodeToCpgSuite
-
-class ReachingDefPassTests extends DataFlowCodeToCpgSuite {}

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/tests/ReachingDefPassTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/tests/ReachingDefPassTests.scala
@@ -1,0 +1,5 @@
+package io.shiftleft.dataflowengineoss.tests
+
+import io.shiftleft.dataflowengineoss.language.DataFlowCodeToCpgSuite
+
+class ReachingDefPassTests extends DataFlowCodeToCpgSuite {}


### PR DESCRIPTION
This is a first round of cleanups for the ReachingDefPass to make the algorithm more visible in preparation for its improvement. It also turned out that we computed the `gen` map a few times although it is sufficient to calculate it only once. This has been fixed, so, the change should also improve performance. There is still a lot of room for improvement here, but I thought I'd make @mpollmeier aware of these changes given that he's currently working on a larger refactor.