### PR TITLE
Fix handling of parameters by oss data flow engine

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.dataflowengineoss.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.{EdgeKeyNames, EdgeTypes, nodes}
-import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.dotgenerator.Shared
 import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
 import io.shiftleft.semanticcpg.language._
@@ -9,10 +9,10 @@ import gremlin.scala._
 
 object DotDdgGenerator {
 
-  def expand(v: CfgNode): Iterator[Edge] = {
+  def expand(v: nodes.StoredNode): Iterator[Edge] = {
     (v.start.raw
       .outE(EdgeTypes.REACHING_DEF)
-      .map(x => Edge(v, x.inVertex().asInstanceOf[nodes.CfgNode], x.value[String](EdgeKeyNames.VARIABLE))))
+      .map(x => Edge(v, x.inVertex().asInstanceOf[nodes.StoredNode], x.value[String](EdgeKeyNames.VARIABLE))))
       .toList
       .iterator
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -10,11 +10,11 @@ object DotCfgGenerator {
 
   def toDotCfg(step: NodeSteps[nodes.Method]): Steps[String] = step.map(Shared.dotGraph(_, expand))
 
-  protected def expand(v: nodes.CfgNode): Iterator[Edge] = {
+  protected def expand(v: nodes.StoredNode): Iterator[Edge] = {
     v._cfgOut()
       .asScala
-      .filter(_.isInstanceOf[nodes.CfgNode])
-      .map(node => Edge(v, node.asInstanceOf[nodes.CfgNode]))
+      .filter(_.isInstanceOf[nodes.StoredNode])
+      .map(node => Edge(v, node))
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
@@ -6,9 +6,9 @@ import io.shiftleft.semanticcpg.language._
 
 object Shared {
 
-  case class Edge(src: nodes.CfgNode, dst: nodes.CfgNode, label: String = "")
+  case class Edge(src: nodes.StoredNode, dst: nodes.StoredNode, label: String = "")
 
-  def dotGraph(method: nodes.Method, expand: nodes.CfgNode => Iterator[Edge]): String = {
+  def dotGraph(method: nodes.Method, expand: nodes.StoredNode => Iterator[Edge]): String = {
     val sb = Shared.namedGraphBegin(method)
     sb.append(nodesAndEdges(method, expand).mkString("\n"))
     Shared.graphEnd(sb)
@@ -19,14 +19,15 @@ object Shared {
       v.isInstanceOf[nodes.Identifier] ||
       v.isInstanceOf[nodes.Block] ||
       v.isInstanceOf[nodes.ControlStructure] ||
-      v.isInstanceOf[nodes.JumpTarget]
+      v.isInstanceOf[nodes.JumpTarget] ||
+      v.isInstanceOf[nodes.MethodParameterIn]
   )
 
-  private def nodesAndEdges(methodNode: nodes.Method, expand: nodes.CfgNode => Iterator[Edge]): List[String] = {
-    val vertices = methodNode.start.cfgNode.l ++ List(methodNode, methodNode.methodReturn)
+  private def nodesAndEdges(methodNode: nodes.Method, expand: nodes.StoredNode => Iterator[Edge]): List[String] = {
+    val vertices = methodNode.start.cfgNode.l ++ List(methodNode, methodNode.methodReturn) ++ methodNode.parameter.l
     val verticesToDisplay = vertices.filter(cfgNodeShouldBeDisplayed)
 
-    def edgesToDisplay(srcNode: nodes.CfgNode, visited: List[nodes.StoredNode] = List()): List[Edge] = {
+    def edgesToDisplay(srcNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List()): List[Edge] = {
       if (visited.contains(srcNode)) {
         List()
       } else {


### PR DESCRIPTION
Previously, we assumed that parameters cannot be redefined inside the function, which may even be true for some languages but is not true in general. We did not include parameter definitions in reaching definition analysis and instead just created `REACHING_DEF` edges from parameters to all users of the parameter.

With this fix, we include parameter definitions in reaching definition analysis just like we already did previously for locals. This is a preparational step for further improvements of the engine code (that are partially ready).