### PR TITLE
Use mutable data structures in CfgDominator calculation.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
@@ -1,5 +1,7 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
+import scala.collection.mutable
+
 class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
 
   /**
@@ -10,7 +12,7 @@ class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
     * The used algorithm is from: "A Simple, Fast Dominance Algorithm" from
     * "Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy".
     */
-  def calculate(cfgEntry: NodeType): Map[NodeType, NodeType] = {
+  def calculate(cfgEntry: NodeType): mutable.Map[NodeType, NodeType] = {
     val UNDEFINED = -1
     val postOrderNumbering = createPostOrderNumbering(cfgEntry)
     val indexOf = postOrderNumbering.withDefaultValue(UNDEFINED) // Index of each node into dominators array.
@@ -87,10 +89,10 @@ class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
     finger1
   }
 
-  private def createPostOrderNumbering(cfgEntry: NodeType): Map[NodeType, Int] = {
+  private def createPostOrderNumbering(cfgEntry: NodeType): mutable.Map[NodeType, Int] = {
     var stack = (cfgEntry, adapter.successors(cfgEntry).iterator) :: Nil
-    var visited = Set.empty[NodeType]
-    var numbering = Map.empty[NodeType, Int]
+    var visited = mutable.Set.empty[NodeType]
+    var numbering = mutable.Map.empty[NodeType, Int]
     var nextNumber = 0
 
     while (stack.nonEmpty) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
@@ -91,8 +91,8 @@ class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
 
   private def createPostOrderNumbering(cfgEntry: NodeType): mutable.Map[NodeType, Int] = {
     var stack = (cfgEntry, adapter.successors(cfgEntry).iterator) :: Nil
-    var visited = mutable.Set.empty[NodeType]
-    var numbering = mutable.Map.empty[NodeType, Int]
+    val visited = mutable.Set.empty[NodeType]
+    val numbering = mutable.Map.empty[NodeType, Int]
     var nextNumber = 0
 
     while (stack.nonEmpty) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
@@ -7,6 +7,8 @@ import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.Node
 
+import scala.collection.mutable
+
 /**
   * This pass has no prerequisites.
   */
@@ -32,7 +34,8 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
     Iterator(dstGraph.build())
   }
 
-  private def addDomTreeEdges(dstGraph: DiffGraph.Builder, cfgNodeToImmediateDominator: Map[Node, Node]): Unit = {
+  private def addDomTreeEdges(dstGraph: DiffGraph.Builder,
+                              cfgNodeToImmediateDominator: mutable.Map[Node, Node]): Unit = {
     // TODO do not iterate over potential hash map to ensure same interation order for
     // edge creation.
     cfgNodeToImmediateDominator.foreach {
@@ -44,7 +47,7 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
   }
 
   private def addPostDomTreeEdges(dstGraph: DiffGraph.Builder,
-                                  cfgNodeToPostImmediateDominator: Map[Node, Node]): Unit = {
+                                  cfgNodeToPostImmediateDominator: mutable.Map[Node, Node]): Unit = {
     // TODO do not iterate over potential hash map to ensure same interation order for
     // edge creation.
     cfgNodeToPostImmediateDominator.foreach {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
@@ -2,10 +2,11 @@ package io.shiftleft.semanticcpg.passes
 
 import io.shiftleft.OverflowDbTestInstance
 import overflowdb._
-import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominator, CfgDominatorFrontier, DomTreeAdapter, CfgAdapter}
+import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgAdapter, CfgDominator, CfgDominatorFrontier, DomTreeAdapter}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 class CfgDominatorFrontierTests extends AnyWordSpec with Matchers {
@@ -18,7 +19,7 @@ class CfgDominatorFrontierTests extends AnyWordSpec with Matchers {
       node.in("CFG").asScala
   }
 
-  private class TestDomTreeAdapter(immediateDominators: Map[Node, Node]) extends DomTreeAdapter[Node] {
+  private class TestDomTreeAdapter(immediateDominators: mutable.Map[Node, Node]) extends DomTreeAdapter[Node] {
     override def immediateDominator(cfgNode: Node): Option[Node] = {
       immediateDominators.get(cfgNode)
     }


### PR DESCRIPTION
Only a small gain of a few seconds for very large CPGs but since it is
already changed we might as well take it.