### PR TITLE
Fixes for OSS Data Flow Tracker

### DIFF
--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -6,6 +6,7 @@ val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(
   "org.antlr"     %  "antlr4-runtime" % antlrVersion,
+  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",
   "org.scalatest" %% "scalatest"      % Versions.scalatest % Test,
   "io.shiftleft"  %% "fuzzyc2cpg"     % Versions.fuzzyc2cpg % Test
 )

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -5,6 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.shiftleft.semanticcpg.language._
 
+import scala.collection.parallel.CollectionConverters._
 import scala.jdk.CollectionConverters._
 
 case class PathElement(node: nodes.TrackingPoint, visible: Boolean = true, resolved: Boolean = true)
@@ -48,13 +49,11 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
       .toSet
 
     val sinks = raw.clone.dedup.toList.sortBy(_.id2)
-    val res = sinks.flatMap { sink =>
+    sinks.par.flatMap { sink =>
       val cache = new ResultCache
       results(List(PathElement(sink)), sources, cache)
       cache.get(List(PathElement(sink))).get
-    }
-
-    res
+    }.toList
   }
 
   /**

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
@@ -92,8 +92,6 @@ class CDataFlowTests2 extends DataFlowCodeToCpgSuite {
       .map(flowToResultPairs)
       .distinct
 
-    flows.foreach(println)
-
     flows.size shouldBe 5
 
     flows.toSet shouldBe

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
@@ -92,6 +92,8 @@ class CDataFlowTests2 extends DataFlowCodeToCpgSuite {
       .map(flowToResultPairs)
       .distinct
 
+    flows.foreach(println)
+
     flows.size shouldBe 5
 
     flows.toSet shouldBe


### PR DESCRIPTION
This iteration of work on the OSS data flow tracker already sketches how I would like to go about multi-threaded interprocedural analysis but mostly brings in a few fixes for now.

* Fix the cache entry to include any results from parents
* Return all results via the cache as opposed to doing so both in the return value and the cache
* Identify call sites that can be resolved and for which no annotations exist and mark them in results
* Bring in parallel collections to calculate results for reachableBy queries in parallel
