### PR TITLE
Reformat tests

### DIFF
--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -6,7 +6,6 @@ import overflowdb.{OdbConfig, OdbGraph}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 /**
   * Specification of the CPGLoader. The loader allows CPGs to be loaded
   * from the CPG protobuf file format (based on Google protocol buffers).

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -9,7 +9,6 @@ import io.shiftleft.passes.{DiffGraph, IntervalKeyPool}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class DiffGraphTest extends AnyWordSpec with Matchers {
   "should be able to build an inverse DiffGraph" in {
     withTestOdb { graph =>

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/predicates/TextTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/predicates/TextTest.scala
@@ -2,8 +2,6 @@ package io.shiftleft.codepropertygraph.predicates
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
-
 class TextTest extends AnyWordSpec with Matchers {
   val name = "fully funny"
 

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
@@ -8,7 +8,6 @@ import io.shiftleft.codepropertygraph.generated._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class CpgOverlayIntegrationTest extends AnyWordSpec with Matchers {
   val InitialNodeCode = "initialNode"
   val Pass1NewNodeCode = "pass1NewNodeCode"

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgPassTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgPassTests.scala
@@ -5,7 +5,6 @@ import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
 
-
 import scala.jdk.CollectionConverters._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
@@ -3,7 +3,6 @@ package io.shiftleft.passes
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class KeyPoolTests extends AnyWordSpec with Matchers {
 
   "IntervalKeyPool" should {

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/ParallelCpgPassTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/ParallelCpgPassTests.scala
@@ -7,7 +7,6 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 import scala.jdk.CollectionConverters._
 
 class ParallelCpgPassTests extends AnyWordSpec with Matchers {

--- a/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.x2cpg
 
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import better.files.File

--- a/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
@@ -4,7 +4,6 @@ import better.files.File
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class ConsoleConfigTest extends AnyWordSpec with Matchers {
   "An InstallConfig" should {
     "set the rootPath to the current working directory by default" in {

--- a/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
@@ -9,7 +9,6 @@ import io.shiftleft.console.cpgcreation.LlvmLanguageFrontend
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class LanguageHelperTests extends AnyWordSpec with Matchers {
 
   "LanguageHelper.guessLanguage" should {

--- a/console/src/test/scala/io/shiftleft/console/PPrinterTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/PPrinterTest.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.console
 
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/console/src/test/scala/io/shiftleft/console/UnixUtilsTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/UnixUtilsTest.scala
@@ -5,7 +5,6 @@ import better.files._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class UnixUtilsTest extends AnyWordSpec with Matchers {
 
   "writes to file (overwrite)" when {

--- a/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
@@ -5,8 +5,6 @@ import java.util.UUID
 import scala.concurrent._
 import scala.concurrent.duration._
 
-
-
 import cask.util.Logger.Console._
 import castor.Context.Simple.global
 import ujson.Value.Value

--- a/console/src/test/scala/io/shiftleft/console/embammonite/EmbeddedAmmoniteTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/embammonite/EmbeddedAmmoniteTests.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.Semaphore
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class EmbeddedAmmoniteTests extends AnyWordSpec with Matchers {
 
   "EmbeddedAmmoniteShell" should {

--- a/console/src/test/scala/io/shiftleft/console/scripting/AmmoniteExecutorTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/AmmoniteExecutorTest.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.console.scripting
 
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceLoaderTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceLoaderTests.scala
@@ -5,7 +5,6 @@ import better.files.File
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 import scala.reflect.io.Directory
 
 class WorkspaceLoaderTests extends AnyWordSpec with Matchers {

--- a/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceManagerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceManagerTests.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class WorkspaceManagerTests extends AnyWordSpec with Matchers {
 
   private val tmpDirPrefix = "workspace-tests"

--- a/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/workspacehandling/WorkspaceTests.scala
@@ -6,7 +6,6 @@ import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 import scala.collection.mutable.ListBuffer
 
 class WorkspaceTests extends AnyWordSpec with Matchers {

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
@@ -8,7 +8,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class CpgValidatorTest extends AnyWordSpec with Matchers {
   private def withNewBaseCpg[T](fun: Cpg => T): T = {
     val graph = OverflowDbTestInstance.create

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/KeysValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/KeysValidatorTest.scala
@@ -9,7 +9,6 @@ import io.shiftleft.cpgvalidator.facts.FactConstructionClasses.Cardinality
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class KeysValidatorTest extends AnyWordSpec with Matchers {
 
   private class TestValidationErrorRegistry extends ValidationErrorRegistry {

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/NoLongJumpValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/NoLongJumpValidatorTest.scala
@@ -8,7 +8,6 @@ import io.shiftleft.cpgvalidator.validators.cfg.NoLongJumpValidator
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class NoLongJumpValidatorTest extends AnyWordSpec with Matchers {
   private def withNewBaseCpg[T](fun: Cpg => T): T = {
     val graph = OverflowDbTestInstance.create

--- a/queries/src/test/scala/io/shiftleft/queries/MallocMemcpyTests.scala
+++ b/queries/src/test/scala/io/shiftleft/queries/MallocMemcpyTests.scala
@@ -3,7 +3,6 @@ package io.shiftleft.queries
 import io.shiftleft.dataflowengineoss.language.{DataFlowCodeToCpgSuite, _}
 import io.shiftleft.semanticcpg.language._
 
-
 class MallocMemcpyTests extends DataFlowCodeToCpgSuite {
 
   override val code: String =

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGeneratorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGeneratorTests.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
-
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgSuite
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/CallGraphTests.scala
@@ -2,7 +2,6 @@ package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.semanticcpg.testfixtures.CodeToCpgSuite
 
-
 class CallGraphTests extends CodeToCpgSuite {
 
   implicit val resolver = NoResolve

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -9,7 +9,6 @@ import org.json4s.native.JsonMethods.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 import scala.collection.mutable
 
 class StepsTest extends AnyWordSpec with Matchers {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/BindingTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/BindingTests.scala
@@ -6,7 +6,6 @@ import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class BindingTests extends AnyWordSpec with Matchers {
 
   "Binding steps" should ExistingCpgFixture("binding") { fixture =>

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTests.scala
@@ -6,7 +6,6 @@ import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class MemberTests extends AnyWordSpec with Matchers {
 
   "Member traversals" should ExistingCpgFixture("type") { fixture =>

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreatorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/EnhancedBaseCreatorTests.scala
@@ -5,7 +5,6 @@ import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class EnhancedBaseCreatorTests extends AnyWordSpec with Matchers {
 
   "EnhancedBaseCreator" should {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPassTests.scala
@@ -6,7 +6,6 @@ import io.shiftleft.semanticcpg.language._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class BindingMethodOverridesPassTests extends AnyWordSpec with Matchers {
   "Binding propagation should not mark non-overwritten bindings" in {
     val cpg = Cpg.emptyCpg

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CapturingLinkerTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CapturingLinkerTests.scala
@@ -8,7 +8,6 @@ import io.shiftleft.semanticcpg.testfixtures.EmptyGraphFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 import scala.jdk.CollectionConverters._
 
 class CapturingLinkerTests extends AnyWordSpec with Matchers {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
@@ -6,7 +6,6 @@ import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominator, CfgDominatorF
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 import scala.jdk.CollectionConverters._
 
 class CfgDominatorFrontierTests extends AnyWordSpec with Matchers {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorPassTests.scala
@@ -8,7 +8,6 @@ import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 import scala.jdk.CollectionConverters._
 
 class CfgDominatorPassTests extends AnyWordSpec with Matchers {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MemberAccessLinkerTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MemberAccessLinkerTests.scala
@@ -6,7 +6,6 @@ import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class MemberAccessLinkerTests extends AnyWordSpec with Matchers {
 
   "have a reference to correct member" in ExistingCpgFixture("memberaccesslinker") { fixture =>

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
@@ -8,7 +8,6 @@ import io.shiftleft.semanticcpg.testfixtures.EmptyGraphFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class MethodDecoratorPassTests extends AnyWordSpec with Matchers {
   "MethodDecoratorTest" in EmptyGraphFixture { graph =>
     val method = graph + NodeTypes.METHOD

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/NamespaceCreatorTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/NamespaceCreatorTests.scala
@@ -9,7 +9,6 @@ import io.shiftleft.semanticcpg.testfixtures.EmptyGraphFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class NamespaceCreatorTests extends AnyWordSpec with Matchers {
   "NamespaceCreateor test " in EmptyGraphFixture { graph =>
     val cpg = new Cpg(graph)

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/CountStatementsTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/utils/CountStatementsTests.scala
@@ -4,7 +4,6 @@ import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class CountStatementsTests extends AnyWordSpec with Matchers {
 
   "Class Statements" should ExistingCpgFixture("method") { fixture =>


### PR DESCRIPTION
Seems that changing the scalatest version influences formatting (?) Anyway, on this branch, all I did was run `sbt test:scalafmt`. Bringing this in separately.