### PR TITLE
Provide methods to check for legacy CPGs

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -1,10 +1,13 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
+import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeKeys
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import overflowdb.OdbGraph
+
+import scala.util.Try
 
 object CpgLoader {
 
@@ -56,6 +59,26 @@ object CpgLoader {
 
   def addDiffGraphs(diffGraphFilenames: Seq[String], cpg: Cpg): Unit =
     new CpgLoader().addDiffGraphs(diffGraphFilenames, cpg)
+
+  /**
+    * Determine whether the CPG is a legacy (proto) CPG
+    *
+    * @param filename name of the file to probe
+    * */
+  def isLegacyCpg(filename: String): Boolean =
+    isLegacyCpg(File(filename))
+
+  /**
+    * Determine whether the CPG is a legacy (proto) CPG
+    *
+    * @param file file to probe
+    * */
+  def isLegacyCpg(file: File): Boolean = {
+    val bytes = file.bytes
+    Try {
+      bytes.next() == 'P' && bytes.next() == 'K'
+    }.getOrElse(false)
+  }
 
 }
 

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -485,7 +485,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
 
     val cpgDestinationPath = cpgDestinationPathOpt.get
 
-    if (isZipFile(cpgFile)) {
+    if (CpgLoader.isLegacyCpg(cpgFile)) {
       report("You have provided a legacy proto CPG. Attempting conversion.")
       try {
         CpgConverter.convertProtoCpgToOverflowDb(cpgFile.path.toString, cpgDestinationPath.toString)
@@ -511,12 +511,6 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
     cpgOpt
   }
 
-  private def isZipFile(file: File): Boolean = {
-    val bytes = file.bytes
-    Try {
-      bytes.next() == 'P' && bytes.next() == 'K'
-    }.getOrElse(false)
-  }
   @Doc(
     "Close project by name",
     """|Close project. Resources are freed but the project remains on disk.


### PR DESCRIPTION
There was a method used in `io.shiftleft.console` to probe whether we're dealing with a legacy CPG (by checking if it's a zip file). I need to perform a similar test in the pipeline. To avoid repeating myself, I've moved this method into `CpgLoader` as a utility.