### PR TITLE
Fix self invocation loop.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -288,7 +288,9 @@ class NodeTypeStarters(cpg: Cpg) {
   /**
   Begin traversal at node with id.
     */
-  def id[NodeType <: nodes.StoredNode](anId: Any): Traversal[NodeType] = id(Seq(anId))
+  def id[NodeType <: nodes.StoredNode](anId: Long): Traversal[NodeType] = {
+    cpg.graph.nodes(anId).cast[NodeType]
+  }
 
   /**
   Begin traversal at set of nodes - specified by their ids


### PR DESCRIPTION
This was caused by only changing the id type from Any to Int for the
overloaded version of function id.
In order to avoid such problems in the future, we do not redirect to the
overload anymore.

Fix for: https://github.com/ShiftLeftSecurity/product/issues/5522