### PR TITLE
Add missing file for the Python Bindings package

### DIFF
--- a/proto-bindings/python/MANIFEST.in
+++ b/proto-bindings/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include PACKAGE-README.md


### PR DESCRIPTION
This manifest file instructs the packager to include `PACKAGE-README.md`
in the source distribution. Without the change, installing the package
fails with a missing file.

Details on the topic:
https://packaging.python.org/guides/using-manifest-in/