### PR TITLE
Reenable falsely disabled tests

### DIFF
--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
@@ -23,7 +23,9 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
   "Test 1: flow from function call read to multiple versions of the same variable" in {
 
     def source = cpg.identifier.name("sz")
+
     def sink = cpg.call.name("read")
+
     def flows = sink.reachableByFlows(source)
 
     flows.size shouldBe 6
@@ -62,10 +64,11 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
     val tmpSourceFile = flows.head.elements.head.method.filename
     flowsPretty.should(include(tmpSourceFile))
   }
+}
 
-  class CDataFlowTests2 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests2 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         |struct node {
         | int value;
         | struct node *next;
@@ -79,45 +82,45 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         |}
       """.stripMargin
 
-    "Test 2: flow with pointers" in {
-      implicit val callResolver = NoResolve
-      val source = cpg.identifier
-      val sink = cpg.method.name("free").parameter.argument
-      val flows = sink.reachableByFlows(source).l
+  "Test 2: flow with pointers" in {
+    implicit val callResolver = NoResolve
+    val source = cpg.identifier
+    val sink = cpg.method.name("free").parameter.argument
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 5
+    flows.size shouldBe 5
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("*p = head", 8),
-            ("free(p)", 10)
-          ),
-          List[(String, Option[Integer])](
-            ("*p = head", 8),
-            ("q = p->next", 9),
-            ("p = q", 8),
-            ("free(p)", 10)
-          ),
-          List[(String, Option[Integer])](
-            ("q = p->next", 9),
-            ("p = q", 8),
-            ("free(p)", 10)
-          ),
-          List[(String, Option[Integer])](
-            ("p = q", 8),
-            ("free(p)", 10)
-          ),
-          List[(String, Option[Integer])](
-            ("free(p)", 10)
-          )
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("*p = head", 8),
+          ("free(p)", 10)
+        ),
+        List[(String, Option[Integer])](
+          ("*p = head", 8),
+          ("q = p->next", 9),
+          ("p = q", 8),
+          ("free(p)", 10)
+        ),
+        List[(String, Option[Integer])](
+          ("q = p->next", 9),
+          ("p = q", 8),
+          ("free(p)", 10)
+        ),
+        List[(String, Option[Integer])](
+          ("p = q", 8),
+          ("free(p)", 10)
+        ),
+        List[(String, Option[Integer])](
+          ("free(p)", 10)
         )
-    }
+      )
   }
+}
 
-  class CDataFlowTests3 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests3 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | int method(int y){
         |  int a = 10;
         |  if (a < y){
@@ -126,28 +129,28 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         | }
       """.stripMargin
 
-    "Test 3: flow from function call argument" in {
-      implicit val callResolver = NoResolve
-      val source = cpg.identifier.name("a")
-      val sink = cpg.method.name("foo").parameter.argument
-      val flows = sink.reachableByFlows(source).l
+  "Test 3: flow from function call argument" in {
+    implicit val callResolver = NoResolve
+    val source = cpg.identifier.name("a")
+    val sink = cpg.method.name("foo").parameter.argument
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 2
+    flows.size shouldBe 2
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(List[(String, Option[Integer])](
-              ("a = 10", 3),
-              ("foo(a)", 5)
-            ),
-            List[(String, Option[Integer])](
-              ("foo(a)", 5)
-            ))
-    }
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(List[(String, Option[Integer])](
+            ("a = 10", 3),
+            ("foo(a)", 5)
+          ),
+          List[(String, Option[Integer])](
+            ("foo(a)", 5)
+          ))
   }
+}
 
-  class CDataFlowTests4 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests4 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | void flow(void) {
         |   int a = 0x37;
         |   int b=a;
@@ -159,34 +162,34 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         | }
       """.stripMargin
 
-    "Test 4: flow chains from x to a" in {
-      val source = cpg.identifier.name("a")
-      val sink = cpg.identifier.name("x")
-      val flows = sink.reachableByFlows(source).l
+  "Test 4: flow chains from x to a" in {
+    val source = cpg.identifier.name("a")
+    val sink = cpg.identifier.name("x")
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 2
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("a = 0x37", 3),
-            ("b=a", 4),
-            ("b + c", 6),
-            ("z = b + c", 6),
-            ("x = z", 9)
-          ),
-          List[(String, Option[Integer])](
-            ("b=a", 4),
-            ("b + c", 6),
-            ("z = b + c", 6),
-            ("x = z", 9)
-          )
+    flows.size shouldBe 2
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("a = 0x37", 3),
+          ("b=a", 4),
+          ("b + c", 6),
+          ("z = b + c", 6),
+          ("x = z", 9)
+        ),
+        List[(String, Option[Integer])](
+          ("b=a", 4),
+          ("b + c", 6),
+          ("z = b + c", 6),
+          ("x = z", 9)
         )
-    }
+      )
   }
+}
 
-  class CDataFlowTests5 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests5 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | int flow(int a){
         |   int z = a;
         |   int b = z;
@@ -195,27 +198,27 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         | }
       """.stripMargin
 
-    "Test 5: flow from method return to a" in {
-      val source = cpg.identifier.name("a")
-      val sink = cpg.methodReturn
-      val flows = sink.reachableByFlows(source).l
+  "Test 5: flow from method return to a" in {
+    val source = cpg.identifier.name("a")
+    val sink = cpg.methodReturn
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 1
+    flows.size shouldBe 1
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("z = a", 3),
-            ("b = z", 4),
-            ("return b;", 6),
-            ("RET", 2)
-          ))
-    }
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("z = a", 3),
+          ("b = z", 4),
+          ("return b;", 6),
+          ("RET", 2)
+        ))
   }
+}
 
-  class CDataFlowTests6 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests6 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | int nested(int a){
         |   int x;
         |   int z = 0x37;
@@ -232,26 +235,26 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         | }
       """.stripMargin
 
-    "Test 6: flow with nested if-statements from method return to a" in {
-      val source = cpg.identifier.name("a")
-      val sink = cpg.methodReturn
-      val flows = sink.reachableByFlows(source).l
+  "Test 6: flow with nested if-statements from method return to a" in {
+    val source = cpg.identifier.name("a")
+    val sink = cpg.methodReturn
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 1
+    flows.size shouldBe 1
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("x = a", 8),
-            ("return x;", 14),
-            ("RET", 2)
-          ))
-    }
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("x = a", 8),
+          ("return x;", 14),
+          ("RET", 2)
+        ))
   }
+}
 
-  class CDataFlowTests7 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests7 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | int nested(int a){
         |   int x;
         |   int z = 0x37;
@@ -268,35 +271,35 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         | }
       """.stripMargin
 
-    "Test 7: flow with nested if-statements from method return to x" in {
-      val source = cpg.identifier.name("x")
-      val sink = cpg.methodReturn
-      val flows = sink.reachableByFlows(source).l
-      flows.size shouldBe 3
+  "Test 7: flow with nested if-statements from method return to x" in {
+    val source = cpg.identifier.name("x")
+    val sink = cpg.methodReturn
+    val flows = sink.reachableByFlows(source).l
+    flows.size shouldBe 3
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("x = z", 12),
-            ("return x;", 14),
-            ("RET", 2)
-          ),
-          List[(String, Option[Integer])](
-            ("x = a", 8),
-            ("return x;", 14),
-            ("RET", 2)
-          ),
-          List[(String, Option[Integer])](
-            ("return x;", 14),
-            ("RET", 2)
-          )
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("x = z", 12),
+          ("return x;", 14),
+          ("RET", 2)
+        ),
+        List[(String, Option[Integer])](
+          ("x = a", 8),
+          ("return x;", 14),
+          ("RET", 2)
+        ),
+        List[(String, Option[Integer])](
+          ("return x;", 14),
+          ("RET", 2)
         )
-    }
+      )
   }
+}
 
-  class CDataFlowTests8 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests8 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | void param(int x){
         |    int a = x;
         |    int b = a;
@@ -304,34 +307,34 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         |  }
       """.stripMargin
 
-    "Test 8: flow chain from function argument of foo to a" in {
-      implicit val callResolver = NoResolve
-      val source = cpg.identifier.name("a")
-      val sink = cpg.method.name("foo").parameter.argument
-      val flows = sink.reachableByFlows(source).l
+  "Test 8: flow chain from function argument of foo to a" in {
+    implicit val callResolver = NoResolve
+    val source = cpg.identifier.name("a")
+    val sink = cpg.method.name("foo").parameter.argument
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 2
+    flows.size shouldBe 2
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(List[(String, Option[Integer])](
-              ("a = x", 3),
-              ("b = a", 4),
-              ("foo(b)", 5)
-            ),
-            List[(String, Option[Integer])](
-              ("b = a", 4),
-              ("foo(b)", 5)
-            ))
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(List[(String, Option[Integer])](
+            ("a = x", 3),
+            ("b = a", 4),
+            ("foo(b)", 5)
+          ),
+          List[(String, Option[Integer])](
+            ("b = a", 4),
+            ("foo(b)", 5)
+          ))
 
-      val source2 = cpg.identifier.name("a")
-      val sink2 = cpg.call.name("foo")
-      val flows2 = sink2.reachableByFlows(source2).l
-      flows shouldBe flows2
-    }
+    val source2 = cpg.identifier.name("a")
+    val sink2 = cpg.call.name("foo")
+    val flows2 = sink2.reachableByFlows(source2).l
+    flows shouldBe flows2
   }
+}
 
-  class CDataFlowTests9 extends DataFlowCodeToCpgSuite {
-    override val code = """
+class CDataFlowTests9 extends DataFlowCodeToCpgSuite {
+  override val code = """
                           | void param(int x){
                           |    int a = x;
                           |    int b = a;
@@ -339,29 +342,29 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
                           |  }
       """.stripMargin
 
-    "Test 9: flow from function foo to a" in {
-      val source = cpg.identifier.name("a")
-      val sink = cpg.call.name("foo")
-      val flows = sink.reachableByFlows(source).l
+  "Test 9: flow from function foo to a" in {
+    val source = cpg.identifier.name("a")
+    val sink = cpg.call.name("foo")
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 2
+    flows.size shouldBe 2
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(List[(String, Option[Integer])](
-              ("a = x", 3),
-              ("b = a", 4),
-              ("foo(b)", 5)
-            ),
-            List[(String, Option[Integer])](
-              ("b = a", 4),
-              ("foo(b)", 5)
-            ))
-    }
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(List[(String, Option[Integer])](
+            ("a = x", 3),
+            ("b = a", 4),
+            ("foo(b)", 5)
+          ),
+          List[(String, Option[Integer])](
+            ("b = a", 4),
+            ("foo(b)", 5)
+          ))
   }
+}
 
-  class CDataFlowTests10 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests10 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | struct node {
         | int value1;
         | int value2;
@@ -375,31 +378,31 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         |}
       """.stripMargin
 
-    "Test 10: flow with member access in expression to identifier x" in {
-      val source = cpg.identifier.name("x")
-      val sink = cpg.call.code("n.value2 = n.value1")
-      val flows = sink.reachableByFlows(source).l
+  "Test 10: flow with member access in expression to identifier x" in {
+    val source = cpg.identifier.name("x")
+    val sink = cpg.call.code("n.value2 = n.value1")
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 2
+    flows.size shouldBe 2
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("x = 10", 8),
-            ("n.value1 = x", 10),
-            ("n.value2 = n.value1", 11)
-          ),
-          List[(String, Option[Integer])](
-            ("n.value1 = x", 10),
-            ("n.value2 = n.value1", 11)
-          )
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("x = 10", 8),
+          ("n.value1 = x", 10),
+          ("n.value2 = n.value1", 11)
+        ),
+        List[(String, Option[Integer])](
+          ("n.value1 = x", 10),
+          ("n.value2 = n.value1", 11)
         )
-    }
+      )
   }
+}
 
-  class CDataFlowTests11 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests11 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | void flow(void) {
         |   int a = 0x37;
         |   int b=a;
@@ -411,28 +414,28 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         | }
       """.stripMargin
 
-    "Test 11: flow chain from x to literal 0x37" in {
-      val source = cpg.literal.code("0x37")
-      val sink = cpg.identifier.name("x")
-      val flows = sink.reachableByFlows(source).l
+  "Test 11: flow chain from x to literal 0x37" in {
+    val source = cpg.literal.code("0x37")
+    val sink = cpg.identifier.name("x")
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 1
+    flows.size shouldBe 1
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("a = 0x37", 3),
-            ("b=a", 4),
-            ("b + c", 6),
-            ("z = b + c", 6),
-            ("x = z", 9)
-          ))
-    }
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("a = 0x37", 3),
+          ("b=a", 4),
+          ("b + c", 6),
+          ("z = b + c", 6),
+          ("x = z", 9)
+        ))
   }
+}
 
-  class CDataFlowTests12 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests12 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
       | void flow(void) {
       |    int a = 0x37;
       |    int b = a;
@@ -441,30 +444,30 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
       | }
        """.stripMargin
 
-    "Test 12: flow with short hand assignment operator" in {
-      val source = cpg.call.code("a = 0x37")
-      val sink = cpg.call.code("z\\+=a")
-      val flows = sink.reachableByFlows(source).l
+  "Test 12: flow with short hand assignment operator" in {
+    val source = cpg.call.code("a = 0x37")
+    val sink = cpg.call.code("z\\+=a")
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 2
+    flows.size shouldBe 2
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(List[(String, Option[Integer])](
-              ("a = 0x37", 3),
-              ("b = a", 4),
-              ("z = b", 5),
-              ("z+=a", 6)
-            ),
-            List[(String, Option[Integer])](
-              ("a = 0x37", 3),
-              ("z+=a", 6)
-            ))
-    }
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(List[(String, Option[Integer])](
+            ("a = 0x37", 3),
+            ("b = a", 4),
+            ("z = b", 5),
+            ("z+=a", 6)
+          ),
+          List[(String, Option[Integer])](
+            ("a = 0x37", 3),
+            ("z+=a", 6)
+          ))
   }
+}
 
-  class CDataFlowTests13 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests13 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | void flow(void) {
         |    int a = 0x37;
         |    int b = a;
@@ -474,34 +477,34 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         | }
       """.stripMargin
 
-    "Test 13: flow after short hand assignment" in {
-      val source = cpg.call.code("a = 0x37")
-      val sink = cpg.identifier.name("w")
-      val flows = sink.reachableByFlows(source).l
+  "Test 13: flow after short hand assignment" in {
+    val source = cpg.call.code("a = 0x37")
+    val sink = cpg.identifier.name("w")
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 2
+    flows.size shouldBe 2
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("a = 0x37", 3),
-            ("b = a", 4),
-            ("z = b", 5),
-            ("z+=a", 6),
-            ("w = z", 7)
-          ),
-          List[(String, Option[Integer])](
-            ("a = 0x37", 3),
-            ("z+=a", 6),
-            ("w = z", 7)
-          )
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("a = 0x37", 3),
+          ("b = a", 4),
+          ("z = b", 5),
+          ("z+=a", 6),
+          ("w = z", 7)
+        ),
+        List[(String, Option[Integer])](
+          ("a = 0x37", 3),
+          ("z+=a", 6),
+          ("w = z", 7)
         )
-    }
+      )
   }
+}
 
-  class CDataFlowTests14 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests14 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
         | int main(int argc, char** argv){
         |    int x = argv[1];
         |    int y = x;
@@ -511,58 +514,56 @@ class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
         | }
       """.stripMargin
 
-    "Test 14: flow from identifier to method parameter" in {
-      val source = cpg.method.parameter
-      val sink = cpg.identifier.name("y")
-      val flows = sink.reachableByFlows(source).l
+  "Test 14: flow from identifier to method parameter" in {
+    val source = cpg.method.parameter
+    val sink = cpg.identifier.name("y")
+    val flows = sink.reachableByFlows(source).l
 
-      flows.size shouldBe 2
+    flows.size shouldBe 2
 
-      flows.map(flowToResultPairs).toSet shouldBe
-        Set(
-          List[(String, Option[Integer])](
-            ("main(int argc, char** argv)", 2),
-            ("x = argv[1]", 3),
-            ("y = x", 4),
-            ("z = y", 5)
-          ),
-          List[(String, Option[Integer])](
-            ("main(int argc, char** argv)", 2),
-            ("x = argv[1]", 3),
-            ("y = x", 4)
-          )
+    flows.map(flowToResultPairs).toSet shouldBe
+      Set(
+        List[(String, Option[Integer])](
+          ("main(int argc, char** argv)", 2),
+          ("x = argv[1]", 3),
+          ("y = x", 4),
+          ("z = y", 5)
+        ),
+        List[(String, Option[Integer])](
+          ("main(int argc, char** argv)", 2),
+          ("x = argv[1]", 3),
+          ("y = x", 4)
         )
-    }
+      )
   }
+}
 
-  class CDataFlowTests15 extends DataFlowCodeToCpgSuite {
-    override val code =
-      """
+class CDataFlowTests15 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
   void foo(bool x, void* y) {
     void* z =  x ? f(y) : g(y);
     return;
   }
       """.stripMargin
 
-    "Test 15: conditional expressions (joern issue #91)" in {
-      val source = cpg.method.parameter.name("y")
-      val sink = cpg.identifier.name("z")
-      val flows = sink.reachableByFlows(source).l
-      flows.map(flowToResultPairs).toSet shouldBe Set(
-        List[(String, Option[Integer])](
-          ("foo(bool x, void* y)", 2),
-          ("g(y)", 3),
-          ("x ? f(y) : g(y)", 3),
-          ("* z =  x ? f(y) : g(y)", 3)
-        ),
-        List[(String, Option[Integer])](
-          ("foo(bool x, void* y)", 2),
-          ("f(y)", 3),
-          ("x ? f(y) : g(y)", 3),
-          ("* z =  x ? f(y) : g(y)", 3)
-        )
+  "Test 15: conditional expressions (joern issue #91)" in {
+    val source = cpg.method.parameter.name("y")
+    val sink = cpg.identifier.name("z")
+    val flows = sink.reachableByFlows(source).l
+    flows.map(flowToResultPairs).toSet shouldBe Set(
+      List[(String, Option[Integer])](
+        ("foo(bool x, void* y)", 2),
+        ("g(y)", 3),
+        ("x ? f(y) : g(y)", 3),
+        ("* z =  x ? f(y) : g(y)", 3)
+      ),
+      List[(String, Option[Integer])](
+        ("foo(bool x, void* y)", 2),
+        ("f(y)", 3),
+        ("x ? f(y) : g(y)", 3),
+        ("* z =  x ? f(y) : g(y)", 3)
       )
-    }
+    )
   }
-
 }


### PR DESCRIPTION
In https://github.com/ShiftLeftSecurity/codepropertygraph/commit/405da0fadfa879d609644ace40703a8f3609152a, I put a curly bracket in the wrong place, which disabled a few of the OSS data flow tests. This fixes that. Placing the curly correctly triggers reformatting, so this PR looks big, however, it's really just that one bracket that's different.