### PR TITLE
Make CONFIG_FILE a TRACKING_POINT

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/java-specific.json
+++ b/codepropertygraph/src/main/resources/schemas/java-specific.json
@@ -78,7 +78,8 @@
           "name": "CONFIG_FILE",
           "keys": ["NAME", "CONTENT"],
           "comment": "Configuration file contents. Might be in use by a framework",
-          "outEdges": []
+          "outEdges": [],
+	  "is" : ["TRACKING_POINT"]
         }
 
 


### PR DESCRIPTION
This is very unfortunate: while since about February, arbitrary nodes can be associated with findings at the CS side, overall, Inspect still relies on the fake flows. This problem has caught up with us in https://github.com/ShiftLeftSecurity/product/issues/5382 which, to be fixes, requires us to create a fake flow from a config file to itself. Us being all type-safe on flows (a good thing), we require any node in a flow to inherit from TRACKING_POINT, and CONFIG_FILE does not (a good thing as well). To make this work, I'll need to change the later: CONFIG_FILE now inherits from TRACKING_POINT, and I hope we can undo this in the future.
 