### PR TITLE
Move `SourceFiles` from `fuzzyc2cpg` to `x2cpg`

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/SourceFiles.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/SourceFiles.scala
@@ -1,0 +1,26 @@
+package io.shiftleft.x2cpg
+
+import better.files._
+
+object SourceFiles {
+
+  /**
+    * For a given array of input paths, determine all
+    * source files by inspecting filename extensions.
+    * */
+  def determine(inputPaths: Set[String], sourceFileExtensions: Set[String]): List[String] = {
+    def hasSourceFileExtension(file: File): Boolean =
+      file.extension.exists(sourceFileExtensions.contains)
+
+    val (dirs, files) = inputPaths
+      .map(File(_))
+      .partition(_.isDirectory)
+
+    val matchingFiles = files.filter(hasSourceFileExtension).map(_.toString)
+    val matchingFilesFromDirs = dirs
+      .flatMap(_.listRecursively.filter(hasSourceFileExtension))
+      .map(_.toString)
+
+    (matchingFiles ++ matchingFilesFromDirs).toList.sorted
+  }
+}


### PR DESCRIPTION
`SourceFiles` allows to determine source files to analyze based on file extension. Moving it to `x2cpg` to allow sharing between frontends.