### PR TITLE
Fix `scalatest` version.

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,17 +3,17 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings)
 
 libraryDependencies ++= Seq(
-  "io.shiftleft" %% "overflowdb-traversal" % "0.124",
-  "com.michaelpollmeier" %% "gremlin-scala" % "3.4.4.5",
-  "com.google.guava" % "guava" % "21.0",
-  "org.apache.commons" % "commons-lang3" % "3.5",
-  "commons-io" % "commons-io" % "2.5",
-  "com.github.pathikrit" %% "better-files"  % "3.8.0",
-  "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
-  "com.github.scopt" %% "scopt" % "3.7.1",
-  "org.slf4j" % "slf4j-api" % "1.7.30",
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.2" % Test,
-  "org.scalatest" %% "scalatest" % "3.1.1" % Test
+  "io.shiftleft"             %% "overflowdb-traversal" % "0.124",
+  "com.michaelpollmeier"     %% "gremlin-scala"        % "3.4.4.5",
+  "com.google.guava"         %  "guava"                % "21.0",
+  "org.apache.commons"       %  "commons-lang3"        % "3.5",
+  "commons-io"               %  "commons-io"           % "2.5",
+  "com.github.pathikrit"     %% "better-files"         % "3.8.0",
+  "org.scala-lang.modules"   %% "scala-java8-compat"   % "0.9.0",
+  "com.github.scopt"         %% "scopt"                % "3.7.1",
+  "org.slf4j"                %  "slf4j-api"            % "1.7.30",
+  "org.apache.logging.log4j" %  "log4j-slf4j-impl"     % "2.11.2" % Test,
+  "org.scalatest"            %% "scalatest"            % Versions.scalatest % Test
 )
 
 import better.files.FileExtensions

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -49,7 +49,6 @@ val CaskVersion = "0.6.7"
 val CatsVersion = "2.0.0"
 val CirceVersion = "0.12.2"
 val AmmoniteVersion = "1.8.1"
-val ScalatestVersion = "3.1.1"
 val ZeroturnaroundVersion = "1.13"
 
 libraryDependencies ++= Seq(
@@ -61,7 +60,7 @@ libraryDependencies ++= Seq(
   "io.circe"             %% "circe-parser"  % CirceVersion,
   "org.zeroturnaround"   %  "zt-zip"        % ZeroturnaroundVersion,
   "com.lihaoyi"          %% "ammonite"      % AmmoniteVersion cross CrossVersion.full,
-  "com.lihaoyi" 	 %% "cask" 	    % CaskVersion,
+  "com.lihaoyi" 	       %% "cask" 	        % CaskVersion,
   "io.shiftleft"         %% "fuzzyc2cpg"    % Versions.fuzzyc2cpg,
-  "org.scalatest"        %% "scalatest"     % ScalatestVersion % Test
+  "org.scalatest"        %% "scalatest"     % Versions.scalatest % Test
 )

--- a/cpgvalidator/build.sbt
+++ b/cpgvalidator/build.sbt
@@ -5,9 +5,9 @@ dependsOn(Projects.codepropertygraph)
 enablePlugins(JavaAppPackaging)
 
 libraryDependencies ++= Seq(
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.2" % Runtime, //redirect tinkerpop's slf4j logging to log4j
-  "com.typesafe.play" %% "play-json" % "2.7.4",
-  "org.scalatest"       %% "scalatest"       % "3.1.1" % "test",
+  "org.apache.logging.log4j" %  "log4j-slf4j-impl" % "2.11.2" % Runtime, //redirect tinkerpop's slf4j logging to log4j
+  "com.typesafe.play"        %% "play-json"       % "2.7.4",
+  "org.scalatest"            %% "scalatest"       % Versions.scalatest % Test
 )
 
 // execute tests in root project so that they work in sbt *and* intellij

--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -5,9 +5,9 @@ dependsOn(Projects.semanticcpg % "compile -> compile; test -> test")
 val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(
-  "org.antlr"            %  "antlr4-runtime"           % antlrVersion,
-  "org.scalatest" %% "scalatest" % "3.1.1" % Test,
-  "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test
+  "org.antlr"     %  "antlr4-runtime" % antlrVersion,
+  "org.scalatest" %% "scalatest"      % Versions.scalatest % Test,
+  "io.shiftleft"  %% "fuzzyc2cpg"     % Versions.fuzzyc2cpg % Test
 )
 
 enablePlugins(Antlr4Plugin)

--- a/project/Utils.scala
+++ b/project/Utils.scala
@@ -1,6 +1,7 @@
 /* reads version declarations from /build.sbt so that we can declare them in one place */
 object Versions {
   val fuzzyc2cpg = parseVersion("fuzzyc2cpgVersion")
+  val scalatest  = "3.1.1"
 
   private def parseVersion(key: String): String = { 
     val versionRegexp = s""".*val $key[ ]+=[ ]?"(.*?)"""".r

--- a/queries/build.sbt
+++ b/queries/build.sbt
@@ -4,6 +4,6 @@ dependsOn(Projects.semanticcpg % "compile -> compile; test -> test",
           Projects.dataflowengineoss % "compile -> compile; test -> test")
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.1.1" % Test,
-  "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test
+  "org.scalatest" %% "scalatest"  % Versions.scalatest % Test,
+  "io.shiftleft"  %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test
 )

--- a/samples/pass/build.sbt
+++ b/samples/pass/build.sbt
@@ -4,11 +4,9 @@ organization := "io.shiftleft"
 val cpgVersion = "0.11.1"
 
 libraryDependencies ++= Seq(
-
-  "io.shiftleft" %% "codepropertygraph" % cpgVersion,
-  "io.shiftleft" %% "enhancements"  % cpgVersion,
-
-  "org.scalatest" %% "scalatest" % "3.1.1" % Test
+  "io.shiftleft"  %% "codepropertygraph" % cpgVersion,
+  "io.shiftleft"  %% "enhancements"      % cpgVersion,
+  "org.scalatest" %% "scalatest"         % Versions.scalatest % Test
 )
 
 ThisBuild / resolvers ++= Seq(

--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -3,10 +3,10 @@ name := "semanticcpg"
 dependsOn(Projects.codepropertygraph)
 
 libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-native" % "3.6.7",
+  "org.json4s"             %% "json4s-native"            % "3.6.7",
   "org.scala-lang.modules" %% "scala-collection-contrib" % "0.2.1",
-  "org.scalatest" %% "scalatest" % "3.1.1",
-  "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg
+  "org.scalatest"          %% "scalatest"                % Versions.scalatest,
+  "io.shiftleft"           %% "fuzzyc2cpg"               % Versions.fuzzyc2cpg
 )
 
 scalacOptions in (Compile, doc) ++= Seq(


### PR DESCRIPTION
I was trying to figure out why IDEA throws a hissy fit over tests that used to run fine.

Turns out that due to reasons we had now multiple versions of at least `scalatest` included, "3.1.1" for testing, "3.0.8" for compilation. Which explains the behaviour.

This is still bad since `codepropertygraph` isn't necessarily using the same versions as `codescience` but already better than before.