### PR TITLE
Update scalatest to 3.1.1.

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "com.github.scopt" %% "scopt" % "3.7.1",
   "org.slf4j" % "slf4j-api" % "1.7.30",
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.2" % Test,
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test
+  "org.scalatest" %% "scalatest" % "3.1.1" % Test
 )
 
 import better.files.FileExtensions

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -3,7 +3,9 @@ package io.shiftleft.codepropertygraph.cpgloading
 import java.nio.file.FileSystemNotFoundException
 
 import overflowdb.{OdbConfig, OdbGraph}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 
 /**
   * Specification of the CPGLoader. The loader allows CPGs to be loaded
@@ -11,7 +13,7 @@ import org.scalatest.{Matchers, WordSpec}
   * An optional `CpgLoaderConfig` can be passed to the loader to influence
   * the loading process.
   * */
-class CpgLoaderTests extends WordSpec with Matchers {
+class CpgLoaderTests extends AnyWordSpec with Matchers {
 
   val filename = "resources/testcode/cpgs/hello-shiftleft-0.0.5/cpg.bin.zip"
 

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -6,9 +6,11 @@ import overflowdb.traversal._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
 import io.shiftleft.passes.{DiffGraph, IntervalKeyPool}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DiffGraphTest extends WordSpec with Matchers {
+
+class DiffGraphTest extends AnyWordSpec with Matchers {
   "should be able to build an inverse DiffGraph" in {
     withTestOdb { graph =>
       // setup existing graph

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/predicates/TextTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/predicates/TextTest.scala
@@ -1,8 +1,10 @@
 package io.shiftleft.codepropertygraph.predicates
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-import org.scalatest.{Matchers, WordSpec}
 
-class TextTest extends WordSpec with Matchers {
+
+class TextTest extends AnyWordSpec with Matchers {
   val name = "fully funny"
 
   "Text.textRegex" should {

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
@@ -5,9 +5,11 @@ import overflowdb._
 import overflowdb.traversal._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CpgOverlayIntegrationTest extends WordSpec with Matchers {
+
+class CpgOverlayIntegrationTest extends AnyWordSpec with Matchers {
   val InitialNodeCode = "initialNode"
   val Pass1NewNodeCode = "pass1NewNodeCode"
   val Pass2NewNodeCode = "pass2NewNodeCode"

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgPassTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgPassTests.scala
@@ -4,11 +4,13 @@ import better.files.File
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import org.scalatest.{Matchers, WordSpec}
+
 
 import scala.jdk.CollectionConverters._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CpgPassTests extends WordSpec with Matchers {
+class CpgPassTests extends AnyWordSpec with Matchers {
 
   private object Fixture {
     def apply(keyPool: Option[KeyPool] = None)(f: (Cpg, CpgPassBase) => Unit): Unit = {

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
@@ -1,8 +1,10 @@
 package io.shiftleft.passes
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class KeyPoolTests extends WordSpec with Matchers {
+
+class KeyPoolTests extends AnyWordSpec with Matchers {
 
   "IntervalKeyPool" should {
     "return [first, ..., last] and then raise" in {

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/ParallelCpgPassTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/ParallelCpgPassTests.scala
@@ -4,11 +4,13 @@ import better.files.File
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 
 import scala.jdk.CollectionConverters._
 
-class ParallelCpgPassTests extends WordSpec with Matchers {
+class ParallelCpgPassTests extends AnyWordSpec with Matchers {
 
   private object Fixture {
     def apply(keyPools: Option[Iterator[KeyPool]] = None)(f: (Cpg, CpgPassBase) => Unit): Unit = {

--- a/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
@@ -1,9 +1,11 @@
 package io.shiftleft.x2cpg
 
-import org.scalatest.{Matchers, WordSpec}
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import better.files.File
 
-class X2CpgTests extends WordSpec with Matchers {
+class X2CpgTests extends AnyWordSpec with Matchers {
 
   "initCpg" should {
 

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -49,7 +49,7 @@ val CaskVersion = "0.6.7"
 val CatsVersion = "2.0.0"
 val CirceVersion = "0.12.2"
 val AmmoniteVersion = "1.8.1"
-val ScalatestVersion = "3.0.8"
+val ScalatestVersion = "3.1.1"
 val ZeroturnaroundVersion = "1.13"
 
 libraryDependencies ++= Seq(

--- a/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
@@ -1,9 +1,11 @@
 package io.shiftleft.console
 
 import better.files.File
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ConsoleConfigTest extends WordSpec with Matchers {
+
+class ConsoleConfigTest extends AnyWordSpec with Matchers {
   "An InstallConfig" should {
     "set the rootPath to the current working directory by default" in {
       val config = new InstallConfig(environment = Map.empty)

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -6,14 +6,16 @@ import java.util.zip.ZipOutputStream
 import better.files.Dsl._
 import better.files._
 import io.shiftleft.codepropertygraph.Cpg
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.console.testing._
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, Scpg}
 
 import scala.util.Try
 
-class ConsoleTests extends WordSpec with Matchers {
+class ConsoleTests extends AnyWordSpec with Matchers {
 
   "importCode" should {
     "provide overview of available language modules" in ConsoleFixture() { (console, _) =>

--- a/console/src/test/scala/io/shiftleft/console/HelpTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/HelpTests.scala
@@ -1,9 +1,11 @@
 package io.shiftleft.console
 
 import io.shiftleft.console.workspacehandling.Project
-import org.scalatest.{Matchers, WordSpec}
 
-class HelpTests extends WordSpec with Matchers {
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class HelpTests extends AnyWordSpec with Matchers {
 
   "Help" should {
     "provide overview of commands as table" in {

--- a/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
@@ -6,9 +6,11 @@ import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.console.LanguageHelper._
 import io.shiftleft.console.cpgcreation.LanguageGuesser._
 import io.shiftleft.console.cpgcreation.LlvmLanguageFrontend
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class LanguageHelperTests extends WordSpec with Matchers {
+
+class LanguageHelperTests extends AnyWordSpec with Matchers {
 
   "LanguageHelper.guessLanguage" should {
 

--- a/console/src/test/scala/io/shiftleft/console/PPrinterTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/PPrinterTest.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.console
 
-import org.scalatest.{Matchers, WordSpec}
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /** We use source-highlight to encode source as ansi strings, e.g. the .dump step
   * Ammonite uses fansi for it's colour-coding, and while both pledge to follow the ansi codec, they aren't compatible
   * TODO: PR for fansi to support these standard encodings out of the box */
-class PPrinterTest extends WordSpec with Matchers {
+class PPrinterTest extends AnyWordSpec with Matchers {
   // ansi colour-encoded strings as source-highlight produces them
   val IntGreenForeground = "\u001b[32mint\u001b[m"
   val IfBlueBold = "\u001b[01;34mif\u001b[m"

--- a/console/src/test/scala/io/shiftleft/console/UnixUtilsTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/UnixUtilsTest.scala
@@ -2,9 +2,11 @@ package io.shiftleft.console
 
 import better.files._
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class UnixUtilsTest extends WordSpec with Matchers {
+
+class UnixUtilsTest extends AnyWordSpec with Matchers {
 
   "writes to file (overwrite)" when {
     "using String" in {

--- a/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
@@ -5,15 +5,17 @@ import java.util.UUID
 import scala.concurrent._
 import scala.concurrent.duration._
 
-import org.scalatest.{Matchers, WordSpec}
+
 
 import cask.util.Logger.Console._
 import castor.Context.Simple.global
 import ujson.Value.Value
 
 import io.shiftleft.console.embammonite.EmbeddedAmmonite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CPGQLServerTests extends WordSpec with Matchers {
+class CPGQLServerTests extends AnyWordSpec with Matchers {
   val validBasicAuthHeaderVal = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
 
   val DefaultPromiseAwaitTimeout = Duration(10, SECONDS)

--- a/console/src/test/scala/io/shiftleft/console/embammonite/EmbeddedAmmoniteTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/embammonite/EmbeddedAmmoniteTests.scala
@@ -2,9 +2,11 @@ package io.shiftleft.console.embammonite
 
 import java.util.concurrent.Semaphore
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class EmbeddedAmmoniteTests extends WordSpec with Matchers {
+
+class EmbeddedAmmoniteTests extends AnyWordSpec with Matchers {
 
   "EmbeddedAmmoniteShell" should {
     "start and shutdown without hanging" in {

--- a/console/src/test/scala/io/shiftleft/console/scripting/AmmoniteExecutorTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/AmmoniteExecutorTest.scala
@@ -1,12 +1,14 @@
 package io.shiftleft.console.scripting
 
-import org.scalatest.{Matchers, WordSpec}
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.{Path, Paths}
 
-class AmmoniteExecutorTest extends WordSpec with Matchers {
+class AmmoniteExecutorTest extends AnyWordSpec with Matchers {
   private object TestAmmoniteExecutor extends AmmoniteExecutor {
     override protected def predef: String =
       """

--- a/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
@@ -2,7 +2,7 @@ package io.shiftleft.console.scripting
 
 import better.files.File
 import cats.effect.IO
-import org.scalatest.{Inside, Matchers, WordSpec}
+import org.scalatest.{Inside}
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.console.scripting.ScriptManager.{ScriptCollections, ScriptDescription, ScriptDescriptions}
@@ -11,8 +11,10 @@ import java.nio.file.{FileSystemNotFoundException, NoSuchFileException, Path}
 
 import scala.io.Source
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ScriptManagerTest extends WordSpec with Matchers with Inside {
+class ScriptManagerTest extends AnyWordSpec with Matchers with Inside {
 
   private object TestScriptExecutor extends AmmoniteExecutor {
     override protected def predef: String = ""

--- a/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceLoaderTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceLoaderTests.scala
@@ -2,11 +2,13 @@ package io.shiftleft.console.workspacehandling
 
 import better.files.Dsl.mkdir
 import better.files.File
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 
 import scala.reflect.io.Directory
 
-class WorkspaceLoaderTests extends WordSpec with Matchers {
+class WorkspaceLoaderTests extends AnyWordSpec with Matchers {
 
   private val tmpDirPrefix = "workspace-tests"
 

--- a/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceManagerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceManagerTests.scala
@@ -2,9 +2,11 @@ package io.shiftleft.console.workspacehandling
 
 import better.files._
 import io.shiftleft.codepropertygraph.Cpg
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class WorkspaceManagerTests extends WordSpec with Matchers {
+
+class WorkspaceManagerTests extends AnyWordSpec with Matchers {
 
   private val tmpDirPrefix = "workspace-tests"
 

--- a/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceTests.scala
@@ -3,11 +3,13 @@ package io.shiftleft.console.workspacehandling
 import better.files.Dsl._
 import better.files.File
 import io.shiftleft.semanticcpg.testing.MockCpg
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 
 import scala.collection.mutable.ListBuffer
 
-class WorkspaceTests extends WordSpec with Matchers {
+class WorkspaceTests extends AnyWordSpec with Matchers {
 
   "toString" should {
 

--- a/cpgvalidator/build.sbt
+++ b/cpgvalidator/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(JavaAppPackaging)
 libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.2" % Runtime, //redirect tinkerpop's slf4j logging to log4j
   "com.typesafe.play" %% "play-json" % "2.7.4",
-  "org.scalatest"       %% "scalatest"       % "3.0.8" % "test",
+  "org.scalatest"       %% "scalatest"       % "3.1.1" % "test",
 )
 
 // execute tests in root project so that they work in sbt *and* intellij

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
@@ -5,9 +5,11 @@ import io.shiftleft.cpgvalidator.validators.CpgValidator
 import overflowdb._
 import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CpgValidatorTest extends WordSpec with Matchers {
+
+class CpgValidatorTest extends AnyWordSpec with Matchers {
   private def withNewBaseCpg[T](fun: Cpg => T): T = {
     val graph = OverflowDbTestInstance.create
     val cpg = Cpg(graph)

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/KeysValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/KeysValidatorTest.scala
@@ -6,9 +6,11 @@ import io.shiftleft.cpgvalidator.validators.KeysValidator
 import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.cpgvalidator.facts.FactConstructionClasses.Cardinality
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class KeysValidatorTest extends WordSpec with Matchers {
+
+class KeysValidatorTest extends AnyWordSpec with Matchers {
 
   private class TestValidationErrorRegistry extends ValidationErrorRegistry {
     def getErrors: Iterable[ValidationError] = validationErrors.values.flatten

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/NoLongJumpValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/NoLongJumpValidatorTest.scala
@@ -5,9 +5,11 @@ import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeysOdb, NodeTypes}
 import io.shiftleft.cpgvalidator.validators.cfg.NoLongJumpValidator
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NoLongJumpValidatorTest extends WordSpec with Matchers {
+
+class NoLongJumpValidatorTest extends AnyWordSpec with Matchers {
   private def withNewBaseCpg[T](fun: Cpg => T): T = {
     val graph = OverflowDbTestInstance.create
     val cpg = Cpg(graph)

--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -3,6 +3,6 @@ name := "dataflowengineoss"
 dependsOn(Projects.semanticcpg % "compile -> compile; test -> test")
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  "org.scalatest" %% "scalatest" % "3.1.1" % Test,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test
 )

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CpgDataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CpgDataFlowTests.scala
@@ -1,8 +1,0 @@
-package io.shiftleft.dataflowengineoss.language
-
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language._
-import org.scalatest.{Matchers, WordSpec}
-
-class CpgDataFlowTests extends WordSpec with Matchers {}

--- a/queries/build.sbt
+++ b/queries/build.sbt
@@ -4,6 +4,6 @@ dependsOn(Projects.semanticcpg % "compile -> compile; test -> test",
           Projects.dataflowengineoss % "compile -> compile; test -> test")
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  "org.scalatest" %% "scalatest" % "3.1.1" % Test,
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test
 )

--- a/queries/src/test/scala/io/shiftleft/queries/MallocMemcpyTests.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/MallocMemcpyTests.scala
@@ -2,7 +2,7 @@ package io.shiftleft.queries
 
 import io.shiftleft.dataflowengineoss.language.{DataFlowCodeToCpgSuite, _}
 import io.shiftleft.semanticcpg.language._
-import org.scalatest.{Matchers, WordSpec}
+
 
 class MallocMemcpyTests extends DataFlowCodeToCpgSuite {
 

--- a/samples/pass/build.sbt
+++ b/samples/pass/build.sbt
@@ -8,7 +8,7 @@ libraryDependencies ++= Seq(
   "io.shiftleft" %% "codepropertygraph" % cpgVersion,
   "io.shiftleft" %% "enhancements"  % cpgVersion,
 
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test
+  "org.scalatest" %% "scalatest" % "3.1.1" % Test
 )
 
 ThisBuild / resolvers ++= Seq(

--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -5,7 +5,7 @@ dependsOn(Projects.codepropertygraph)
 libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-native" % "3.6.7",
   "org.scala-lang.modules" %% "scala-collection-contrib" % "0.2.1",
-  "org.scalatest" %% "scalatest" % "3.0.8",
+  "org.scalatest" %% "scalatest" % "3.1.1",
   "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg
 )
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgSuite.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgSuite.scala
@@ -6,9 +6,11 @@ import java.nio.file.Files
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
 import io.shiftleft.semanticcpg.testfixtures.LanguageFrontend.FuzzycFrontend
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
 
-class CodeToCpgSuite extends WordSpec with Matchers with BeforeAndAfterAll {
+class CodeToCpgSuite extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   val code = ""
   var cpg: Cpg = _

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
@@ -1,10 +1,12 @@
 package io.shiftleft.semanticcpg
 
 import io.shiftleft.semanticcpg.testing.MockCpg
-import org.scalatest.{Matchers, WordSpec}
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import io.shiftleft.semanticcpg.language._
 
-class OverlaysTests extends WordSpec with Matchers {
+class OverlaysTests extends AnyWordSpec with Matchers {
 
   "Overlays" should {
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGeneratorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGeneratorTests.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
-import org.scalatest.{Matchers, WordSpec}
+
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgSuite
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgSuite
-import org.scalatest.{Matchers, WordSpec}
+
 
 class CallGraphTests extends CodeToCpgSuite {
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NewNodeStepsTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/NewNodeStepsTests.scala
@@ -9,12 +9,13 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.{EdgeKeyNames, ModifierTypes}
 import io.shiftleft.passes.DiffGraph
 import io.shiftleft.passes.DiffGraph.{EdgeInDiffGraph, EdgeToOriginal}
-import org.scalatest.{Matchers, WordSpec}
 import io.shiftleft.codepropertygraph.generated.NodeKeyNames
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.jdk.CollectionConverters._
 
-class NewNodeStepsTest extends WordSpec with Matchers {
+class NewNodeStepsTest extends AnyWordSpec with Matchers {
   import NewNodeNodeStepsTest._
 
   "stores NewNodes" in {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -6,11 +6,13 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.json4s.JString
 import org.json4s.native.JsonMethods.parse
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 
 import scala.collection.mutable
 
-class StepsTest extends WordSpec with Matchers {
+class StepsTest extends AnyWordSpec with Matchers {
 
   "generic cpg" should {
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/ExpressionTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/ExpressionTests.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import org.scalatest.{Matchers, WordSpec}
+
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ExpressionTests extends WordSpec with Matchers {
+class ExpressionTests extends AnyWordSpec with Matchers {
 
   "generic cpg" should ExistingCpgFixture("expression") { fixture =>
     "expand to next expression in CFG" in {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/BindingTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/BindingTests.scala
@@ -3,9 +3,11 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class BindingTests extends WordSpec with Matchers {
+
+class BindingTests extends AnyWordSpec with Matchers {
 
   "Binding steps" should ExistingCpgFixture("binding") { fixture =>
     "expand from BindingTest class to one method binding" in {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/FileTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/FileTests.scala
@@ -4,8 +4,10 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import org.scalatest.{LoneElement, Matchers, WordSpec}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class FileTests extends WordSpec with Matchers with LoneElement {
+class FileTests extends AnyWordSpec with Matchers with LoneElement {
   val fileName = "io/shiftleft/testcode/file/FileTest.java"
 
   "generic cpg" should ExistingCpgFixture("file") { fixture =>

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTests.scala
@@ -3,9 +3,11 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.ModifierTypes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MemberTests extends WordSpec with Matchers {
+
+class MemberTests extends AnyWordSpec with Matchers {
 
   "Member traversals" should ExistingCpgFixture("type") { fixture =>
     "should find two members: `member` and `static_member`" in {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTests.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import org.scalatest.{Matchers, WordSpec}
+
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MethodParameterTests extends WordSpec with Matchers {
+class MethodParameterTests extends AnyWordSpec with Matchers {
 
   "generic cpg" should ExistingCpgFixture("methodparameter") { fixture =>
     "find parameters" when {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTests.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, nodes}
-import org.scalatest.{Matchers, WordSpec}
+
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MethodTests extends WordSpec with Matchers {
+class MethodTests extends AnyWordSpec with Matchers {
 
   "Method traversals" should ExistingCpgFixture("method") { fixture =>
     "expand to type declaration" in {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTests.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import org.scalatest.{Matchers, WordSpec}
+
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NamespaceTests extends WordSpec with Matchers {
+class NamespaceTests extends AnyWordSpec with Matchers {
 
   "generic cpg" should ExistingCpgFixture("namespace") { fixture =>
     "find package io.shiftleft.testcode.namespace" in {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTests.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import org.scalatest.{Matchers, WordSpec}
+
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TypeTests extends WordSpec with Matchers {
+class TypeTests extends AnyWordSpec with Matchers {
   ExistingCpgFixture("type") { fixture =>
     "ClassMemberTest" should {
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreatorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreatorTests.scala
@@ -2,9 +2,11 @@ package io.shiftleft.semanticcpg.layers
 
 import io.shiftleft.semanticcpg.Overlays
 import io.shiftleft.semanticcpg.testing.MockCpg
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class EnhancedBaseCreatorTests extends WordSpec with Matchers {
+
+class EnhancedBaseCreatorTests extends AnyWordSpec with Matchers {
 
   "EnhancedBaseCreator" should {
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPassTests.scala
@@ -3,9 +3,11 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.passes.DiffGraph
 import io.shiftleft.semanticcpg.language._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class BindingMethodOverridesPassTests extends WordSpec with Matchers {
+
+class BindingMethodOverridesPassTests extends AnyWordSpec with Matchers {
   "Binding propagation should not mark non-overwritten bindings" in {
     val cpg = Cpg.emptyCpg
     val diffGraph = DiffGraph.newBuilder

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CapturingLinkerTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CapturingLinkerTests.scala
@@ -5,11 +5,13 @@ import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeysOdb, NodeTyp
 import overflowdb._
 import io.shiftleft.semanticcpg.passes.linking.capturinglinker.CapturingLinker
 import io.shiftleft.semanticcpg.testfixtures.EmptyGraphFixture
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 
 import scala.jdk.CollectionConverters._
 
-class CapturingLinkerTests extends WordSpec with Matchers {
+class CapturingLinkerTests extends AnyWordSpec with Matchers {
 
   "link CLOSURE_BINDING and LOCALS with same CLOSURE_BINDING_IDs" in EmptyGraphFixture { graph =>
     val closureBinding1 = graph + (NodeTypes.CLOSURE_BINDING, NodeKeysOdb.CLOSURE_BINDING_ID -> "id1")

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
@@ -3,11 +3,13 @@ package io.shiftleft.semanticcpg.passes
 import io.shiftleft.OverflowDbTestInstance
 import overflowdb._
 import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominator, CfgDominatorFrontier, DomTreeAdapter, CfgAdapter}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 
 import scala.jdk.CollectionConverters._
 
-class CfgDominatorFrontierTests extends WordSpec with Matchers {
+class CfgDominatorFrontierTests extends AnyWordSpec with Matchers {
 
   private class TestCfgAdapter extends CfgAdapter[Node] {
     override def successors(node: Node): IterableOnce[Node] =

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorPassTests.scala
@@ -5,11 +5,13 @@ import overflowdb._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 
 import scala.jdk.CollectionConverters._
 
-class CfgDominatorPassTests extends WordSpec with Matchers {
+class CfgDominatorPassTests extends AnyWordSpec with Matchers {
   "Have correct DOMINATE/POST_DOMINATE edges after CfgDominatorPass run." in {
     val graph = OverflowDbTestInstance.create
     val cpg = new Cpg(graph)

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/ContainsEdgePassTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/ContainsEdgePassTest.scala
@@ -5,10 +5,12 @@ import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.passes.containsedges.ContainsEdgePass
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 import scala.jdk.CollectionConverters._
 
-class ContainsEdgePassTest extends WordSpec with Matchers {
+class ContainsEdgePassTest extends AnyWordSpec with Matchers {
 
   import ContainsEdgePassTest.Fixture
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MemberAccessLinkerTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MemberAccessLinkerTests.scala
@@ -3,9 +3,11 @@ package io.shiftleft.semanticcpg.passes
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MemberAccessLinkerTests extends WordSpec with Matchers {
+
+class MemberAccessLinkerTests extends AnyWordSpec with Matchers {
 
   "have a reference to correct member" in ExistingCpgFixture("memberaccesslinker") { fixture =>
     val members = fixture.cpg.call(Operators.indirectMemberAccess).referencedMember.l

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
@@ -5,9 +5,11 @@ import io.shiftleft.codepropertygraph.generated._
 import overflowdb._
 import io.shiftleft.semanticcpg.passes.methoddecorations.MethodDecoratorPass
 import io.shiftleft.semanticcpg.testfixtures.EmptyGraphFixture
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MethodDecoratorPassTests extends WordSpec with Matchers {
+
+class MethodDecoratorPassTests extends AnyWordSpec with Matchers {
   "MethodDecoratorTest" in EmptyGraphFixture { graph =>
     val method = graph + NodeTypes.METHOD
     val parameterIn = graph

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/NamespaceCreatorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/NamespaceCreatorTests.scala
@@ -6,9 +6,11 @@ import overflowdb._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.semanticcpg.testfixtures.EmptyGraphFixture
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NamespaceCreatorTests extends WordSpec with Matchers {
+
+class NamespaceCreatorTests extends AnyWordSpec with Matchers {
   "NamespaceCreateor test " in EmptyGraphFixture { graph =>
     val cpg = new Cpg(graph)
     val block1 = graph + (NodeTypes.NAMESPACE_BLOCK, NodeKeysOdb.NAME -> "namespace1")

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/CountStatementsTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/CountStatementsTests.scala
@@ -1,9 +1,11 @@
 package io.shiftleft.semanticcpg.utils
 
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CountStatementsTests extends WordSpec with Matchers {
+
+class CountStatementsTests extends AnyWordSpec with Matchers {
 
   "Class Statements" should ExistingCpgFixture("method") { fixture =>
     "count statements correctly" in {


### PR DESCRIPTION
I needed to change all the import because of an API change in scalatest.
This resolves a problem in Intellij is not able to run codescience unit
tests because of conflicting scalatest versions. We end up with
conflicting scalatest versions because currently semanticcpg used
scalatest as full dependency and not just as a test dependency.