### PR TITLE
Check for invalid node indices upon node insertion, not just edge insertion

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
@@ -55,8 +55,12 @@ class ProtoToCpg(overflowConfig: OdbConfig = OdbConfig.withoutOverflow) {
     val properties = node.getPropertyList.asScala.toSeq
       .map(prop => (prop.getName.name, prop.getValue))
       .map(toProperty)
-    try odbGraph + (node.getType.name, node.getKey, properties: _*)
-    catch {
+    try {
+      if (node.getKey() == -1) {
+        throw new IllegalArgumentException("node has illegal key -1. Something is wrong with the cpg.")
+      }
+      odbGraph + (node.getType.name, node.getKey, properties: _*)
+    } catch {
       case e: Exception =>
         throw new RuntimeException("Failed to insert a node. proto:\n" + node, e)
     }


### PR DESCRIPTION
We recently had some flakyness with java2cpg. Java2cpg initializes all nodes with ID -1, and then later assigns proper IDs. In order to catch bugs earlier, we consider ID -1 illegal, and throw on edge insertion with such ids.

This PR adds the same check to node insertions, in the hope that we get better error messages: This can trigger earlier, and give us more info about the offending node, helping us to track down where the issue lies.