### PR TITLE
Assume that calls to unannotated methods redefine all args

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -56,7 +56,8 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
                     .filter(_.isInstanceOf[nodes.CfgNode])
                     .map(_.asInstanceOf[nodes.CfgNode].code)
                     .getOrElse("")
-                  addEdge(in, use, edgeLabel)
+                  if (!use.isInstanceOf[nodes.FieldIdentifier])
+                    addEdge(in, use, edgeLabel)
                 }
               }
           }
@@ -64,7 +65,9 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
           if (!hasAnnotation(call)) {
             usageAnalyzer.uses(call, gen).foreach { use =>
               gen(call).foreach { g =>
-                addEdge(use, g)
+                if (g == use || g == call) {
+                  addEdge(use, g)
+                }
               }
             }
           } else {

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -94,15 +94,25 @@ class ReachingDefTransferFunction(method: nodes.Method) extends TransferFunction
         .order
         .l
 
-      call.start.argument.l.filter(arg => definedParams.contains(arg.argumentIndex)).toSet ++ {
+      val explicitlyDefined = call.start.argument.l.filter(arg => definedParams.contains(arg.argumentIndex)).toSet ++ {
         if (methodForCall(call)
               .map(method => method.methodReturn)
-              .exists(methodReturn => methodReturn._propagateIn().hasNext) || !hasAnnotation(call)) {
+              .exists(methodReturn => methodReturn._propagateIn().hasNext)) {
           Set(call)
         } else {
           Set()
         }
       }
+
+      val implicilyDefined = {
+        if (!hasAnnotation(call)) {
+          Set(call) ++ call.start.argument.where(x => !x.isInstanceOf[nodes.Literal]).toSet
+        } else {
+          Set()
+        }
+      }
+
+      explicitlyDefined ++ implicilyDefined
     }
 
     val defsForParams = method.start.parameter.l.map { param =>

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
@@ -24,10 +24,10 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       |""".stripMargin
 
   "A PdgDotGenerator" should {
-    "create a dot graph with 15 edges" in {
+    "create a dot graph with 26 edges" in {
       val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
       lines.head.startsWith("digraph foo") shouldBe true
-      lines.count(x => x.contains("->")) shouldBe 22
+      lines.count(x => x.contains("->")) shouldBe 26
       lines.last.startsWith("}") shouldBe true
     }
   }

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblemTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblemTests.scala
@@ -53,9 +53,9 @@ class ReachingDefProblemTests2 extends ReachingDefProblemSuite {
     "contain definitions of parameters for each parameter" in {
       method.parameter.l.map(transfer.gen(_)) shouldBe method.parameter.map(Set(_)).l
     }
-    "contain definition of return value for unannotated method" in {
+    "contain definition of return value and all arguments for unannotated method" in {
       val call = method.start.call.name("escape").head
-      transfer.gen(call) shouldBe Set(call)
+      transfer.gen(call) shouldBe Set(call) ++ method.start.call.name("escape").argument.toSet
     }
 
     "contain only correct argument for annotated method" in {


### PR DESCRIPTION
This is a pretty important change for the data flow engine. Consider the following code:

```
int foo (int x) {
   bar(x);
   sink(x);
}
```

and requests to determine flows from the parameter declaration `int x` to the argument `x` of the call to sink. Consider also that `bar` has NOT been annotated, that is, we know nothing about the way it propagates taint. If we now assume by default that calls to unannotated methods such as `bar(x)` do not lead to modifications of the argument (`x`), then the flow that comes back is

```
int x
sink(x)
```

If we assume that it does change its argument, we arrive at
```
int x
bar(x)
sink(x)
```
For exploratory code analysis, I argue that the latter is better because we end up with flows that show us all transformations that _may_ affect `x`. It's possible that flows with `bar(x)` on the path are also uninteresting for us, in which case we an filter for flows that do not contain `bar(x)`, where is with the previous behavior, we wouldn't know whether `bar(x)` is on the flow or not. 

Annotation, with this default behavior, leads to less flows being returned, but annotation is not a prerequisite for flows to be returned at all. The downside, of course, is that our flows may be much too detailed, but again, in exploratory mode, this makes sense and can then be compensated by filtering flows.

