### PR TITLE
Drastically improve performance of DataFlowSolver

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -33,11 +33,10 @@ class DataFlowSolver {
             problem.flowGraph.succ(n)
           else
             List()
-        }.toList
+        }
         worklist.clear
         worklist ++= newEntries
       } else {
-
         val newEntries = worklist.flatMap { n =>
           val outSet = problem.flowGraph
             .succ(n)


### PR DESCRIPTION
No new parallelism needed here, it turns out just using a flatMap instead of removing elements one by one from the list already drastically improves performance: from 20 minutes to 1.5 minutes on a highly nested sample function.

Fixes: https://github.com/ShiftLeftSecurity/joern/issues/322