### PR TITLE
Fix method filename in locations.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -16,10 +16,9 @@ object LocationCreator {
     try {
       location(node)
     } catch {
-      case exc @ (_: NoSuchElementException | _: ClassCastException) => {
+      case exc @ (_: NoSuchElementException | _: ClassCastException) =>
         logger.error(s"Cannot determine location for ${node.label} due to broken CPG", exc)
         emptyLocation(node.label, Some(node))
-      }
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -112,11 +112,13 @@ object LocationCreator {
     }
   }
 
-  def apply(node: nodes.CpgNode,
-            symbol: String,
-            label: String,
-            lineNumber: Option[Integer],
-            method: nodes.Method): nodes.NewLocation = {
+  def apply(
+      node: nodes.CpgNode,
+      symbol: String,
+      label: String,
+      lineNumber: Option[Integer],
+      method: nodes.Method
+  ): nodes.NewLocation = {
 
     if (method == null) {
       nodes.NewLocation("", "", "", "", None, "", "", "", "", Some(node))
@@ -132,9 +134,6 @@ object LocationCreator {
       } yield namespace.name
       val namespaceName = namespaceOption.getOrElse("")
 
-      val fileOption = ExpandTo.methodToFile(method)
-      val fileName = fileOption.map(_.name).getOrElse("N/A")
-
       nodes.NewLocation(
         symbol = symbol,
         methodFullName = method.fullName,
@@ -144,7 +143,7 @@ object LocationCreator {
         className = typeName,
         classShortName = typeShortName,
         nodeLabel = label,
-        filename = fileName,
+        filename = if (method.filename.isEmpty) "N/A" else method.filename,
         node = Some(node)
       )
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/filecompat/FileNameCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/filecompat/FileNameCompat.scala
@@ -19,10 +19,9 @@ class FileNameCompat(cpg: Cpg) extends CpgPass(cpg) {
 
     def updateDefaultFileName(node: nodes.StoredNode with nodes.HasFilename): Unit = {
       // When creating nodes via NewNode classes, filename is "", not null.
+      // For operators, filename might also be null.
       if (node.filename == null || node.filename == "") {
-        node.start.file.name.headOption().foreach { name =>
-          dstGraph.addNodeProperty(node, "FILENAME", name)
-        }
+        dstGraph.addNodeProperty(node, "FILENAME", node.start.file.name.headOption.getOrElse(""))
       }
     }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/ExpandTo.scala
@@ -70,9 +70,6 @@ object ExpandTo {
   def methodToTypeDecl(method: nodes.Method): Option[nodes.TypeDecl] =
     findVertex(method, _.isInstanceOf[nodes.TypeDecl]).map(_.asInstanceOf[nodes.TypeDecl])
 
-  def methodToFile(method: nodes.Method): Option[nodes.File] =
-    findVertex(method, _.isInstanceOf[nodes.File]).map(_.asInstanceOf[nodes.File])
-
   @tailrec
   private def findVertex(node: nodes.StoredNode, instanceCheck: nodes.StoredNode => Boolean): Option[nodes.StoredNode] =
     node._astIn.nextOption match {


### PR DESCRIPTION
Fixes <https://github.com/ShiftLeftSecurity/product/issues/5393#issuecomment-683800676>, the reported filenames are wrong, although it should now be possible to be more accurate since <https://github.com/ShiftLeftSecurity/codepropertygraph/pull/622> was merged.

Happy to know it can't be done this way, apart from that, it actually works for this case.

But, it doesn't seem to work e.g. in `sptests`, as the attribute doesn't get set? This shouldn't be the case since the `FileNameCompat` pass would set it if missing.

In any case, appreciate any input on this.