### PR TITLE
Cleanups for `reachableBy` implementation

### DIFF
--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -6,7 +6,6 @@ val antlrVersion = "4.7.2"
 
 libraryDependencies ++= Seq(
   "org.antlr"     %  "antlr4-runtime" % antlrVersion,
-  "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0",
   "org.scalatest" %% "scalatest"      % Versions.scalatest % Test,
   "io.shiftleft"  %% "fuzzyc2cpg"     % Versions.fuzzyc2cpg % Test
 )

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -1,145 +1,16 @@
 package io.shiftleft.dataflowengineoss.language
 
-import java.util.concurrent.{Callable, ExecutorCompletionService, Executors}
-
 import gremlin.scala._
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.dataflowengineoss.queryengine.{PathElement, ReachableByResult, ResultTable}
-import io.shiftleft.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
+import io.shiftleft.dataflowengineoss.queryengine.{Engine, ReachableByResult}
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language._
-import org.slf4j.{Logger, LoggerFactory}
-
-import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success, Try}
-
-private case class ReachableByTask(sink: nodes.TrackingPoint, sources: Set[nodes.TrackingPoint], table: ResultTable)
-
-private class ReachableByCallable(task: ReachableByTask, semantics: Semantics)
-    extends Callable[List[ReachableByResult]] {
-  override def call(): List[ReachableByResult] = {
-    implicit val sem: Semantics = semantics
-    results(List(PathElement(task.sink)), task.sources, task.table)
-    task.table.get(task.sink).get
-  }
-
-  /**
-    * Recursively expand the DDG backwards and return a list of all
-    * results, given by at least a source node in `sourceSymbols` and the
-    * path between the source symbol and the sink.
-    *
-    * @param path This is a path from a node to the sink. The first node
-    *             of the path is expanded by this method
-    * */
-  private def results[NodeType <: nodes.TrackingPoint](path: List[PathElement],
-                                                       sources: Set[NodeType],
-                                                       table: ResultTable)(implicit semantics: Semantics): Unit = {
-    val curNode = path.head.node
-
-    val resultsForParents: List[ReachableByResult] = {
-      val ddgParents = ddgIn(curNode).filter(parent => !path.map(_.node).contains(parent)).toList
-      val parentPathElements = if (argToCall(curNode).isEmpty) {
-        ddgParents.flatMap { parentNode =>
-          List(PathElement(parentNode))
-        }
-      } else {
-        val (arguments, nonArguments) = ddgParents.partition(_.isInstanceOf[nodes.Expression])
-        val elemsForArguments = arguments.flatMap { parentNode =>
-          elemForArgument(parentNode.asInstanceOf[nodes.Expression], curNode)
-        }
-        elemsForArguments ++ nonArguments.map(parentNode => PathElement(parentNode))
-      }
-
-      parentPathElements.flatMap { parent =>
-        table.createFromTable(parent :: path).getOrElse {
-          results(parent :: path, sources, table)
-          table.get(parent.node).get
-        }
-      }
-    }
-
-    val resultsForCurNode = Some(curNode).collect {
-      case n if sources.contains(n.asInstanceOf[NodeType]) =>
-        ReachableByResult(path)
-    }.toList
-
-    table.add(curNode, resultsForParents ++ resultsForCurNode)
-  }
-
-  /**
-    * For a given `(parentNode, curNode)` pair, determine whether to expand into
-    * `parentNode`. If so, return a corresponding path element or None if
-    * `parentNode` should not be followed.
-    * */
-  private def elemForArgument(parentNode: nodes.Expression, curNode: nodes.TrackingPoint)(
-      implicit semantics: Semantics): Option[PathElement] = {
-    val parentNodeCall = argToCall(parentNode)
-    if (parentNodeCall == argToCall(curNode)) {
-      val callers = parentNodeCall.toList
-        .flatMap(x => methodsForCall(x))
-      if (semanticsForCallByArg(parentNode.asInstanceOf[nodes.Expression]).nonEmpty || callers.isEmpty) {
-        Some(PathElement(parentNode)).filter(_ => isUsed(parentNode) && isDefined(curNode))
-      } else {
-        // There is no semantic and we can resolve the method, so, this is an
-        // argument we would need to resolve. Report that, but don't take action for now
-        Some(PathElement(parentNode, resolved = false)).filter(_ => isUsed(parentNode) && isDefined(curNode))
-      }
-    } else {
-      Some(PathElement(parentNode, isDefined(parentNode))).filter(_ => isUsed(curNode))
-    }
-  }
-
-  private def ddgIn(dstNode: nodes.TrackingPoint): Iterator[nodes.TrackingPoint] = {
-    dstNode._reachingDefIn().asScala.collect { case n: nodes.TrackingPoint => n }
-  }
-
-  private def isUsed(srcNode: nodes.StoredNode)(implicit semantics: Semantics) = {
-    Some(srcNode)
-      .collect {
-        case arg: nodes.Expression =>
-          val s = semanticsForCallByArg(arg)
-          s.isEmpty || s.exists(_.mappings.exists { case (srcIndex, _) => srcIndex == arg.order })
-      }
-      .getOrElse(true)
-  }
-
-  private def isDefined(srcNode: nodes.StoredNode)(implicit semantics: Semantics) = {
-    Some(srcNode)
-      .collect {
-        case arg: nodes.Expression =>
-          val s = semanticsForCallByArg(arg)
-          s.isEmpty || s.exists(_.mappings.exists { case (_, dstIndex) => dstIndex == arg.order })
-      }
-      .getOrElse(true)
-  }
-
-  private def semanticsForCallByArg(arg: nodes.Expression)(implicit semantics: Semantics): List[FlowSemantic] = {
-    argToMethods(arg).flatMap { method =>
-      semantics.forMethod(method.fullName)
-    }
-  }
-
-  private def methodsForCall(call: nodes.Call): List[nodes.Method] = {
-    NoResolve.getCalledMethods(call).toList
-  }
-
-  private def argToMethods(arg: nodes.Expression) = {
-    argToCall(arg).toList.flatMap { call =>
-      methodsForCall(call)
-    }
-  }
-
-  private def argToCall(n: nodes.TrackingPoint) =
-    n._argumentIn.asScala.collectFirst { case c: nodes.Call => c }
-
-}
 
 /**
   * Base class for nodes that can occur in data flows
   * */
 class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal {
   private def raw: GremlinScala[nodes.TrackingPoint] = wrapped.raw
-
-  import TrackingPoint._
 
   /**
     * The enclosing method of the tracking point
@@ -168,39 +39,14 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
   private def reachableByInternal[NodeType <: nodes.TrackingPoint](sourceTravs: Seq[Steps[NodeType]])(
       implicit semantics: Semantics): List[ReachableByResult] = {
 
-    val sources: Set[nodes.TrackingPoint] = sourceTravs
+    val sources: List[nodes.TrackingPoint] = sourceTravs
       .flatMap(_.raw.clone.toList)
       .collect { case n: nodes.TrackingPoint => n }
-      .toSet
+      .toList
 
     val sinks = raw.clone.dedup.toList.sortBy(_.id2)
 
-    val tasks = sinks.map { sink =>
-      ReachableByTask(sink, sources, new ResultTable)
-    }
-
-    val executorService = Executors.newWorkStealingPool()
-    val completionService = new ExecutorCompletionService[List[ReachableByResult]](executorService)
-    tasks.foreach { task =>
-      completionService.submit(new ReachableByCallable(task, semantics))
-    }
-
-    var result = List[ReachableByResult]()
-    for (_ <- 1 to tasks.size) {
-      Try {
-        completionService.take.get
-      } match {
-        case Success(list) =>
-          result ++= list
-        case Failure(exception) =>
-          logger.warn(exception.getMessage)
-      }
-    }
-    result
+    new Engine().determineFlowsBackwards(sinks, sources)
   }
 
-}
-
-object TrackingPoint {
-  val logger: Logger = LoggerFactory.getLogger(this.getClass)
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -104,8 +104,7 @@ class TrackingPoint(val wrapped: NodeSteps[nodes.TrackingPoint]) extends AnyVal 
         ReachableByResult(path)
     }.toList
 
-    val nodeToResults = List(curNode -> (resultsForParents ++ resultsForCurNode))
-    table.addAll(nodeToResults)
+    table.add(curNode, resultsForParents ++ resultsForCurNode)
   }
 
   /**
@@ -198,14 +197,10 @@ private class ResultTable {
 
   private val table = new java.util.concurrent.ConcurrentHashMap[nodes.StoredNode, List[ReachableByResult]].asScala
 
-  def addAll(results: List[(nodes.StoredNode, List[ReachableByResult])]): Unit = {
-    results.foreach {
-      case (key, value) =>
-        table.asJava.compute(key, { (_, existingValue) =>
-          Option(existingValue).toList.flatten ++ value
-        })
-    }
-    table.addAll(results)
+  def add(key: nodes.StoredNode, value: List[ReachableByResult]): Unit = {
+    table.asJava.compute(key, { (_, existingValue) =>
+      Option(existingValue).toList.flatten ++ value
+    })
   }
 
   /**

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -5,6 +5,7 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.utils.MemberAccess
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.jdk.CollectionConverters._
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -3,9 +3,8 @@ package io.shiftleft.dataflowengineoss.language.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.dataflowengineoss.language._
-import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.dataflowengineoss.queryengine.EngineContext
 import io.shiftleft.semanticcpg.utils.MemberAccess
-import org.slf4j.{Logger, LoggerFactory}
 
 import scala.jdk.CollectionConverters._
 
@@ -27,7 +26,7 @@ class TrackingPointMethods(val node: nodes.TrackingPointBase) extends AnyVal {
     }
 
   def reachableBy[NodeType <: nodes.TrackingPoint](sourceTravs: Steps[NodeType]*)(
-      implicit semantics: Semantics): Steps[NodeType] =
+      implicit context: EngineContext): Steps[NodeType] =
     node.start.reachableBy(sourceTravs: _*)
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -1,0 +1,169 @@
+package io.shiftleft.dataflowengineoss.queryengine
+
+import java.util.concurrent.{Callable, ExecutorCompletionService, Executors}
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
+import io.shiftleft.semanticcpg.language.NoResolve
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.util.{Failure, Success, Try}
+import scala.jdk.CollectionConverters._
+
+private case class ReachableByTask(sink: nodes.TrackingPoint, sources: Set[nodes.TrackingPoint], table: ResultTable)
+
+class Engine {
+
+  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+    * Determine flows from sources to sinks by analyzing backwards from sinks.
+    * */
+  def determineFlowsBackwards(sinks: List[nodes.TrackingPoint], sources: List[nodes.TrackingPoint])(
+      implicit semantics: Semantics): List[ReachableByResult] = {
+    val sourcesSet = sources.toSet
+    val tasks = sinks.map { sink =>
+      ReachableByTask(sink, sourcesSet, new ResultTable)
+    }
+
+    val executorService = Executors.newWorkStealingPool()
+    val completionService = new ExecutorCompletionService[List[ReachableByResult]](executorService)
+    tasks.foreach { task =>
+      completionService.submit(new ReachableByCallable(task, semantics))
+    }
+
+    var result = List[ReachableByResult]()
+    for (_ <- 1 to tasks.size) {
+      Try {
+        completionService.take.get
+      } match {
+        case Success(list) =>
+          result ++= list
+        case Failure(exception) =>
+          logger.warn(exception.getMessage)
+      }
+    }
+    result
+  }
+
+}
+
+private class ReachableByCallable(task: ReachableByTask, semantics: Semantics)
+    extends Callable[List[ReachableByResult]] {
+
+  override def call(): List[ReachableByResult] = {
+    implicit val sem: Semantics = semantics
+    results(List(PathElement(task.sink)), task.sources, task.table)
+    task.table.get(task.sink).get
+  }
+
+  /**
+    * Recursively expand the DDG backwards and return a list of all
+    * results, given by at least a source node in `sourceSymbols` and the
+    * path between the source symbol and the sink.
+    *
+    * @param path This is a path from a node to the sink. The first node
+    *             of the path is expanded by this method
+    * */
+  private def results[NodeType <: nodes.TrackingPoint](path: List[PathElement],
+                                                       sources: Set[NodeType],
+                                                       table: ResultTable)(implicit semantics: Semantics): Unit = {
+    val curNode = path.head.node
+
+    val resultsForParents: List[ReachableByResult] = {
+      val ddgParents = ddgIn(curNode).filter(parent => !path.map(_.node).contains(parent)).toList
+      val parentPathElements = if (argToCall(curNode).isEmpty) {
+        ddgParents.flatMap { parentNode =>
+          List(PathElement(parentNode))
+        }
+      } else {
+        val (arguments, nonArguments) = ddgParents.partition(_.isInstanceOf[nodes.Expression])
+        val elemsForArguments = arguments.flatMap { parentNode =>
+          elemForArgument(parentNode.asInstanceOf[nodes.Expression], curNode)
+        }
+        elemsForArguments ++ nonArguments.map(parentNode => PathElement(parentNode))
+      }
+
+      parentPathElements.flatMap { parent =>
+        table.createFromTable(parent :: path).getOrElse {
+          results(parent :: path, sources, table)
+          table.get(parent.node).get
+        }
+      }
+    }
+
+    val resultsForCurNode = Some(curNode).collect {
+      case n if sources.contains(n.asInstanceOf[NodeType]) =>
+        ReachableByResult(path)
+    }.toList
+
+    table.add(curNode, resultsForParents ++ resultsForCurNode)
+  }
+
+  /**
+    * For a given `(parentNode, curNode)` pair, determine whether to expand into
+    * `parentNode`. If so, return a corresponding path element or None if
+    * `parentNode` should not be followed.
+    * */
+  private def elemForArgument(parentNode: nodes.Expression, curNode: nodes.TrackingPoint)(
+      implicit semantics: Semantics): Option[PathElement] = {
+    val parentNodeCall = argToCall(parentNode)
+    if (parentNodeCall == argToCall(curNode)) {
+      val callers = parentNodeCall.toList
+        .flatMap(x => methodsForCall(x))
+      if (semanticsForCallByArg(parentNode.asInstanceOf[nodes.Expression]).nonEmpty || callers.isEmpty) {
+        Some(PathElement(parentNode)).filter(_ => isUsed(parentNode) && isDefined(curNode))
+      } else {
+        // There is no semantic and we can resolve the method, so, this is an
+        // argument we would need to resolve. Report that, but don't take action for now
+        Some(PathElement(parentNode, resolved = false)).filter(_ => isUsed(parentNode) && isDefined(curNode))
+      }
+    } else {
+      Some(PathElement(parentNode, isDefined(parentNode))).filter(_ => isUsed(curNode))
+    }
+  }
+
+  private def ddgIn(dstNode: nodes.TrackingPoint): Iterator[nodes.TrackingPoint] = {
+    dstNode._reachingDefIn().asScala.collect { case n: nodes.TrackingPoint => n }
+  }
+
+  private def isUsed(srcNode: nodes.StoredNode)(implicit semantics: Semantics) = {
+    Some(srcNode)
+      .collect {
+        case arg: nodes.Expression =>
+          val s = semanticsForCallByArg(arg)
+          s.isEmpty || s.exists(_.mappings.exists { case (srcIndex, _) => srcIndex == arg.order })
+      }
+      .getOrElse(true)
+  }
+
+  private def isDefined(srcNode: nodes.StoredNode)(implicit semantics: Semantics) = {
+    Some(srcNode)
+      .collect {
+        case arg: nodes.Expression =>
+          val s = semanticsForCallByArg(arg)
+          s.isEmpty || s.exists(_.mappings.exists { case (_, dstIndex) => dstIndex == arg.order })
+      }
+      .getOrElse(true)
+  }
+
+  private def semanticsForCallByArg(arg: nodes.Expression)(implicit semantics: Semantics): List[FlowSemantic] = {
+    argToMethods(arg).flatMap { method =>
+      semantics.forMethod(method.fullName)
+    }
+  }
+
+  private def methodsForCall(call: nodes.Call): List[nodes.Method] = {
+    NoResolve.getCalledMethods(call).toList
+  }
+
+  private def argToMethods(arg: nodes.Expression) = {
+    argToCall(arg).toList.flatMap { call =>
+      methodsForCall(call)
+    }
+  }
+
+  private def argToCall(n: nodes.TrackingPoint) =
+    n._argumentIn.asScala.collectFirst { case c: nodes.Call => c }
+
+}

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -1,0 +1,61 @@
+package io.shiftleft.dataflowengineoss.queryengine
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import scala.jdk.CollectionConverters._
+
+class ResultTable {
+
+  private val table = new java.util.concurrent.ConcurrentHashMap[nodes.StoredNode, List[ReachableByResult]].asScala
+
+  /**
+    * Add all results in `value` to table entry at `key`, appending to existing
+    * results.
+    */
+  def add(key: nodes.StoredNode, value: List[ReachableByResult]): Unit = {
+    table.asJava.compute(key, { (_, existingValue) =>
+      Option(existingValue).toList.flatten ++ value
+    })
+  }
+
+  /**
+    * For a given path, determine whether results for the first element (`first`) are stored in the
+    * table, and if so, for each result, determine the path up to `first` and prepend it to
+    * `path`, giving us new results via table lookup.
+    */
+  def createFromTable(path: List[PathElement]): Option[List[ReachableByResult]] = {
+    val first = path.head
+    table.get(first.node).map { res =>
+      res.map { r =>
+        val completePath = r.path.slice(0, r.path.map(_.node).indexOf(first.node)) ++ path
+        r.copy(path = completePath)
+      }
+    }
+  }
+
+  /**
+    * Retrieve list of results for `node` or None if they are not
+    * available in the table.
+    */
+  def get(node: nodes.StoredNode): Option[List[ReachableByResult]] = {
+    table.get(node)
+  }
+
+}
+
+/**
+  * A partial result, informing about a path that exists from a source to another
+  * node in the graph.
+  *
+  * @param path this is the main result - a known path
+  *
+  * */
+case class ReachableByResult(path: List[PathElement]) {
+  def source: nodes.TrackingPoint = path.head.node
+
+  def unresolvedArgs: List[nodes.TrackingPoint] = path.collect {
+    case elem if !elem.resolved =>
+      elem.node
+  }
+}
+
+case class PathElement(node: nodes.TrackingPoint, visible: Boolean = true, resolved: Boolean = true)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -49,13 +49,14 @@ class ResultTable {
   * @param path this is the main result - a known path
   *
   * */
-case class ReachableByResult(path: List[PathElement]) {
+case class ReachableByResult(path: List[PathElement], partial: Boolean = false) {
   def source: nodes.TrackingPoint = path.head.node
 
-  def unresolvedArgs: List[nodes.TrackingPoint] = path.collect {
-    case elem if !elem.resolved =>
-      elem.node
-  }
+  def unresolvedArgs: List[nodes.TrackingPoint] =
+    path.collect {
+      case elem if !elem.resolved =>
+        elem.node
+    }.distinct
 }
 
 case class PathElement(node: nodes.TrackingPoint, visible: Boolean = true, resolved: Boolean = true)

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/DataFlowCodeToCpgSuite.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/DataFlowCodeToCpgSuite.scala
@@ -3,6 +3,7 @@ package io.shiftleft.dataflowengineoss.language
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
+import io.shiftleft.dataflowengineoss.queryengine.EngineContext
 import io.shiftleft.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.shiftleft.semanticcpg.language.NodeSteps
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
@@ -16,7 +17,8 @@ import scala.util.Try
 class DataFlowCodeToCpgSuite extends CodeToCpgSuite {
 
   val semanticsFilename = "dataflowengineoss/src/test/resources/default.semantics"
-  implicit val semantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
+  val semantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
+  implicit val context = EngineContext(semantics)
 
   implicit val viewer: ImageViewer = (pathStr: String) =>
     Try {

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -55,7 +55,7 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val table = new ResultTable
       table.add(pivotNode, List(ReachableByResult(pathContainingPivot)))
       table.createFromTable(pathFromPivot) match {
-        case Some(List(ReachableByResult(path))) =>
+        case Some(List(ReachableByResult(path, _))) =>
           path.map(_.node.id2) shouldBe List(node4.id2, pivotNode.id2, node1.id2)
         case None => fail
       }

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -1,0 +1,65 @@
+package io.shiftleft.dataflowengineoss.queryengine
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.testing.MockCpg
+import io.shiftleft.semanticcpg.language._
+
+class ResultTableTests extends AnyWordSpec with Matchers {
+
+  "ResultTable::add" should {
+
+    val cpg = MockCpg()
+      .withCustom({ (diffGraph, _) =>
+        diffGraph.addNode(nodes.NewLiteral("foo"))
+        diffGraph.addNode(nodes.NewLiteral("bar"))
+      })
+      .cpg
+
+    "append to existing results on multiple inserts for same key" in {
+      val node1 = cpg.literal.head
+      val node2 = cpg.literal.last
+      val table = new ResultTable
+      val res1 = List(ReachableByResult(List(PathElement(node1))))
+      val res2 = List(ReachableByResult(List(PathElement(node2))))
+      table.add(node1, res1)
+      table.add(node1, res2)
+      table.get(node1) match {
+        case Some(results) =>
+          results.flatMap(_.path.map(_.node.id2)) shouldBe List(node1.id2, node2.id2)
+        case None => fail
+      }
+    }
+
+  }
+
+  "ResultTable::createFromTable" should {
+
+    val cpg = MockCpg()
+      .withCustom({ (diffGraph, _) =>
+        diffGraph.addNode(nodes.NewLiteral("foo"))
+        diffGraph.addNode(nodes.NewLiteral("bar"))
+        diffGraph.addNode(nodes.NewLiteral("woo"))
+        diffGraph.addNode(nodes.NewLiteral("moo"))
+      })
+      .cpg
+
+    "correctly combine path and path stored in table on createFromTable" in {
+      val node1 = cpg.literal.code("foo").head
+      val pivotNode = cpg.literal.code("bar").head
+      val node3 = cpg.literal.code("woo").head
+      val node4 = cpg.literal.code("moo").head
+      val pathFromPivot = List(PathElement(pivotNode), PathElement(node1))
+      val pathContainingPivot = List(PathElement(node4), PathElement(pivotNode), PathElement(node3))
+      val table = new ResultTable
+      table.add(pivotNode, List(ReachableByResult(pathContainingPivot)))
+      table.createFromTable(pathFromPivot) match {
+        case Some(List(ReachableByResult(path))) =>
+          path.map(_.node.id2) shouldBe List(node4.id2, pivotNode.id2, node1.id2)
+        case None => fail
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
* Rename ResultCache to ResultTable to make clear that this isn't an optimization but part of the algorithm
* Simplify ResultTable API and make sure we append as opposed to replace
* Add tests for ResultTable
* Make task scheduling more explicit and more flexible by replacing parallel collections with ExecutorCompletionService
* Bring in EngineContext with EngineConfig via implicit as opposed to just Semantics
