### PR TITLE
Flow deduplication + new test

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -31,9 +31,13 @@ class TrackingPoint(val traversal: Traversal[nodes.TrackingPoint]) extends AnyVa
   def reachableByFlows[A <: nodes.TrackingPoint](sourceTravs: Traversal[A]*)(
       implicit context: EngineContext): Traversal[Path] = {
     val paths = reachableByInternal(sourceTravs).map { result =>
-      Path(result.path.filter(_.visible == true).map(_.node))
-    }
+      Path(removeConsecutiveDuplicates(result.path.filter(_.visible == true).map(_.node)))
+    }.dedup
     paths.to(Traversal)
+  }
+
+  private def removeConsecutiveDuplicates[T](l: List[T]): List[T] = {
+    l.headOption.map(x => x :: l.sliding(2).collect { case Seq(a, b) if a != b => b }.toList).getOrElse(List())
   }
 
   private def reachableByInternal[NodeType <: nodes.TrackingPoint](sourceTravs: Seq[Traversal[NodeType]])(


### PR DESCRIPTION
The current data flow engine can produce flows with duplicate consecutive elements. Rather than making the algorithm more complex, I am filtering consecutive duplicates before returning flows now. Brings in a new test that would fail without this deduplication.