### PR TITLE
Remove superfluous instruction from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ can use to generate your own language-specific bindings. For instance, to create
 ```
 sbt package
 cd codepropertygraph/target
-unzip codepropertygraph-*.jar cpg.proto
 mkdir cpp python
 protoc --cpp_out=cpp --python_out=python cpg.proto
 ```


### PR DESCRIPTION
`cpg.proto` is placed under `codepropertygraph/target` on executing `sbt
stage`, which makes the `unzip` execution unnecessary.