### PR TITLE
Carry over Bernhard's AccessPath work

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessElement.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessElement.scala
@@ -1,0 +1,19 @@
+package io.shiftleft.semanticcpg.accesspath
+
+sealed abstract class AccessElement(name: String) {
+  override def toString: String = name
+}
+
+case class ConstantAccess(constant: String) extends AccessElement(constant)
+
+case object VariableAccess extends AccessElement("?")
+
+case object VariablePointerShift extends AccessElement("<?>")
+
+// this will eventually get an optional extent (how many bytes wide is the memory load/store)
+case object IndirectionAccess extends AccessElement("*")
+
+case object AddressOf extends AccessElement("&")
+
+// this will eventually obtain an optional byteOffset
+case class PointerShift(logicalOffset: Int) extends AccessElement(s"<${logicalOffset}>")

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPath.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPath.scala
@@ -9,7 +9,7 @@ object MatchResult extends Enumeration {
 }
 
 object AccessPath {
-  val noExclusions = List[Elements]()
+  val noExclusions: List[Elements] = List[Elements]()
   val empty = new AccessPath(Elements(), noExclusions)
   def apply(elements: Elements, exclusions: Seq[Elements]): AccessPath = {
     if (elements.isEmpty && exclusions.isEmpty) AccessPath.empty
@@ -30,7 +30,7 @@ object AccessPath {
 case class FullMatchResult(
                            /** The unaffected part of the accesspath. Some(this) for no match, None for perfect match;
                              * may have additional exclusions to this.*/
-                           val stepOverPath: Option[AccessPath],
+                           stepOverPath: Option[AccessPath],
                            //
                            /** The affected part of the accesspath, mapped to be relative to this.
                              *
@@ -40,13 +40,13 @@ case class FullMatchResult(
                              * Outside of overtainting, if stepIntoPath.isDefined && stepIntoPath.elements.nonEmpty then:
                              *    path.elements == other.elements ++ path.matchFull(other).stepIntoPath.get.elements
                              *    extensionDiff.isEmpty */
-                           val stepIntoPath: Option[AccessPath],
+                           stepIntoPath: Option[AccessPath],
                            //
                            /** extensionDiff.nonEmpty if and only if a proper subset is affected.
                              * Outside of overtainting, if extensionDiff.nonEmpty then:
                              *    path.elements ++ path.matchFull(other).extensionDiff == other.elements
                              *    path.matchFull(other).stepIntoPath.get.elements.isEmpty */
-                           val extensionDiff: Elements) {
+                           extensionDiff: Elements) {
   def hasMatch: Boolean = stepIntoPath.nonEmpty
 }
 
@@ -78,7 +78,7 @@ case class AccessPath(elements: Elements, exclusions: Seq[Elements]) {
     val res = this.matchFull(other.elements)
     if (res.extensionDiff.isEmpty && res.stepIntoPath.isDefined && isExtensionExcluded(other.exclusions,
                                                                                        res.stepIntoPath.get.elements)) {
-      return FullMatchResult(Some(this), None, Elements.empty)
+      FullMatchResult(Some(this), None, Elements.empty)
     } else res
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPath.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPath.scala
@@ -1,0 +1,209 @@
+package io.shiftleft.semanticcpg.accesspath
+
+sealed trait MatchResult
+
+object MatchResult extends Enumeration {
+  type MatchResult = Value
+  val NO_MATCH, EXACT_MATCH, VARIABLE_EXACT_MATCH, PREFIX_MATCH, VARIABLE_PREFIX_MATCH, EXTENDED_MATCH,
+  VARIABLE_EXTENDED_MATCH = Value
+}
+
+object AccessPath {
+  val noExclusions = List[Elements]()
+  val empty = new AccessPath(Elements(), noExclusions)
+  def apply(elements: Elements, exclusions: Seq[Elements]): AccessPath = {
+    if (elements.isEmpty && exclusions.isEmpty) AccessPath.empty
+    else new AccessPath(elements, exclusions.toList)
+  }
+
+  def isExtensionExcluded(exclusions: Seq[Elements], extension: Elements): Boolean = {
+    exclusions.exists(exclusion => extension.elements.startsWith(exclusion.elements))
+  }
+}
+
+/**
+  * Invariants:
+  *   - Exclusions have no invertible tail
+  *   - Only paths without overTaint can have exclusions
+  *   TODO: Figure out sensible assertions to defend these invariants
+  */
+case class FullMatchResult(
+                           /** The unaffected part of the accesspath. Some(this) for no match, None for perfect match;
+                             * may have additional exclusions to this.*/
+                           val stepOverPath: Option[AccessPath],
+                           //
+                           /** The affected part of the accesspath, mapped to be relative to this.
+                             *
+                             * stepIntoPath.isDefined if and only if there is a match in pathes, i.e. if the call can
+                             * affect the tracked variable at all
+                             *
+                             * Outside of overtainting, if stepIntoPath.isDefined && stepIntoPath.elements.nonEmpty then:
+                             *    path.elements == other.elements ++ path.matchFull(other).stepIntoPath.get.elements
+                             *    extensionDiff.isEmpty */
+                           val stepIntoPath: Option[AccessPath],
+                           //
+                           /** extensionDiff.nonEmpty if and only if a proper subset is affected.
+                             * Outside of overtainting, if extensionDiff.nonEmpty then:
+                             *    path.elements ++ path.matchFull(other).extensionDiff == other.elements
+                             *    path.matchFull(other).stepIntoPath.get.elements.isEmpty */
+                           val extensionDiff: Elements) {
+  def hasMatch: Boolean = stepIntoPath.nonEmpty
+}
+
+case class AccessPath(elements: Elements, exclusions: Seq[Elements]) {
+  import AccessPath.isExtensionExcluded
+  def isTrivial: Boolean = this.elements.isEmpty && this.exclusions.isEmpty
+
+  // for handling of invertible elements, cf AccessPathAlgebra.md
+  def ++(other: Elements): Option[AccessPath] = {
+    if (isExtensionExcluded(this.exclusions, other)) None
+    //fixme: may need to process invertible tail of other better
+    else Some(AccessPath(this.elements ++ other, this.truncateExclusions(other).exclusions))
+  }
+  def ++(other: AccessPath): Option[AccessPath] = {
+    if (isExtensionExcluded(this.exclusions, other.elements)) None
+    //fixme: may need to process invertible tail of other better
+    else {
+      var accessPath = AccessPath(this.elements ++ other.elements, this.truncateExclusions(other.elements).exclusions)
+      for (exclusion <- other.exclusions) {
+        accessPath = accessPath.addExclusion(exclusion)
+      }
+      Some(accessPath)
+    }
+  }
+
+  def prepend(other: Elements): AccessPath = AccessPath(other ++ this.elements, this.exclusions)
+
+  def matchFull(other: AccessPath): FullMatchResult = {
+    val res = this.matchFull(other.elements)
+    if (res.extensionDiff.isEmpty && res.stepIntoPath.isDefined && isExtensionExcluded(other.exclusions,
+                                                                                       res.stepIntoPath.get.elements)) {
+      return FullMatchResult(Some(this), None, Elements.empty)
+    } else res
+  }
+
+  def matchFull(other: Elements): FullMatchResult = {
+    val (matchRes, matchDiff) = this.matchAndDiff(other)
+    matchRes match {
+      case MatchResult.NO_MATCH =>
+        FullMatchResult(Some(this), None, Elements.empty)
+      case MatchResult.PREFIX_MATCH | MatchResult.EXACT_MATCH =>
+        FullMatchResult(None, Some(AccessPath(matchDiff, this.exclusions).intern), Elements.empty)
+      case MatchResult.VARIABLE_PREFIX_MATCH | MatchResult.VARIABLE_EXACT_MATCH =>
+        FullMatchResult(Some(this), Some(AccessPath(matchDiff, this.exclusions).intern), Elements.empty)
+      case MatchResult.EXTENDED_MATCH =>
+        FullMatchResult(Some(this.addExclusion(matchDiff)),
+                        Some(AccessPath(Elements.empty, exclusions).truncateExclusions(matchDiff)),
+                        matchDiff)
+      case MatchResult.VARIABLE_EXTENDED_MATCH =>
+        FullMatchResult(Some(this),
+                        Some(AccessPath(Elements.empty, exclusions).truncateExclusions(matchDiff)),
+                        matchDiff)
+    }
+  }
+
+  //we track this and encounter compareAgainst. PREFIX means that this is longer, EXTENDED means that compareAgainst is longer
+  def matchAndDiff(other: Elements): (MatchResult.MatchResult, Elements) = {
+    val thisTail = elements.invertibleTailLength
+    val otherTail = other.invertibleTailLength
+    val thisHead = elements.elements.length - thisTail
+    val otherHead = other.elements.length - otherTail
+
+    val cmpUntil = scala.math.min(thisHead, otherHead)
+    var idx = 0
+    var overTainted = false
+    while (idx < cmpUntil) {
+      (elements.elements(idx), other.elements(idx)) match {
+        case (VariableAccess, VariableAccess) | (_: ConstantAccess, VariableAccess) |
+            (VariableAccess, _: ConstantAccess) | (VariablePointerShift, VariablePointerShift) |
+            (_: PointerShift, VariablePointerShift) | (VariablePointerShift, _: PointerShift) =>
+          overTainted = true
+        case (thisElem, otherElem) =>
+          if (thisElem != otherElem)
+            return (MatchResult.NO_MATCH, Elements.empty)
+      }
+      idx += 1
+    }
+    var done = false
+
+    /**
+      *  We now try to greedily match more elements. We know that one of the two pathes will only contain invertible
+      *  elements. The issue is the following:
+      *   prefix <1> & x
+      *   prefix <?> &
+      *  With greedy matching, we end up with a diff: x.
+      *  If we just did the invert-append algorithm, we would end up with a less precise
+      *   diff: * <?> <1> &  x == * <?> & x.
+      */
+    val minlen = scala.math.min(elements.elements.length, other.elements.length)
+    while (!done && idx < minlen) {
+      (elements.elements(idx), other.elements(idx)) match {
+        case (_: PointerShift, VariablePointerShift) | (VariablePointerShift, _: PointerShift) |
+            (VariablePointerShift, VariablePointerShift) =>
+          overTainted = true
+          idx += 1
+        case (thisElem, otherElem) =>
+          if (thisElem == otherElem) {
+            idx += 1
+          } else {
+            done = true
+          }
+      }
+    }
+    if (thisHead >= otherHead) {
+      // prefix or exact
+      val diff = Elements.inverted(other.elements.drop(idx)) ++ Elements.unnormalized(elements.elements.drop(idx))
+
+      /**
+        * we don't need to overtaint if thisTail has variable PointerShift: They can still get excluded
+        * e.g. suppose we track "a" "b" <?> and encounter "a" <4>.
+        */
+      overTainted |= !other.noOvertaint(otherHead)
+      if (!overTainted & thisHead == otherHead) (MatchResult.EXACT_MATCH, diff)
+      else if (overTainted && thisHead == otherHead) (MatchResult.VARIABLE_EXACT_MATCH, diff)
+      else if (!overTainted && thisHead != otherHead) (MatchResult.PREFIX_MATCH, diff)
+      else if (overTainted && thisHead != otherHead) (MatchResult.VARIABLE_PREFIX_MATCH, diff)
+      else throw new RuntimeException()
+    } else {
+      //extended
+      val diff = Elements.inverted(elements.elements.drop(idx)) ++ Elements.unnormalized(other.elements.drop(idx))
+
+      /**
+        * we need to overtaint if any either otherTail or thisTail has variable PointerShift:
+        * e.g. suppose we track "a" <4> and encounter "a" "b" <?> "c", or suppose that we track "a" <?> and encounter "a" "b"
+        */
+      overTainted |= !elements.noOvertaint(thisHead) | !other.noOvertaint(otherHead)
+
+      if (overTainted) (MatchResult.VARIABLE_EXTENDED_MATCH, diff)
+      else if (isExtensionExcluded(this.exclusions, diff)) (MatchResult.NO_MATCH, Elements.empty)
+      else (MatchResult.EXTENDED_MATCH, diff)
+    }
+  }
+
+  def truncateExclusions(compareExclusion: Elements): AccessPath = {
+    val size = compareExclusion.elements.length
+    val newExclusions =
+      exclusions
+        .filter(_.elements.startsWith(compareExclusion.elements))
+        .map(exclusion => Elements.normalized(exclusion.elements.drop(size)))
+    new AccessPath(elements, newExclusions)
+  }
+
+  def addExclusion(newExclusion: Elements): AccessPath = {
+    if (newExclusion.noOvertaint()) {
+      val ex =
+        Elements.unnormalized(newExclusion.elements.dropRight(newExclusion.invertibleTailLength))
+      val unshadowed = exclusions.filter(!_.elements.startsWith(ex.elements))
+      AccessPath(elements, unshadowed :+ ex)
+    } else this
+  }
+  def intern(): AccessPath = {
+    if (this == AccessPath.empty) AccessPath.empty
+    else this
+  }
+
+  def isEmpty: Boolean = {
+    this.elements.isEmpty && this.exclusions.isEmpty
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPathAlgebra.md
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPathAlgebra.md
@@ -1,0 +1,77 @@
+## 
+
+The handling of access paths was designed and implemented by Bernhard Brehm (bbrehm@shiftleft.io).
+
+## Access Path Algebra without relations
+
+Classically, access paths are modeled as a roughly a "free monoid": A path is a list of strings, including one special "VariableAccess" token. Member access appends to this path; either the field name, or the VariableAccess token "?" for non-literal index accesses. It is not possible to invert elements in this list; these are the only supported ways of deriving one object reference from another, and two derived references are assumed to be equal if and only if they have identical access paths.
+
+We also have a notion of "contexts": The access path of a context describes a set of access paths; we encode this by storing a prefix, and a set of exclusions. Then, this set describes the set of reachable paths starting from there. Let's call this a context path.
+
+Now, if we track some base symbol with given context path CP, and encounter a function call with access path AP, we need to split: We continue to track with CP \ AP, i.e. we continue to track everything reachable through CP that is not reachable through AP. The remainder, CP \intersect AP, is translated and tracked into the function call. Very often, this will not find any changes, and we will emerge with CP \intersect AP again.
+
+We split in a non-disjoint way for VarableAccess tokens: I.e. we overtaint. The path is tracked into the function, but not excluded at all.
+
+Due to the "free monoid" style of paths, the intersection is easy: CP \intersect AP is either empty, or CP is a prefix of AP: Then it is AP itself (plus exclusions), or AP is a prefix of CP: Then it is CP itself, and CP \ AP is empty.
+
+In this model, we don't need any special handling for the "deref" / "*" operator: It is simply an access path token like any other.
+
+## Complex Access Path Elements
+
+Now, we want to handle four complications.
+
+1. the AddressOf operator, which has the special property that it cancels with the Deref operator. I.e. *(&x) is identical to x itself. Depending on modeling decisions, we may also say that &(*x) is equal to x itself. For simplicity, we will write all pathes in postfix, i.e. x: & * and x: * &.
+
+2. the PointerShift operator, which we will write as p: <i>, and which corresponds to p+i. This again has a VariableAccess variant, such that p: <5> and p: <?> are valid paths. The property of the pointershift is that subsequent shifts collapse by addition, i.e. p: <5> <-3> <-2> * === p: *. Then, a C array access can be writen as p[4] === *(p+4) === p: <4> *.
+
+3. the getelementptr ("GEP") construct. Consider C code like p->a: This is mostly equivalent to both (*p).a and *&(p->a); the subtle difference is that &p->a does not load from memory, it instead derives a pointer from p (C's addressof is not a function/operator, it is a syntactic construct). This is a very natural operation in LLVM (given a pointer to a struct, derive a pointer to a specific member; i.e. a LEA instruction). Now, we have two valid paths to the member p->a: We can first load the entire struct from main memory into register / stack, and then extract the element a, or we can derive a pointer &(p->a) to the struct element from p, and then load it. Both of these paths lead to the exact same element, but they look different. To be more precise, we have a conflict between `p: [GEP a] *` and `p: * [Extract a]`. Typical C code will prefer the `p: * [Extract a]` notation (closer to the source, i.e. C syntax!) while typical LLVM code will prefer `p: [GEP a] *` (closer to the source, i.e. llvm-IR; also, compilers prefer to emit this). Suppose that we have AddressOf working; then, we can obtain correct behavior by either:
+
+    2.1 Logical viewpoint: `[Extract a] => a`, `[GEP a] => * a &`. Consider the example: We then get the two paths `p: * a` and `p: * a & *`, and these are equal (as long as `& *` cancels).
+    3.2 Memory viewpoint: `[Extract a] => & a *`, `[GEP a] => a`. Consider the example: We then get the two paths `p: * & a *` and `p: a *`, and these are equal (as long as `* &` cancels).
+
+A large consideration is whether we want to consider this as an invertible operation on paths. We currently tend to consider it as non-invertible: I.e. we can derive a field-pointer from a parent struct-pointer, but we cannot go back (it is of course theoretically possible to go back, but we don't want to support that).
+
+4. The pointercast construct. Consider C code like `((myStruct*)p)->a`, or consider C unions. In these cases, pointers are reinterpreted into pointers of different types. This changes the meaning of subsequent path elements (load, GEP, pointershift). Realistically, our goal should be to overtaint most of the time, but still retain correct behavior independent of pointer base-type: I.e. if our base pointer is char*, but it is always used as myStruct* (i.e. always cast right before use), then we want to find the exact same flows as if it was a myStruct* pointer in the first place. Unfortunately we don't know how to model this nicely, yet.
+
+## One-sided invertible AddressOf
+
+We chose to handle complications 1-3 in the following way. We chose to make both `& *` and `* &` collapse, and hence use the logical viewpoint `[Extract a] => a`, `[GEP a] => * a &`. We propose that GEP, Extract and Shift become new built-in accessPath modifying functions, and AddressOf and Shift become new tokens for access paths. This way, we can change the backend representation in the future, without needing front-ends to change their emissions. 
+
+The elements `<LiteralInteger>` and `<?>` and `&` are considered invertible, but `*` is considered non-invertible (even though, in reality, `*` is invertible and `<?>` is non-invertible). We will maintain the invariant that exclusions cannot contain the tokens `<?>` or `?`, and exclusions cannot have trailing invertible elements.
+
+When we track a context path CP and encounter call with argument access path AP, from the same base, then we need to matchAndDiff. The general approach is the following:
+
+ 1. Normalize the paths: We collapse internal elements (`& *` -> nil, `<0>`->nil, `<i> <j>`->`<i+j>`, `<i> <?>`->`<?>`, `<?> <i>`->`<?>`), and split off all trailing invertible elements, into CP = CP_HEAD CP_INV and AP = AP_HEAD AP_INV (we can possibly just maintain this split all the time).
+
+ 2. Suppose AP_HEAD is a prefix or equal to CP_HEAD. That is, CP = AP_HEAD OVERHEAD CP_INV For example, we track base: `* <5> *`, and we encounter foo(`base: * <2>`). In this case, we don't split and track into the function. For this, we mentally rewrite our current path into CP = AP_HEAD AP_INV AP_INV^(-1) OVERHEAD CP_INV, and hence track into the call with translated path AP_INV^(-1) OVERHEAD CP_INV, which would be arg: `<-2> <5> *` = `arg: <3> *`. Now suppose that the call doesn't change anything: Then, we would prepend AP on returning, such that we come out tracking base: `* <2> <3> * = base: * <5> *`, just as it should be.
+
+ 3.  Suppose AP_HEAD is an extension of CP_HEAD. That is, AP = CP_HEAD EXT AP_INV. For example, we track `base: * <2>` and encounter `foo(base: * <5> * <1>)`. Then we mentally rewrite AP = CP_HEAD CP_INV CP_INV^(-1) EXT AP_INV, which would be `AP = (*) (<2>) (<-2>) (<5> *) (<1>)`. We now need to split: I.e. we need to check for the exclusion CP_INV^(-1) EXT, and track both into and around the call. The step-over flow gets an extended exclusion list, and the step-into call will track arg: , i.e. an empty path. If the extemsion is already excluded, i.e. if there exists an exclusion starting with CP_INV^(-1) EXT, then we don't track into, and simply go on. Otherwise, the ongoing flow gets the new exclusion added to its list, possibly removing (shadowing) some existing exclusions: If there existed an exclusion of the form CP_INV^(-1) EXT TRAIL, then it can be deleted because it is implied by the new exclusion. Further, we need to track into the function. For this, the tracked path is empty, with truncated exclusion list: We keep exclusions of the form CP_INV^(-1) EXT TRAIL, and truncate them to TRAIL. Note that this scheme preserves the fact that exclusions always terminate in a non-invertible symbol. In our example, suppose that `<3> *` was excluded, i.e. we originally tracked `base: * <2> \ <3> *`. We now encounter `foo(base: * <2> <-2> <5> *)`: This is excluded, and we don't need to track it. 
+    
+ Suppose on the other hand that we started with `base: * <2> \ <3> * *`. Then, we track into, with path `arg: \ *`, and continue tracking with exclusion `base: * <2> \ <3> *` (which shadows the old exclusion). If the call did not change anything, then we will come out with `arg: \ *` again, which translates back to `base: * <5> * \ *`. Naively this might look nonsensical-- we track a pointer, but we don't care about the pointee. However, it makes sense in view of arrays: For example, `base: * <5> * <1> *` is a perfectly valid access path that we still care about! This is due to the unfortunate fact that C and llvm don't properly distinguish between pointers to single objects and pointers to packed arrays.
+
+By using this approach, we don't change any existing code paths, i.e. CPGs that don't use Shift or AddressOf are unchanged. However, it is incubent on frontends to properly translate code such that it does not rely on the non-existing cancellation `* &`. I.e. `&arr[5]` needs to be translated into `arr: <5>` by the frontend. This is not an undue burden: The addressof really must appear in the same expression, since it is a syntactic construct, not a function. `tmp = arr[5]; &tmp` is semantically different, and the addressof does not undo the dereference!
+
+A further issue is that this approach is very unforgiving for policies. Say that e.g. someone wrote a policy for a function `void foo(int* src, int* dst){*dst = *src;}`. We can track through this function all right, but suppose its policy was a MAP override. If this was called like `foo(&someptr[5], other)`, then it would transfer the entire array to other, instead of just excluding / transfering the 5th element. Passing the entire array through the function is correct (it could be `dst[-2] = *src`), but the policy must tell us that it overrides the access path through *, i.e. must include the deref. Hence, we need to expand the policy language to permit such information.
+
+## Further examples
+
+Consider
+```
+void foo(T1 arg1, T2 arg2){
+    arg1[1] = *arg2;    //return from policy with arg2: <0> *
+                        //enter with LHS, continue with arg1: <3> \ <-3> *, <-2> *
+                        //AP arg1: <3> <-3> <1> *, arg2: <0> *
+                        //CP arg1: <3> \ <-3> *
+}
+...
+q = source();   //find flow via q *
+foo(p+2, q);    //return twice: [q: *] and [p: <2> <3> \ <-3> *, <-2> *]
+                //enter with arg1: <3> \ <-3> *
+                //AP p: <2>
+                //CP p: <2> <-2> <5> \ <-3> *
+foo(p[2], q);   //would enter with arg1: <3> * which is excluded
+                //AP p <5> <-5> <2> *
+                //CP p <5> \ <3> *  
+p[2] = 0; // track: p: <5> \ <-3> *
+sink(p+5); // track p: <5>
+```

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/Elements.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/Elements.scala
@@ -1,0 +1,241 @@
+package io.shiftleft.semanticcpg.accesspath
+
+/**
+  * For handling of invertible elements, cf AccessPathAlgebra.md.
+  * The general rule is that elements concatenate normally, except for:
+  *
+  *
+  *   Elements(&) ++ Elements(*) == Elements()
+  *   Elements(*) ++ Elements(&) == Elements()
+  *   Elements(<0>) == Elements()
+  *   Elements(<i>) ++ Elements(<j>) == Elements(<i+j>)
+  *   Elements(<?>) ++ Elements(<j>) == Elements(<?>)
+  *   Elements(<i>) ++ Elements(<?>) == Elements(<?>)
+  *   Elements(<?>) ++ Elements(<?>) == Elements(<?>)
+  *
+  *   From this, once can see that <i>, * and & are invertible, <?> is idempotent and <0> is a convoluted way of describing
+  *   and empty sequence of tokens. Nevertheless, we mostly consider * as noninvertible (because it is, in real computers!)
+  *   and <?> as invertible (because it is in real computers, we just don't know the offset)
+  *
+  *   Elements get a private constructor. Users should use the no-argument Elements.apply() factory method to get an
+  *   empty path, and the specific concat operators for building up pathes. The Elements.normalized(iter) factory method
+  *   serves to build this in bulk.
+  *
+  *   The unnormalized factory method is more of an escape hatch.
+  *
+  *   The elements field should never be mutated outside of this file: We compare and hash Elements by their contents, not by
+  *   identity, and this breaks in case of mutation.
+  *
+  *   The reason for using a mutable Array instead of an immutable Vector is that this is the lightest weight datastructure for
+  *   the job.
+  *
+  *   The reason for making this non-private is simply that it is truly annoying to write wrappers for all possible uses.
+  */
+// TODO: Figure out sensible assertions to defend invariant that the empty instance is the only empty elements instance
+// i.e. assert that elems.isEmpty implies elems eq Elements.empty
+
+object Elements {
+  val empty = new Elements()
+  def normalized(elems: IterableOnce[AccessElement]): Elements =
+    destructiveNormalized(elems.iterator.toArray)
+  def normalized(elems: AccessElement*): Elements =
+    destructiveNormalized(elems.toArray)
+
+  private def destructiveNormalized(elems: Array[AccessElement]): Elements = {
+    var idxRight = 0
+    var idxLeft = -1
+    while (idxRight < elems.length) {
+      val nextE = elems(idxRight)
+      if (nextE.isInstanceOf[PointerShift] && nextE.asInstanceOf[PointerShift].logicalOffset == 0) {
+        //nothing to do
+      } else if (idxLeft == -1) {
+        idxLeft = 0
+        elems(0) = nextE
+      } else {
+        val lastE = elems(idxLeft)
+        (lastE, nextE) match {
+          case (last: PointerShift, next: PointerShift) =>
+            val newShift = last.logicalOffset + next.logicalOffset
+            if (newShift != 0) elems(idxLeft) = PointerShift(newShift)
+            else idxLeft -= 1
+          case (VariablePointerShift, _: PointerShift) | (VariablePointerShift, VariablePointerShift) =>
+          case (_: PointerShift, VariablePointerShift) =>
+            elems(idxLeft) = VariablePointerShift
+          case (AddressOf, IndirectionAccess) =>
+            idxLeft -= 1
+          case (IndirectionAccess, AddressOf) =>
+            idxLeft -= 1 // WRONG but useful, cf comment for `Elements.:+`
+          case _ =>
+            idxLeft += 1
+            elems(idxLeft) = nextE
+        }
+      }
+      idxRight += 1
+    }
+    newIfNonEmpty(elems.take(idxLeft + 1))
+  }
+
+  def unnormalized(elems: IterableOnce[AccessElement]): Elements =
+    newIfNonEmpty(elems.iterator.toArray)
+
+  private def newIfNonEmpty(elems: Array[AccessElement]): Elements = {
+    if (!elems.isEmpty) new Elements(elems)
+    else empty
+  }
+
+  def inverted(elems: Iterable[AccessElement]): Elements = {
+    newIfNonEmpty(elems.toArray.reverse.map {
+      _ match {
+        case AddressOf            => IndirectionAccess
+        case IndirectionAccess    => AddressOf
+        case PointerShift(idx)    => PointerShift(-idx)
+        case VariablePointerShift => VariablePointerShift
+        case _                    => throw new RuntimeException(s"Cannot invert ${Elements.unnormalized(elems)}")
+      }
+    })
+  }
+
+  def noOvertaint(elems: Iterable[AccessElement]): Boolean =
+    elems.forall(_ != VariableAccess)
+
+  def apply(): Elements =
+    empty
+}
+
+final class Elements private (val elements: Array[AccessElement] = Array[AccessElement]()) {
+
+  def noOvertaint(start: Int = 0, untilExclusive: Int = elements.length): Boolean = {
+    elements
+      .slice(start, untilExclusive)
+      .find {
+        case (VariablePointerShift | VariableAccess) => true
+        case _                                       => false
+      }
+      .map(_ => false)
+      .getOrElse(true)
+  }
+
+  def invertibleTailLength: Int = {
+
+    /**
+      * In all sane situations, invertibleTailLength is 0 or 1:
+      *   - we don't expect <i> &, because you cannot take the address of pointer+i (can only take address of rvalue)
+      *   - we don't expect & <i>: The & should have collapsed against a preceding *.
+      * An example where this occurs is (&(ptr->field))[1], which becomes ptr: * field & <2> *
+      * This reads the _next_ field: It doesn't alias with ptr->field at all, but reads the next bytes in the struct,
+      * after field.
+      *
+      * Such code is very un-idiomatic.
+      */
+    var i = 0
+    val nElements = elements.length - 1
+    while (nElements - i > -1) {
+      elements(nElements - i) match {
+        case (AddressOf | VariablePointerShift | _: PointerShift) => i += 1
+        case _                                                    => return i
+      }
+    }
+    i
+  }
+
+  def canEqual(that: Any): Boolean = that.isInstanceOf[Elements]
+
+  override def equals(that: Any): Boolean = {
+    that match {
+      case thatElements: Elements =>
+        Array.equals(elements.asInstanceOf[Array[AnyRef]], thatElements.elements.asInstanceOf[Array[AnyRef]])
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = java.util.Arrays.hashCode(elements.asInstanceOf[Array[AnyRef]])
+
+  def :+(element: AccessElement): Elements = {
+    element match {
+      case _ if !elements.isEmpty =>
+        (elements.last, element) match {
+          case (last: PointerShift, elem: PointerShift) => {
+            val newOffset = last.logicalOffset + elem.logicalOffset
+
+            if (newOffset == 0) Elements.newIfNonEmpty(elements.dropRight(1))
+            else
+              Elements.newIfNonEmpty(elements.updated(elements.length - 1, PointerShift(newOffset)))
+          }
+          case (_: PointerShift, VariablePointerShift) => {
+            new Elements(elements.updated(elements.length - 1, VariablePointerShift))
+          }
+          case (VariablePointerShift, _: PointerShift) | (VariablePointerShift, VariablePointerShift) =>
+            this
+          case (AddressOf, IndirectionAccess) => {
+            Elements.newIfNonEmpty(elements.dropRight(1))
+          }
+          case (IndirectionAccess, AddressOf) => {
+
+            /** We also collapse *&. This is WRONG (you cannot deref a pointer and then un-deref the result).
+              * However, it is sometimes valid as a syntactic construct, and the language should make sure that this
+              * only occurs in such settings.
+              * I.e. valid code should only produce such paths when their contraction is valid.
+              * We still treat * as un-invertible, though!
+              */
+            Elements.newIfNonEmpty(elements.dropRight(1))
+          }
+          case _ => Elements.newIfNonEmpty(elements :+ element)
+        }
+      case PointerShift(0) =>
+        Elements.empty
+      case _ =>
+        Elements.newIfNonEmpty(Array(element))
+    }
+  }
+
+  def ++(otherElements: Elements): Elements = {
+
+    if (elements.isEmpty) return otherElements
+    if (otherElements.isEmpty) return this
+
+    var buf = None: Option[AccessElement]
+    val otherSize = otherElements.elements.length
+    var idx = 0
+    val until = scala.math.min(elements.length, otherSize)
+    var done = false
+
+    while (idx < until & !done) {
+      (elements(elements.length - idx - 1), otherElements.elements(idx)) match {
+        case (AddressOf, IndirectionAccess) =>
+          idx += 1
+        case (IndirectionAccess, AddressOf) =>
+          // WRONG but useful, cf comment for `Elements.:+`
+          idx += 1
+        case (VariablePointerShift, VariablePointerShift) | (_: PointerShift, VariablePointerShift) |
+            (VariablePointerShift, _: PointerShift) =>
+          done = true
+          buf = Some(VariablePointerShift)
+          idx += 1
+        case (last: PointerShift, first: PointerShift) =>
+          val newOffset = last.logicalOffset + first.logicalOffset
+          if (newOffset != 0) {
+            done = true
+            buf = Some(PointerShift(newOffset))
+          }
+          idx += 1
+        case _ =>
+          done = true
+      }
+    }
+    val sz = elements.length + otherSize - 2 * idx + (if (buf != None) 1 else 0)
+    val res = Array.fill(sz) { null }: Array[AccessElement]
+    elements.copyToArray(res, 0, elements.length - idx)
+    if (buf != None) {
+      res(elements.length - idx) = buf.get
+      java.lang.System.arraycopy(otherElements.elements, idx, res, elements.length - idx + 1, otherSize - idx)
+    } else {
+      java.lang.System.arraycopy(otherElements.elements, idx, res, elements.length - idx, otherSize - idx)
+    }
+    Elements.newIfNonEmpty(res)
+  }
+
+  def isEmpty: Boolean = elements.isEmpty
+
+  override def toString(): String = s"Elements(${elements.mkString(",")})"
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/MemberAccessToElement.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/MemberAccessToElement.scala
@@ -1,0 +1,98 @@
+package io.shiftleft.semanticcpg.accesspath
+
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, Operators, nodes}
+import io.shiftleft.semanticcpg.utils.ExpandTo
+import org.slf4j.LoggerFactory
+import scala.jdk.CollectionConverters._
+
+object MemberAccessToElement {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def convert(memberAccess: nodes.Call): Elements = {
+    memberAccess.name match {
+      case Operators.memberAccess | Operators.indirectMemberAccess => {
+        val memberOption = memberAccess
+          .out(EdgeTypes.ARGUMENT)
+          .asScala
+          .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2)
+        Elements.normalized(List(ConstantAccess(memberOption.get.property(NodeKeys.NAME))))
+      }
+      case Operators.computedMemberAccess | Operators.indirectComputedMemberAccess => {
+        val memberOption = memberAccess
+          .out(EdgeTypes.ARGUMENT)
+          .asScala
+          .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2)
+
+        memberOption match {
+          case Some(member) =>
+            member match {
+              case literal: nodes.Literal =>
+                Elements.normalized(List(ConstantAccess(literal.code)))
+              case _ =>
+                Elements.normalized(List(VariableAccess))
+            }
+          case None =>
+            logger.warn(
+              s"Invalid AST: Found member access without second argument." +
+                s" Member access CODE: ${memberAccess.code}" +
+                s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
+            Elements.normalized(List(VariableAccess))
+        }
+      }
+      case Operators.indirection => Elements.normalized(IndirectionAccess)
+      case Operators.addressOf   => Elements.normalized(AddressOf)
+      case Operators.fieldAccess | Operators.indexAccess =>
+        Elements.normalized(extractAccessStringToken(memberAccess))
+      case Operators.indirectFieldAccess =>
+        Elements.normalized(IndirectionAccess, extractAccessStringToken(memberAccess))
+      case Operators.indirectIndexAccess =>
+        Elements.normalized(extractAccessIntToken(memberAccess), IndirectionAccess)
+      case Operators.pointerShift =>
+        Elements.normalized(extractAccessIntToken(memberAccess))
+      case Operators.getElementPtr =>
+        Elements.normalized(IndirectionAccess, extractAccessStringToken(memberAccess), AddressOf)
+    }
+  }
+
+  private def extractAccessStringToken(memberAccess: nodes.Call): AccessElement = {
+    memberAccess
+      .out(EdgeTypes.ARGUMENT)
+      .asScala
+      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2) match {
+      case None => {
+        logger.warn(
+          s"Invalid AST: Found member access without second argument." +
+            s" Member access CODE: ${memberAccess.code}" +
+            s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
+        VariableAccess
+      }
+      case Some(literal: nodes.Literal) => ConstantAccess(literal.code)
+      case Some(fieldIdentifier: nodes.FieldIdentifier) =>
+        ConstantAccess(fieldIdentifier.canonicalName)
+      case _ => VariableAccess
+    }
+  }
+  private def extractAccessIntToken(memberAccess: nodes.Call): AccessElement = {
+    memberAccess
+      .out(EdgeTypes.ARGUMENT)
+      .asScala
+      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2) match {
+      case None => {
+        logger.warn(
+          s"Invalid AST: Found member access without second argument." +
+            s" Member access CODE: ${memberAccess.code}" +
+            s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
+        VariablePointerShift
+      }
+      case Some(literal: nodes.Literal) =>
+        literal.code.toIntOption.map { PointerShift(_) }.getOrElse(VariablePointerShift)
+      case Some(fieldIdentifier: nodes.FieldIdentifier) =>
+        fieldIdentifier.canonicalName.toIntOption
+          .map { PointerShift(_) }
+          .getOrElse(VariablePointerShift)
+      case _ => VariablePointerShift
+    }
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/MemberAccessToElement.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/MemberAccessToElement.scala
@@ -9,7 +9,7 @@ object MemberAccessToElement {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
-  def convert(memberAccess: nodes.Call): Elements = {
+  def apply(memberAccess: nodes.Call): Elements = {
     memberAccess.name match {
       case Operators.memberAccess | Operators.indirectMemberAccess => {
         val memberOption = memberAccess
@@ -86,10 +86,10 @@ object MemberAccessToElement {
         VariablePointerShift
       }
       case Some(literal: nodes.Literal) =>
-        literal.code.toIntOption.map { PointerShift(_) }.getOrElse(VariablePointerShift)
+        literal.code.toIntOption.map(PointerShift).getOrElse(VariablePointerShift)
       case Some(fieldIdentifier: nodes.FieldIdentifier) =>
         fieldIdentifier.canonicalName.toIntOption
-          .map { PointerShift(_) }
+          .map(PointerShift)
           .getOrElse(VariablePointerShift)
       case _ => VariablePointerShift
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/TrackingPointToElements.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/TrackingPointToElements.scala
@@ -1,0 +1,43 @@
+package io.shiftleft.semanticcpg.accesspath
+
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
+import io.shiftleft.codepropertygraph.generated.nodes.TrackingPoint
+import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointMethodsBase
+import io.shiftleft.semanticcpg.utils.MemberAccess
+import scala.jdk.CollectionConverters._
+
+object TrackingPointToElements {
+
+  def apply(node: nodes.TrackingPoint): Elements = {
+    node match {
+      case call: nodes.Call => convertCall(call)
+      case block: nodes.Block =>
+        val lastInBlock = TrackingPointMethodsBase.lastExpressionInBlock(block).get
+        TrackingPointToElements.apply(lastInBlock)
+      case _: nodes.MethodParameterIn  => Elements()
+      case _: nodes.MethodParameterOut => Elements()
+      case _: nodes.MethodReturn       => Elements()
+      case _: nodes.ImplicitCall       => Elements()
+      case _: nodes.Expression         => Elements()
+      case _: nodes.TrackingPoint      => Elements()
+    }
+  }
+
+  private def firstArgument(call: nodes.Call): TrackingPoint = {
+    call
+      .out(EdgeTypes.ARGUMENT)
+      .asScala
+      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 1)
+      .get
+      .asInstanceOf[nodes.TrackingPoint]
+  }
+
+  private def convertCall(call: nodes.Call): Elements = {
+    if (MemberAccess.isGenericMemberAccessName(call.name)) {
+      val baseElements = TrackingPointToElements.apply(firstArgument(call))
+      baseElements ++ MemberAccessToElement(call)
+    } else {
+      Elements()
+    }
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/TrackingPointToTrackedBase.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/TrackingPointToTrackedBase.scala
@@ -1,0 +1,68 @@
+package io.shiftleft.semanticcpg.accesspath
+
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
+import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointMethodsBase
+import io.shiftleft.semanticcpg.utils.MemberAccess
+import scala.jdk.CollectionConverters._
+
+trait TrackedBase
+case class TrackedNamedVariable(name: String) extends TrackedBase
+case class TrackedReturnValue(call: nodes.CallRepr) extends TrackedBase {
+  override def toString: String = {
+    s"TrackedReturnValue(${call.code})"
+  }
+}
+case class TrackedLiteral(literal: nodes.Literal) extends TrackedBase {
+  override def toString: String = {
+    s"TrackedLiteral(${literal.code})"
+  }
+}
+case class TrackedMethodOrTypeRef(methodOrTypeRef: nodes.StoredNode with nodes.HasCode) extends TrackedBase {
+  override def toString: String = {
+    s"TrackedMethodOrTypeRef(${methodOrTypeRef.code})"
+  }
+}
+
+object TrackedUnknown extends TrackedBase {
+  override def toString: String = {
+    "TrackedUnknown"
+  }
+}
+object TrackedFormalReturn extends TrackedBase {
+  override def toString: String = {
+    "TrackedFormalReturn"
+  }
+}
+
+object TrackingPointToTrackedBase {
+  def apply(node: nodes.TrackingPoint): TrackedBase = node match {
+    case node: nodes.MethodParameterIn  => TrackedNamedVariable(node.name)
+    case node: nodes.MethodParameterOut => TrackedNamedVariable(node.name)
+    case node: nodes.ImplicitCall       => TrackedReturnValue(node)
+    case node: nodes.Identifier         => TrackedNamedVariable(node.name)
+    case node: nodes.Literal            => TrackedLiteral(node)
+    case node: nodes.MethodRef          => TrackedMethodOrTypeRef(node)
+    case node: nodes.TypeRef            => TrackedMethodOrTypeRef(node)
+    case _: nodes.Return                => TrackedFormalReturn
+    case _: nodes.MethodReturn          => TrackedFormalReturn
+    case _: nodes.Unknown               => TrackedUnknown
+    case block: nodes.Block             => this(TrackingPointMethodsBase.lastExpressionInBlock(block).get)
+    case call: nodes.Call               => handleCall(call)
+    // FieldIdentifiers are only fake arguments, hence should not be tracked
+    case _: nodes.FieldIdentifier => TrackedUnknown
+  }
+
+  def handleCall(call: nodes.Call): TrackedBase = {
+    if (MemberAccess.isGenericMemberAccessName(call.name)) {
+      val trackingPoint = call
+        .out(EdgeTypes.ARGUMENT)
+        .asScala
+        .find(_.property(NodeKeys.ARGUMENT_INDEX) == 1)
+        .get
+        .asInstanceOf[nodes.TrackingPoint]
+      this(trackingPoint)
+    } else {
+      TrackedReturnValue(call)
+    }
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
@@ -3,11 +3,10 @@ package io.shiftleft.semanticcpg.language.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.utils.MemberAccess
-import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 
-private object TrackingPointMethodsBase {
+object TrackingPointMethodsBase {
   def lastExpressionInBlock(block: nodes.Block): Option[nodes.Expression] =
     block._astOut.asScala
       .collect {
@@ -30,6 +29,7 @@ object TrackingPointToCfgNode {
     node match {
       case node: nodes.Identifier => parentExpansion(node)
       case node: nodes.MethodRef  => parentExpansion(node)
+      case node: nodes.TypeRef    => parentExpansion(node)
       case node: nodes.Literal    => parentExpansion(node)
 
       case node: nodes.MethodParameterIn => node.method

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
@@ -1,0 +1,55 @@
+package io.shiftleft.semanticcpg.language.nodemethods
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.utils.MemberAccess
+import overflowdb.traversal._
+
+import scala.jdk.CollectionConverters._
+
+private object TrackingPointMethodsBase {
+  def lastExpressionInBlock(block: nodes.Block): Option[nodes.Expression] =
+    block._astOut.asScala
+      .collect {
+        case node: nodes.Expression if !node.isInstanceOf[nodes.Local] && !node.isInstanceOf[nodes.Method] => node
+      }
+      .toVector
+      .sortBy(_.order)
+      .lastOption
+}
+
+object TrackingPointToCfgNode {
+  def apply(node: nodes.TrackingPointBase): nodes.CfgNode = {
+    applyInternal(node, _.parentExpression.get)
+  }
+
+  @scala.annotation.tailrec
+  private def applyInternal(node: nodes.TrackingPointBase,
+                            parentExpansion: nodes.Expression => nodes.Expression): nodes.CfgNode = {
+
+    node match {
+      case node: nodes.Identifier => parentExpansion(node)
+      case node: nodes.MethodRef  => parentExpansion(node)
+      case node: nodes.Literal    => parentExpansion(node)
+
+      case node: nodes.MethodParameterIn => node.method
+
+      case node: nodes.MethodParameterOut =>
+        node.method.methodReturn
+
+      case node: nodes.Call if MemberAccess.isGenericMemberAccessName(node.name) =>
+        parentExpansion(node)
+
+      case node: nodes.Call         => node
+      case node: nodes.ImplicitCall => node
+      case node: nodes.MethodReturn => node
+      case block: nodes.Block       =>
+        // Just taking the lastExpressionInBlock is not quite correct because a BLOCK could have
+        // different return expressions. So we would need to expand via CFG.
+        // But currently the frontends do not even put the BLOCK into the CFG so this is the best
+        // we can do.
+        applyInternal(TrackingPointMethodsBase.lastExpressionInBlock(block).get, identity)
+      case node: nodes.Expression => node
+    }
+  }
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
@@ -1,8 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.TrackingPoint
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
-import io.shiftleft.semanticcpg.accesspath.{Elements, MemberAccessToElement}
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.utils.MemberAccess
 
@@ -54,46 +52,6 @@ object TrackingPointToCfgNode {
         // we can do.
         applyInternal(TrackingPointMethodsBase.lastExpressionInBlock(block).get, identity)
       case node: nodes.Expression => node
-    }
-  }
-}
-
-object TrackingPointToElements {
-
-  def apply(node: nodes.TrackingPoint): Elements = {
-    convertRealNode(node)
-  }
-
-  private def convertRealNode(node: nodes.TrackingPoint): Elements = {
-    node match {
-      case call: nodes.Call => convertCall(call)
-      case block: nodes.Block =>
-        val lastInBlock = TrackingPointMethodsBase.lastExpressionInBlock(block).get
-        TrackingPointToElements.apply(lastInBlock)
-      case _: nodes.MethodParameterIn  => Elements()
-      case _: nodes.MethodParameterOut => Elements()
-      case _: nodes.MethodReturn       => Elements()
-      case _: nodes.ImplicitCall       => Elements()
-      case _: nodes.Expression         => Elements()
-      case _: nodes.TrackingPoint      => Elements()
-    }
-  }
-
-  private def firstArgument(call: nodes.Call): TrackingPoint = {
-    call
-      .out(EdgeTypes.ARGUMENT)
-      .asScala
-      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 1)
-      .get
-      .asInstanceOf[nodes.TrackingPoint]
-  }
-
-  private def convertCall(call: nodes.Call): Elements = {
-    if (MemberAccess.isGenericMemberAccessName(call.name)) {
-      val baseElements = TrackingPointToElements.apply(firstArgument(call))
-      baseElements ++ MemberAccessToElement.convert(call)
-    } else {
-      Elements()
     }
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
@@ -1,10 +1,14 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.TrackingPoint
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
+import io.shiftleft.semanticcpg.accesspath.{Elements, MemberAccessToElement}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.utils.MemberAccess
 
 import scala.jdk.CollectionConverters._
+
+// Utility methods for dealing with tracking points
 
 object TrackingPointMethodsBase {
   def lastExpressionInBlock(block: nodes.Block): Option[nodes.Expression] =
@@ -50,6 +54,46 @@ object TrackingPointToCfgNode {
         // we can do.
         applyInternal(TrackingPointMethodsBase.lastExpressionInBlock(block).get, identity)
       case node: nodes.Expression => node
+    }
+  }
+}
+
+object TrackingPointToElements {
+
+  def apply(node: nodes.TrackingPoint): Elements = {
+    convertRealNode(node)
+  }
+
+  private def convertRealNode(node: nodes.TrackingPoint): Elements = {
+    node match {
+      case call: nodes.Call => convertCall(call)
+      case block: nodes.Block =>
+        val lastInBlock = TrackingPointMethodsBase.lastExpressionInBlock(block).get
+        TrackingPointToElements.apply(lastInBlock)
+      case _: nodes.MethodParameterIn  => Elements()
+      case _: nodes.MethodParameterOut => Elements()
+      case _: nodes.MethodReturn       => Elements()
+      case _: nodes.ImplicitCall       => Elements()
+      case _: nodes.Expression         => Elements()
+      case _: nodes.TrackingPoint      => Elements()
+    }
+  }
+
+  private def firstArgument(call: nodes.Call): TrackingPoint = {
+    call
+      .out(EdgeTypes.ARGUMENT)
+      .asScala
+      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 1)
+      .get
+      .asInstanceOf[nodes.TrackingPoint]
+  }
+
+  private def convertCall(call: nodes.Call): Elements = {
+    if (MemberAccess.isGenericMemberAccessName(call.name)) {
+      val baseElements = TrackingPointToElements.apply(firstArgument(call))
+      baseElements ++ MemberAccessToElement.convert(call)
+    } else {
+      Elements()
     }
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/MemberAccess.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/MemberAccess.scala
@@ -1,8 +1,14 @@
 package io.shiftleft.semanticcpg.utils
 
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, Operators, nodes}
+import io.shiftleft.semanticcpg.accesspath._
+import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters._
 
 object MemberAccess {
+
+  private val logger = LoggerFactory.getLogger(getClass)
 
   /**
     * For a given name, determine whether it is the
@@ -22,6 +28,92 @@ object MemberAccess {
     (name == Operators.indirectIndexAccess) ||
     (name == Operators.pointerShift) ||
     (name == Operators.getElementPtr)
+  }
+
+  def memberAccessToElement(memberAccess: nodes.Call): Elements = {
+    memberAccess.name match {
+      case Operators.memberAccess | Operators.indirectMemberAccess => {
+        val memberOption = memberAccess
+          .out(EdgeTypes.ARGUMENT)
+          .asScala
+          .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2)
+        Elements.normalized(List(ConstantAccess(memberOption.get.property(NodeKeys.NAME))))
+      }
+      case Operators.computedMemberAccess | Operators.indirectComputedMemberAccess => {
+        val memberOption = memberAccess
+          .out(EdgeTypes.ARGUMENT)
+          .asScala
+          .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2)
+
+        memberOption match {
+          case Some(member) =>
+            member match {
+              case literal: nodes.Literal =>
+                Elements.normalized(List(ConstantAccess(literal.code)))
+              case _ =>
+                Elements.normalized(List(VariableAccess))
+            }
+          case None =>
+            logger.warn(
+              s"Invalid AST: Found member access without second argument." +
+                s" Member access CODE: ${memberAccess.code}" +
+                s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
+            Elements.normalized(List(VariableAccess))
+        }
+      }
+      case Operators.indirection => Elements.normalized(IndirectionAccess)
+      case Operators.addressOf   => Elements.normalized(AddressOf)
+      case Operators.fieldAccess | Operators.indexAccess =>
+        Elements.normalized(extractAccessStringToken(memberAccess))
+      case Operators.indirectFieldAccess =>
+        Elements.normalized(IndirectionAccess, extractAccessStringToken(memberAccess))
+      case Operators.indirectIndexAccess =>
+        Elements.normalized(extractAccessIntToken(memberAccess), IndirectionAccess)
+      case Operators.pointerShift =>
+        Elements.normalized(extractAccessIntToken(memberAccess))
+      case Operators.getElementPtr =>
+        Elements.normalized(IndirectionAccess, extractAccessStringToken(memberAccess), AddressOf)
+    }
+  }
+
+  private def extractAccessStringToken(memberAccess: nodes.Call): AccessElement = {
+    memberAccess
+      .out(EdgeTypes.ARGUMENT)
+      .asScala
+      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2) match {
+      case None => {
+        logger.warn(
+          s"Invalid AST: Found member access without second argument." +
+            s" Member access CODE: ${memberAccess.code}" +
+            s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
+        VariableAccess
+      }
+      case Some(literal: nodes.Literal) => ConstantAccess(literal.code)
+      case Some(fieldIdentifier: nodes.FieldIdentifier) =>
+        ConstantAccess(fieldIdentifier.canonicalName)
+      case _ => VariableAccess
+    }
+  }
+  private def extractAccessIntToken(memberAccess: nodes.Call): AccessElement = {
+    memberAccess
+      .out(EdgeTypes.ARGUMENT)
+      .asScala
+      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2) match {
+      case None => {
+        logger.warn(
+          s"Invalid AST: Found member access without second argument." +
+            s" Member access CODE: ${memberAccess.code}" +
+            s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
+        VariablePointerShift
+      }
+      case Some(literal: nodes.Literal) =>
+        literal.code.toIntOption.map { PointerShift(_) }.getOrElse(VariablePointerShift)
+      case Some(fieldIdentifier: nodes.FieldIdentifier) =>
+        fieldIdentifier.canonicalName.toIntOption
+          .map { PointerShift(_) }
+          .getOrElse(VariablePointerShift)
+      case _ => VariablePointerShift
+    }
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/MemberAccess.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/utils/MemberAccess.scala
@@ -1,14 +1,8 @@
 package io.shiftleft.semanticcpg.utils
 
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, Operators, nodes}
-import io.shiftleft.semanticcpg.accesspath._
-import org.slf4j.LoggerFactory
-
-import scala.jdk.CollectionConverters._
+import io.shiftleft.codepropertygraph.generated.Operators
 
 object MemberAccess {
-
-  private val logger = LoggerFactory.getLogger(getClass)
 
   /**
     * For a given name, determine whether it is the
@@ -28,92 +22,6 @@ object MemberAccess {
     (name == Operators.indirectIndexAccess) ||
     (name == Operators.pointerShift) ||
     (name == Operators.getElementPtr)
-  }
-
-  def memberAccessToElement(memberAccess: nodes.Call): Elements = {
-    memberAccess.name match {
-      case Operators.memberAccess | Operators.indirectMemberAccess => {
-        val memberOption = memberAccess
-          .out(EdgeTypes.ARGUMENT)
-          .asScala
-          .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2)
-        Elements.normalized(List(ConstantAccess(memberOption.get.property(NodeKeys.NAME))))
-      }
-      case Operators.computedMemberAccess | Operators.indirectComputedMemberAccess => {
-        val memberOption = memberAccess
-          .out(EdgeTypes.ARGUMENT)
-          .asScala
-          .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2)
-
-        memberOption match {
-          case Some(member) =>
-            member match {
-              case literal: nodes.Literal =>
-                Elements.normalized(List(ConstantAccess(literal.code)))
-              case _ =>
-                Elements.normalized(List(VariableAccess))
-            }
-          case None =>
-            logger.warn(
-              s"Invalid AST: Found member access without second argument." +
-                s" Member access CODE: ${memberAccess.code}" +
-                s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
-            Elements.normalized(List(VariableAccess))
-        }
-      }
-      case Operators.indirection => Elements.normalized(IndirectionAccess)
-      case Operators.addressOf   => Elements.normalized(AddressOf)
-      case Operators.fieldAccess | Operators.indexAccess =>
-        Elements.normalized(extractAccessStringToken(memberAccess))
-      case Operators.indirectFieldAccess =>
-        Elements.normalized(IndirectionAccess, extractAccessStringToken(memberAccess))
-      case Operators.indirectIndexAccess =>
-        Elements.normalized(extractAccessIntToken(memberAccess), IndirectionAccess)
-      case Operators.pointerShift =>
-        Elements.normalized(extractAccessIntToken(memberAccess))
-      case Operators.getElementPtr =>
-        Elements.normalized(IndirectionAccess, extractAccessStringToken(memberAccess), AddressOf)
-    }
-  }
-
-  private def extractAccessStringToken(memberAccess: nodes.Call): AccessElement = {
-    memberAccess
-      .out(EdgeTypes.ARGUMENT)
-      .asScala
-      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2) match {
-      case None => {
-        logger.warn(
-          s"Invalid AST: Found member access without second argument." +
-            s" Member access CODE: ${memberAccess.code}" +
-            s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
-        VariableAccess
-      }
-      case Some(literal: nodes.Literal) => ConstantAccess(literal.code)
-      case Some(fieldIdentifier: nodes.FieldIdentifier) =>
-        ConstantAccess(fieldIdentifier.canonicalName)
-      case _ => VariableAccess
-    }
-  }
-  private def extractAccessIntToken(memberAccess: nodes.Call): AccessElement = {
-    memberAccess
-      .out(EdgeTypes.ARGUMENT)
-      .asScala
-      .find(_.property(NodeKeys.ARGUMENT_INDEX) == 2) match {
-      case None => {
-        logger.warn(
-          s"Invalid AST: Found member access without second argument." +
-            s" Member access CODE: ${memberAccess.code}" +
-            s" In method ${ExpandTo.expressionToMethod(memberAccess).property(NodeKeys.FULL_NAME)}")
-        VariablePointerShift
-      }
-      case Some(literal: nodes.Literal) =>
-        literal.code.toIntOption.map { PointerShift(_) }.getOrElse(VariablePointerShift)
-      case Some(fieldIdentifier: nodes.FieldIdentifier) =>
-        fieldIdentifier.canonicalName.toIntOption
-          .map { PointerShift(_) }
-          .getOrElse(VariablePointerShift)
-      case _ => VariablePointerShift
-    }
   }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/accesspath/AccessPathTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/accesspath/AccessPathTests.scala
@@ -1,0 +1,141 @@
+package io.shiftleft.semanticcpg.accesspath
+
+import io.shiftleft.semanticcpg.accesspath.MatchResult._
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+
+class AccessPathTests extends AnyWordSpec {
+  implicit def convert(constant: String): ConstantAccess = {
+    ConstantAccess(constant)
+  }
+  implicit def convert(constant: Int): PointerShift = PointerShift(constant)
+
+  def E(elements: AccessElement*): Elements = {
+    Elements.normalized(elements)
+  }
+
+  val V = VariableAccess
+  val I = IndirectionAccess
+  val A = AddressOf
+  val VP = VariablePointerShift
+
+  "Test matchPath" in {
+    AccessPath(E("a"), Seq()).matchAndDiff(E("b")) shouldBe (NO_MATCH, E())
+    AccessPath(E("a", "b"), Seq()).matchAndDiff(E("b", "a")) shouldBe (NO_MATCH, E())
+    AccessPath(E("a", "b"), Seq()).matchAndDiff(E("a", "c")) shouldBe (NO_MATCH, E())
+    AccessPath(E("a", V), Seq()).matchAndDiff(E("b", V)) shouldBe (NO_MATCH, E())
+    AccessPath(E("a", V), Seq()).matchAndDiff(E("b")) shouldBe (NO_MATCH, E())
+    AccessPath(E("a"), Seq()).matchAndDiff(E("b", V)) shouldBe (NO_MATCH, E())
+    AccessPath(E("a", V, "b"), Seq()).matchAndDiff(E("b", V, "a")) shouldBe (NO_MATCH, E())
+    AccessPath(E("a", I), Seq()).matchAndDiff(E(I)) shouldBe (NO_MATCH, E())
+    AccessPath(E("a", I), Seq()).matchAndDiff(E("a", V)) shouldBe (NO_MATCH, E())
+
+    AccessPath(E("a", "b"), Seq()).matchAndDiff(E("a")) shouldBe (PREFIX_MATCH, E("b"))
+    AccessPath(E("a", V), Seq()).matchAndDiff(E("a")) shouldBe (PREFIX_MATCH, E(V))
+
+    AccessPath(E(V, "a"), Seq()).matchAndDiff(E(V)) shouldBe (VARIABLE_PREFIX_MATCH, E("a"))
+
+    AccessPath(E("a"), Seq()).matchAndDiff(E("a")) shouldBe (EXACT_MATCH, E())
+    AccessPath(E("a", "b"), Seq()).matchAndDiff(E("a", "b")) shouldBe (EXACT_MATCH, E())
+
+    AccessPath(E("a"), Seq()).matchAndDiff(E(V)) shouldBe (VARIABLE_EXACT_MATCH, E())
+    AccessPath(E(V), Seq()).matchAndDiff(E("a")) shouldBe (VARIABLE_EXACT_MATCH, E())
+    AccessPath(E("a", "b"), Seq()).matchAndDiff(E("a", V)) shouldBe (VARIABLE_EXACT_MATCH, E())
+    AccessPath(E(V, "b"), Seq()).matchAndDiff(E(V, "b")) shouldBe (VARIABLE_EXACT_MATCH, E())
+    AccessPath(E("a", V), Seq()).matchAndDiff(E(V, V)) shouldBe (VARIABLE_EXACT_MATCH, E())
+    AccessPath(E(V, "a"), Seq()).matchAndDiff(E(V, V)) shouldBe (VARIABLE_EXACT_MATCH, E())
+    AccessPath(E(V, V), Seq()).matchAndDiff(E("a", V)) shouldBe (VARIABLE_EXACT_MATCH, E())
+    AccessPath(E(V, V), Seq()).matchAndDiff(E(V, "a")) shouldBe (VARIABLE_EXACT_MATCH, E())
+
+    AccessPath(E(), Seq()).matchAndDiff(E("a")) shouldBe (EXTENDED_MATCH, E("a"))
+    AccessPath(E("a"), Seq()).matchAndDiff(E("a", "b")) shouldBe (EXTENDED_MATCH, E("b"))
+    AccessPath(E("a"), Seq()).matchAndDiff(E("a", V)) shouldBe (EXTENDED_MATCH, E(V))
+
+    AccessPath(E("a"), Seq()).matchAndDiff(E(V, "b")) shouldBe (VARIABLE_EXTENDED_MATCH, E("b"))
+
+    AccessPath(E("a"), Seq(E("b"))).matchAndDiff(E("a", "b", "c")) shouldBe (NO_MATCH, E())
+    AccessPath(E("a"), Seq(E("b"))).matchAndDiff(E("a", "b", V)) shouldBe (NO_MATCH, E())
+    AccessPath(E("a"), Seq(E("b", "c"))).matchAndDiff(E("a", "b")) shouldBe (EXTENDED_MATCH, E("b"))
+
+    AccessPath(E("a"), Seq(E("b"))).matchAndDiff(E("a", "b")) shouldBe (NO_MATCH, E())
+    AccessPath(E("a"), Seq(E("c"))).matchAndDiff(E("a", "b")) shouldBe (EXTENDED_MATCH, E("b"))
+    AccessPath(E(V), Seq(E("b"))).matchAndDiff(E("a", "b")) shouldBe (VARIABLE_EXTENDED_MATCH, E("b"))
+  }
+  "Test normalization and concatenation" in {
+    E(A, 0, I) shouldBe E()
+    E(2, -1, "a", I, 3, -5, 2, A) shouldBe E(1, "a")
+    E(2) ++ E(-1) ++ E("a") ++ E(I) ++ E(3) ++ E(-5) ++ E(2) ++ E(A) shouldBe E(1, "a")
+    E(2) :+ PointerShift(-1) :+ ConstantAccess("a") :+ I :+ PointerShift(3) :+ PointerShift(-5) :+ PointerShift(2) :+ A shouldBe E(
+      1,
+      "a")
+
+    E("a", 3, A, 4, I, 4, I) ++ E(A, -4, A, -4, I, -3) shouldBe E("a")
+    Elements.inverted(E("a", 3, A, 4, I, 4, I).elements.drop(1)) shouldBe E(A, -4, A, -4, I, -3)
+    E(A, 1, VP, 2, I) shouldBe E(A, VP, I)
+    E(I, "a", A) ++ E(I) shouldBe E(I, "a") //GEP
+  }
+  "Test matchPath with inverses" in {
+    //exact:
+    AccessPath(E("a", 1, A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", 8, A, 16)) shouldBe (EXACT_MATCH, E(-16, I, -7, A, 2))
+    AccessPath(E("a", 1, A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", 8, A, 16, I)) shouldBe (EXTENDED_MATCH, E(-2, I, 7, A, 16, I))
+    AccessPath(E("a", 1, A, 2, I), Seq(E("c")))
+      .matchAndDiff(E("a", 8, A, 16)) shouldBe (PREFIX_MATCH, E(-16, I, -7, A, 2, I))
+
+    AccessPath(E("a", 1, A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", 8, A, 16)) shouldBe (EXACT_MATCH, E(-16, I, -7, A, 2))
+
+    AccessPath(E("a", 1, A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", 8, A, 16, I)) shouldBe (EXTENDED_MATCH, E(-2, I, 7, A, 16, I))
+
+    AccessPath(E("a", VP, A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", 8, A, 16, I)) shouldBe (VARIABLE_EXTENDED_MATCH, E(14, I))
+    AccessPath(E("a", 1, A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", VP, A, 16, I)) shouldBe (VARIABLE_EXTENDED_MATCH, E(14, I))
+    AccessPath(E("a", 1, A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", "b", 8, A, 16)) shouldBe (EXTENDED_MATCH, E(-2, I, -1, "b", 8, A, 16))
+
+    AccessPath(E("a", 1, "b", A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", 8, A, 16)) shouldBe (PREFIX_MATCH, E(-16, I, -7, "b", A, 2))
+    //revisit: could be exact
+    AccessPath(E("a", VP, "b", A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", 8, A, 16)) shouldBe (VARIABLE_PREFIX_MATCH, E(-16, I, "b", A, 2))
+    AccessPath(E("a", 1, "b", A, 2), Seq(E("c")))
+      .matchAndDiff(E("a", VP, A, 16)) shouldBe (VARIABLE_PREFIX_MATCH, E(-16, I, "b", A, 2))
+
+    // example where we track effectively nothing
+    AccessPath(E("a", 1, A, 2), Seq(E(-2, I)))
+      .matchAndDiff(E("a", "b", 8, A, 16)) shouldBe (NO_MATCH, E())
+    //suboptimal:
+    AccessPath(E("a", 1, A, 2), Seq(E(-2, I)))
+      .matchAndDiff(E("a", VP, A, 16, I)) shouldBe (VARIABLE_EXTENDED_MATCH, E(14, I))
+  }
+
+  "Test FullMatch" in {
+    //no match
+    AccessPath(E("a", "b"), Seq(E("c")))
+      .matchFull(AccessPath(E("C"), Seq())) shouldBe FullMatchResult(stepOverPath =
+                                                                       Some(AccessPath(E("a", "b"), Seq(E("c")))),
+                                                                     stepIntoPath = None,
+                                                                     extensionDiff = E())
+    //prefix
+    AccessPath(E("a", "b"), E("c") :: Nil)
+      .matchFull(E("a")) shouldBe FullMatchResult(stepOverPath = None,
+                                                  stepIntoPath = Some(AccessPath(E("b"), E("c") :: Nil)),
+                                                  extensionDiff = E())
+    //extension
+    AccessPath(E("a", "b"), E("c", "d") :: Nil)
+      .matchFull(AccessPath(E("a", "b", "c"), Nil)) shouldBe FullMatchResult(
+      stepOverPath = Some(AccessPath(E("a", "b"), E("c") :: Nil)),
+      stepIntoPath = Some(AccessPath(E(), E("d") :: Nil)),
+      extensionDiff = E("c"))
+    //rhs has exclusions
+    AccessPath(E("a", "b"), E("c") :: Nil)
+      .matchFull(AccessPath(E("a"), E("b") :: Nil)) shouldBe FullMatchResult(
+      stepOverPath = Some(AccessPath(E("a", "b"), E("c") :: Nil)),
+      stepIntoPath = None,
+      extensionDiff = E())
+  }
+
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/accesspath/TrackingPointToElementsTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/accesspath/TrackingPointToElementsTests.scala
@@ -1,0 +1,366 @@
+package io.shiftleft.semanticcpg.accesspath
+
+import io.shiftleft.OverflowDbTestInstance
+import io.shiftleft.codepropertygraph.generated._
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
+
+class TrackingPointToElementsTests extends AnyWordSpec {
+
+  def E(elements: AccessElement*): Elements = {
+    Elements.normalized(elements)
+  }
+
+  private val V = VariableAccess
+  private val I = IndirectionAccess
+  private val C = ConstantAccess
+  private val A = AddressOf
+  private val VS = VariablePointerShift
+  private val S = PointerShift
+
+  private val g = OverflowDbTestInstance.create
+
+  private def genCALL(graph: Graph, op: String, args: Node*): nodes.Call = {
+    val ret = graph + NodeTypes.CALL //(NodeTypes.CALL, NodeKeys.NAME -> op)
+    ret.setProperty(NodeKeys.NAME, op)
+    args.reverse.zipWithIndex.foreach { argTup =>
+      val arg = argTup._1
+      val idx = argTup._2
+      ret --- EdgeTypes.ARGUMENT --> arg
+      arg.setProperty(NodeKeys.ARGUMENT_INDEX, new Integer(idx + 1))
+    }
+    ret.asInstanceOf[nodes.Call]
+  }
+
+  private def genLit(graph: Graph, payload: String): nodes.Literal = {
+    val ret = graph + NodeTypes.LITERAL
+    ret.setProperty(NodeKeys.CODE, payload)
+    ret.asInstanceOf[nodes.Literal]
+  }
+
+  private def genID(graph: Graph, payload: String): nodes.Identifier = {
+    val ret = graph + NodeTypes.IDENTIFIER
+    ret.setProperty(NodeKeys.NAME, payload)
+    ret.asInstanceOf[nodes.Identifier]
+  }
+
+  private def genFID(graph: Graph, payload: String): nodes.FieldIdentifier = {
+    val ret = graph + NodeTypes.FIELD_IDENTIFIER
+    ret.setProperty(NodeKeys.CANONICAL_NAME, payload)
+    ret.asInstanceOf[nodes.FieldIdentifier]
+  }
+
+  "memberAccess" should {
+    "work" in {
+      val call =
+        genCALL(g,
+                Operators.memberAccess,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), C("a"))
+    }
+  }
+
+  "indirectMemberAccess" should {
+    "work" in {
+      val call =
+        genCALL(g,
+                Operators.indirectMemberAccess,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), C("a"))
+    }
+  }
+
+  "computedMemberAccess" should {
+    "work with Literal" in {
+      val call =
+        genCALL(g,
+                Operators.computedMemberAccess,
+                genLit(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), C("a"))
+    }
+    "overtaint with others" in {
+      val call =
+        genCALL(g,
+                Operators.computedMemberAccess,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), V)
+    }
+  }
+
+  "indirectComputedMemberAccess" should {
+    "work with Literal" in {
+      val call =
+        genCALL(g,
+                Operators.indirectComputedMemberAccess,
+                genLit(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), C("a"))
+    }
+    "overtaint with others" in {
+      val call =
+        genCALL(g,
+                Operators.indirectComputedMemberAccess,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), V)
+    }
+
+  }
+
+  "indirection" should {
+    "work" in {
+      val call =
+        genCALL(g, Operators.indirection, genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), I)
+    }
+  }
+
+  "addressOf" should {
+    "work" in {
+      val call =
+        genCALL(g, Operators.addressOf, genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), A)
+    }
+  }
+  // new style
+
+  "FieldAccess" should {
+    "work with Literal" in {
+      val call =
+        genCALL(g,
+                Operators.fieldAccess,
+                genLit(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), C("a"))
+    }
+
+    "work with FieldIdentifier" in {
+      val call =
+        genCALL(g,
+                Operators.fieldAccess,
+                genFID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), C("a"))
+    }
+
+    "overtaint with others" in {
+      val call =
+        genCALL(g,
+                Operators.fieldAccess,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), V)
+    }
+  }
+
+  "IndirectFieldAccess" should {
+    "work with Literal" in {
+      val call =
+        genCALL(g,
+                Operators.indirectFieldAccess,
+                genLit(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), I, C("a"))
+    }
+
+    "work with FieldIdentifier" in {
+      val call =
+        genCALL(g,
+                Operators.indirectFieldAccess,
+                genFID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), I, C("a"))
+    }
+
+    "overtaint with others" in {
+      val call =
+        genCALL(g,
+                Operators.indirectFieldAccess,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), I, V)
+    }
+  }
+
+  "indexAccess" should {
+    "work with Literal" in {
+      val call =
+        genCALL(g,
+                Operators.indexAccess,
+                genLit(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), C("a"))
+    }
+
+    "work with FieldIdentifier" in {
+      val call =
+        genCALL(g,
+                Operators.indexAccess,
+                genFID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), C("a"))
+    }
+
+    "overtaint with others" in {
+      val call =
+        genCALL(g,
+                Operators.indexAccess,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), V)
+    }
+  }
+
+  "indirectIndexAccess" should {
+    "work with Literal" in {
+      val call =
+        genCALL(g,
+                Operators.indirectIndexAccess,
+                genLit(g, "12"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), S(12), I)
+    }
+
+    "work with FieldIdentifier" in {
+      val call =
+        genCALL(g,
+                Operators.indirectIndexAccess,
+                genFID(g, "12"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), S(12), I)
+    }
+
+    "overtaint with others" in {
+      val call =
+        genCALL(g,
+                Operators.indirectIndexAccess,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), VS, I)
+    }
+    "overtaint on parsing failure" in {
+      val call =
+        genCALL(g,
+                Operators.indirectIndexAccess,
+                genLit(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), VS, I)
+    }
+
+  }
+
+  "pointerShft" should {
+    //fixme
+    "work with Literal" in {
+      val call =
+        genCALL(g,
+                Operators.pointerShift,
+                genLit(g, "12"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), S(12))
+    }
+
+    "work with FieldIdentifier" in {
+      val call =
+        genCALL(g,
+                Operators.pointerShift,
+                genFID(g, "12"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), S(12))
+    }
+
+    "overtaint with others" in {
+      val call =
+        genCALL(g,
+                Operators.pointerShift,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), VS)
+    }
+    "overtaint with parsing fails" in {
+      val call =
+        genCALL(g,
+                Operators.pointerShift,
+                genLit(g, "abc"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), VS)
+    }
+
+  }
+
+  "getElementPointer" should {
+    //fixme
+    "work with Literal" in {
+      val call =
+        genCALL(g,
+                Operators.getElementPtr,
+                genLit(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), I, C("a"), A)
+    }
+
+    "work with FieldIdentifier" in {
+      val call =
+        genCALL(g,
+                Operators.getElementPtr,
+                genFID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), I, C("a"), A)
+    }
+
+    "overtaint with others" in {
+      val call =
+        genCALL(g,
+                Operators.getElementPtr,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E(C("b"), I, V, A)
+    }
+  }
+
+  "Others" should {
+    "not expand through" in {
+      val call =
+        genCALL(g,
+                Operators.addition,
+                genID(g, "a"),
+                genCALL(g, Operators.computedMemberAccess, genLit(g, "b"), genCALL(g, "foo")))
+
+      TrackingPointToElements(call) shouldBe E()
+    }
+  }
+
+}


### PR DESCRIPTION
As discussed yesterday, for our open-source release of **redacted** language module, we will need access path support as outlined here: https://github.com/ShiftLeftSecurity/codescience/issues/3198

I have also used this as an opportunity to reduce code duplication between `codescience` and `codepropertygraph`.

This PR carries over @bbrehm's access path work, which I will integrate with the OSS data flow tracker in follow-up PRs.