### PR TITLE
Add more convenient accessor for arguments of calls

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -5,9 +5,10 @@ import io.shiftleft.semanticcpg.language._
 import scala.jdk.CollectionConverters._
 
 class CallMethods(val node: nodes.Call) extends AnyVal {
-  def argumentOption(index: Int): Option[nodes.Expression] =
-    node._argumentOut.asScala
-      .collectFirst { case expr: nodes.Expression if expr.argumentIndex == index => expr }
+  def arguments(index: Int): Iterable[nodes.Expression] =
+    node._argumentOut.asScala.collect {
+      case expr: nodes.Expression if expr.argumentIndex == index => expr
+    }.toList
 
-  def argument(index: Int): nodes.Expression = argumentOption(index).get
+  def argument(index: Int): nodes.Expression = arguments(index).head
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -2,7 +2,12 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
+import scala.jdk.CollectionConverters._
 
 class CallMethods(val node: nodes.Call) extends AnyVal {
-  def argument(index: Int): nodes.Expression = node.start.argument(index).head
+  def argumentOption(index: Int): Option[nodes.Expression] =
+    node._argumentOut.asScala
+      .collectFirst { case expr: nodes.Expression if expr.argumentIndex == index => expr }
+
+  def argument(index: Int): nodes.Expression = argumentOption(index).get
 }


### PR DESCRIPTION
Add more convenient accessor argumentOption for call->argument.  Make old accessor faster (don't use gremlin).

This is more convenient because many possible uses want to handle the None-case instead of having an exception thrown in their face. Ping @ml86 to make you aware of this new API (it can simplify a lot of code in the closed source dataflow tracker!).