### PR TITLE
not all expressions have a parent expression - reflect that in the type

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -44,7 +44,7 @@ private object TrackingPointMethodsBase {
 
 private object TrackingPointToCfgNode {
   def apply(node: nodes.TrackingPointBase): nodes.CfgNode = {
-    applyInternal(node, _.parentExpression)
+    applyInternal(node, _.parentExpression.get)
   }
 
   private def applyInternal(node: nodes.TrackingPointBase,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
@@ -89,9 +89,9 @@ object Shared {
 
   def toCfgNode(node: nodes.StoredNode): nodes.CfgNode = {
     node match {
-      case node: nodes.Identifier => node.parentExpression
-      case node: nodes.MethodRef  => node.parentExpression
-      case node: nodes.Literal    => node.parentExpression
+      case node: nodes.Identifier => node.parentExpression.get
+      case node: nodes.MethodRef  => node.parentExpression.get
+      case node: nodes.Literal    => node.parentExpression.get
 
       case node: nodes.MethodParameterIn => node.method
 
@@ -99,7 +99,7 @@ object Shared {
         node.method.methodReturn
 
       case node: nodes.Call if MemberAccess.isGenericMemberAccessName(node.name) =>
-        node.parentExpression
+        node.parentExpression.get
 
       case node: nodes.Call         => node
       case node: nodes.ImplicitCall => node

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/ExpressionMethods.scala
@@ -13,16 +13,18 @@ class ExpressionMethods(val node: nodes.AstNode) extends AnyVal {
     * It's continuing it's walk until it hits an expression that's not a generic
     * "member access operation", e.g., "<operator>.memberAccess".
     * */
-  def parentExpression: nodes.Expression = _parentExpression(node)
+  def parentExpression: Option[nodes.Expression] = _parentExpression(node)
 
   @tailrec
-  private final def _parentExpression(argument: nodes.AstNode): nodes.Expression = {
+  private final def _parentExpression(argument: nodes.AstNode): Option[nodes.Expression] = {
     val parent = argument._astIn.onlyChecked
     parent match {
       case call: nodes.Call if MemberAccess.isGenericMemberAccessName(call.name) =>
         _parentExpression(call)
       case expression: nodes.Expression =>
-        expression
+        Some(expression)
+      case _ =>
+        None
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/Expression.scala
@@ -17,7 +17,7 @@ class Expression[NodeType <: nodes.Expression](val traversal: Traversal[NodeType
     * "member access operation", e.g., "<operator>.memberAccess".
     * */
   def parentExpression: Traversal[nodes.Expression] =
-    traversal.map(_.parentExpression)
+    traversal.flatMap(_.parentExpression)
 
   /**
     Traverse to enclosing expression


### PR DESCRIPTION
this PR fixes an issue reported by Niko: with HelloShiftLeft Java:
```
cpg.call.codeExact("fos.write($r18)").parentExpression.parentExpression.l

scala.MatchError:
io.shiftleft.codepropertygraph.generated.nodes.Method[label=METHOD;
id=6865517531448291682] (of class
io.shiftleft.codepropertygraph.generated.nodes.Method)
  io.shiftleft.semanticcpg.language.nodemethods.ExpressionMethods$._parentExpression$extension(SourceFile:21)
```