### PR TITLE
Minor OSS data flow engine fixes to make joern-latest green

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -36,6 +36,9 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
 
     def addEdge(fromNode: nodes.StoredNode, toNode: nodes.StoredNode, variable: String = ""): Unit = {
       val properties = List((EdgeKeyNames.VARIABLE, variable))
+      if (toNode.isInstanceOf[nodes.Literal] || fromNode.isInstanceOf[nodes.Unknown] || toNode
+            .isInstanceOf[nodes.Unknown])
+        return
       dstGraph.addEdgeInOriginal(fromNode, toNode, EdgeTypes.REACHING_DEF, properties)
     }
 
@@ -56,8 +59,7 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
                     .filter(_.isInstanceOf[nodes.CfgNode])
                     .map(_.asInstanceOf[nodes.CfgNode].code)
                     .getOrElse("")
-                  if (!use.isInstanceOf[nodes.FieldIdentifier])
-                    addEdge(in, use, edgeLabel)
+                  addEdge(in, use, edgeLabel)
                 }
               }
           }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -112,7 +112,9 @@ class ReachingDefTransferFunction(method: nodes.Method) extends TransferFunction
         }
       }
 
-      explicitlyDefined ++ implicilyDefined
+      (explicitlyDefined ++ implicilyDefined)
+        .filterNot(_.isInstanceOf[nodes.FieldIdentifier])
+        .map(_.asInstanceOf[nodes.StoredNode])
     }
 
     val defsForParams = method.start.parameter.l.map { param =>

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/UsageAnalyzer.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/UsageAnalyzer.scala
@@ -29,7 +29,7 @@ class UsageAnalyzer(in: Map[nodes.StoredNode, Set[nodes.StoredNode]],
   }
 
   def uses(node: nodes.StoredNode, gen: Map[nodes.StoredNode, Set[nodes.StoredNode]]): Set[nodes.StoredNode] = {
-    node match {
+    val n = node match {
       case ret: nodes.Return =>
         ret.astChildren.map(_.asInstanceOf[nodes.StoredNode]).toSet()
       case call: nodes.Call =>
@@ -44,6 +44,7 @@ class UsageAnalyzer(in: Map[nodes.StoredNode, Set[nodes.StoredNode]],
         }
       case _ => Set()
     }
+    n.filterNot(_.isInstanceOf[nodes.FieldIdentifier]).map(_.asInstanceOf[nodes.StoredNode])
   }
 
   private def hasAnnotation(call: nodes.Call): Boolean = {

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
@@ -3,10 +3,6 @@ package io.shiftleft.dataflowengineoss.dotgenerator
 import io.shiftleft.dataflowengineoss.language.DataFlowCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.dataflowengineoss.language._
-import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
-
-import scala.sys.process.Process
-import scala.util.Try
 
 class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
 


### PR DESCRIPTION
* Prohibit reachable-by edges to literals and to/from unknown nodes
* Ensure that field identifiers are neither used nor generated
* Remove unused imports