### PR TITLE
API for traversing the DDG

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -1,6 +1,8 @@
 package io.shiftleft.dataflowengineoss.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.{EdgeKeys, EdgeTypes, nodes}
+import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.dotgenerator.Shared
 import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
 import overflowdb.Node
@@ -8,11 +10,26 @@ import overflowdb.traversal._
 
 object DotDdgGenerator {
 
-  def expand(v: nodes.StoredNode): Iterator[Edge] = {
-    v.start
-      .outE(EdgeTypes.REACHING_DEF)
-      .map(x => Edge(v, x.inNode.asInstanceOf[nodes.StoredNode], x.property(EdgeKeys.VARIABLE)))
-      .iterator
+  def expand(v: nodes.StoredNode)(implicit semantics: Semantics): Iterator[Edge] = {
+
+    val allInEdges = v
+      .inE(EdgeTypes.REACHING_DEF)
+      .map(x => Edge(x.outNode.asInstanceOf[nodes.StoredNode], v, x.property(EdgeKeys.VARIABLE)))
+
+    val edgesFromMethods = allInEdges.filter(_.src.isInstanceOf[nodes.Method])
+
+    v match {
+      case trackingPoint: nodes.TrackingPoint =>
+        trackingPoint
+          .ddgInPathElem()
+          .map(x => Edge(x.node.asInstanceOf[nodes.StoredNode], v, x.inEdgeLabel))
+          .iterator ++ edgesFromMethods.iterator
+      case _ =>
+        v.inE(EdgeTypes.REACHING_DEF)
+          .map(x => Edge(x.outNode.asInstanceOf[nodes.StoredNode], v, x.property(EdgeKeys.VARIABLE)))
+          .iterator
+    }
+
   }
 
   def cfgNodeShouldBeDisplayed(v: Node): Boolean = !(
@@ -21,7 +38,7 @@ object DotDdgGenerator {
       v.isInstanceOf[nodes.JumpTarget]
   )
 
-  def toDotDdg(traversal: Traversal[nodes.Method]): Traversal[String] =
+  def toDotDdg(traversal: Traversal[nodes.Method])(implicit semantics: Semantics): Traversal[String] =
     traversal.map(Shared.dotGraph(_, expand, cfgNodeShouldBeDisplayed))
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -49,7 +49,6 @@ class TrackingPoint(val traversal: Traversal[nodes.TrackingPoint]) extends AnyVa
         .toList
 
     val sinks = traversal.dedup.toList.sortBy(_.id)
-
     new Engine(context).backwards(sinks, sources)
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/dotextension/DdgNodeDot.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/dotextension/DdgNodeDot.scala
@@ -3,14 +3,15 @@ package io.shiftleft.dataflowengineoss.language.dotextension
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.dataflowengineoss.dotgenerator.DotDdgGenerator
 import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language.dotextension.{ImageViewer, Shared}
 import overflowdb.traversal.Traversal
 
 class DdgNodeDot(val traversal: Traversal[nodes.Method]) extends AnyVal {
 
-  def dotDdg: Traversal[String] = DotDdgGenerator.toDotDdg(traversal)
+  def dotDdg(implicit semantics: Semantics): Traversal[String] = DotDdgGenerator.toDotDdg(traversal)
 
-  def plotDotDdg(implicit viewer: ImageViewer): Unit = {
+  def plotDotDdg(implicit viewer: ImageViewer, semantics: Semantics): Unit = {
     Shared.plotAndDisplay(traversal.dotDdg.l, viewer)
   }
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
@@ -1,0 +1,38 @@
+package io.shiftleft.dataflowengineoss.language.nodemethods
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.TrackingPoint
+import io.shiftleft.dataflowengineoss.queryengine.{Engine, PathElement}
+import io.shiftleft.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
+import io.shiftleft.semanticcpg.language.{NoResolve, toExpression}
+import overflowdb.traversal.{NodeOps, Traversal}
+
+class ExpressionMethods[NodeType <: nodes.Expression](val node: NodeType) extends AnyVal {
+
+  def isUsed(implicit semantics: Semantics): Boolean = {
+    val s = semanticsForCallByArg
+    s.isEmpty || s.exists(_.mappings.exists { case (srcIndex, _) => srcIndex == node.order })
+  }
+
+  def isDefined(implicit semantics: Semantics): Boolean = {
+    val s = semanticsForCallByArg
+    s.isEmpty || s.exists(_.mappings.exists { case (_, dstIndex) => dstIndex == node.order })
+  }
+
+  def semanticsForCallByArg(implicit semantics: Semantics): List[FlowSemantic] = {
+    argToMethods(node).flatMap { method =>
+      semantics.forMethod(method.fullName)
+    }
+  }
+
+  private def argToMethods(arg: nodes.Expression): List[nodes.Method] = {
+    arg.start.inCall.l.flatMap { call =>
+      NoResolve.getCalledMethods(call).toList
+    }
+  }
+
+  def ddgIn(path: List[PathElement] = List())(implicit semantics: Semantics): Traversal[TrackingPoint] = {
+    Engine.expandIn(node, path).map(_.node).to(Traversal)
+  }
+
+}

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
@@ -7,16 +7,27 @@ import overflowdb.traversal.NodeOps
 
 class ExpressionMethods[NodeType <: nodes.Expression](val node: NodeType) extends AnyVal {
 
+  /**
+    * Determine whether evaluation of the call this argument is a part of results
+    * in usage of this argument.
+    * */
   def isUsed(implicit semantics: Semantics): Boolean = {
     val s = semanticsForCallByArg
     s.isEmpty || s.exists(_.mappings.exists { case (srcIndex, _) => srcIndex == node.order })
   }
 
+  /**
+    * Determine whether evaluation of the call this argument is a part of results
+    * in definition of this argument.
+    * */
   def isDefined(implicit semantics: Semantics): Boolean = {
     val s = semanticsForCallByArg
     s.isEmpty || s.exists(_.mappings.exists { case (_, dstIndex) => dstIndex == node.order })
   }
 
+  /**
+    * Retrieve flow semantic for the call this argument is a part of.
+    * */
   def semanticsForCallByArg(implicit semantics: Semantics): List[FlowSemantic] = {
     argToMethods(node).flatMap { method =>
       semantics.forMethod(method.fullName)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
@@ -1,11 +1,9 @@
 package io.shiftleft.dataflowengineoss.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.TrackingPoint
-import io.shiftleft.dataflowengineoss.queryengine.{Engine, PathElement}
 import io.shiftleft.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.shiftleft.semanticcpg.language.{NoResolve, toExpression}
-import overflowdb.traversal.{NodeOps, Traversal}
+import overflowdb.traversal.NodeOps
 
 class ExpressionMethods[NodeType <: nodes.Expression](val node: NodeType) extends AnyVal {
 
@@ -29,10 +27,6 @@ class ExpressionMethods[NodeType <: nodes.Expression](val node: NodeType) extend
     arg.start.inCall.l.flatMap { call =>
       NoResolve.getCalledMethods(call).toList
     }
-  }
-
-  def ddgIn(path: List[PathElement] = List())(implicit semantics: Semantics): Traversal[TrackingPoint] = {
-    Engine.expandIn(node, path).map(_.node).to(Traversal)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -30,10 +30,19 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
       implicit context: EngineContext): Traversal[NodeType] =
     node.start.reachableBy(sourceTravs: _*)
 
+  /**
+    * Traverse back in the data dependence graph by one step, taking into account semantics
+    * @param path optional list of path elements that have been expended already
+    * */
   def ddgIn(path: List[PathElement] = List())(implicit semantics: Semantics): Traversal[TrackingPoint] = {
     ddgInPathElem(path).map(_.node)
   }
 
+  /**
+    * Traverse back in the data dependence graph by one step and generate corresponding PathElement,
+    * taking into account semantics
+    * @param path optional list of path elements that have been expended already
+    * */
   def ddgInPathElem(path: List[PathElement] = List())(implicit semantics: Semantics): Traversal[PathElement] = {
     Engine.expandIn(node, path).to(Traversal)
   }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -1,11 +1,13 @@
 package io.shiftleft.dataflowengineoss.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.dataflowengineoss.queryengine.EngineContext
+import io.shiftleft.codepropertygraph.generated.nodes.TrackingPoint
+import io.shiftleft.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement}
 import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointToCfgNode
 import overflowdb.traversal.Traversal
 import overflowdb.traversal._
 import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 
 class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) extends AnyVal {
 
@@ -27,5 +29,13 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
   def reachableBy[NodeType <: nodes.TrackingPoint](sourceTravs: Traversal[NodeType]*)(
       implicit context: EngineContext): Traversal[NodeType] =
     node.start.reachableBy(sourceTravs: _*)
+
+  def ddgIn(path: List[PathElement] = List())(implicit semantics: Semantics): Traversal[TrackingPoint] = {
+    ddgInPathElem(path).map(_.node)
+  }
+
+  def ddgInPathElem(path: List[PathElement] = List())(implicit semantics: Semantics): Traversal[PathElement] = {
+    Engine.expandIn(node, path).to(Traversal)
+  }
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/package.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/package.scala
@@ -2,7 +2,7 @@ package io.shiftleft.dataflowengineoss
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.dataflowengineoss.language.dotextension.DdgNodeDot
-import io.shiftleft.dataflowengineoss.language.nodemethods.TrackingPointMethods
+import io.shiftleft.dataflowengineoss.language.nodemethods.{ExpressionMethods, TrackingPointMethods}
 import io.shiftleft.semanticcpg.language.nodemethods.AstNodeMethods
 import io.shiftleft.semanticcpg.language.types.expressions.generalizations.AstNode
 import overflowdb.traversal.Traversal
@@ -12,6 +12,9 @@ package object language {
   implicit def trackingPointBaseMethodsQp[NodeType <: nodes.TrackingPoint](
       node: NodeType): TrackingPointMethods[NodeType] =
     new TrackingPointMethods(node)
+
+  implicit def expressionMethods[NodeType <: nodes.Expression](node: NodeType): ExpressionMethods[NodeType] =
+    new ExpressionMethods(node)
 
   implicit def toTrackingPoint[NodeType <: nodes.TrackingPointBase](traversal: Traversal[NodeType]): TrackingPoint =
     new TrackingPoint(traversal.cast[nodes.TrackingPoint])

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -290,24 +290,14 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
     }
   }
 
-  private def isUsed(srcNode: nodes.TrackingPoint)(implicit semantics: Semantics) = {
-    Some(srcNode)
-      .collect {
-        case arg: nodes.Expression =>
-          val s = semanticsForCallByArg(arg)
-          s.isEmpty || s.exists(_.mappings.exists { case (srcIndex, _) => srcIndex == arg.order })
-      }
-      .getOrElse(true)
+  private def isUsed(arg: nodes.Expression)(implicit semantics: Semantics) = {
+    val s = semanticsForCallByArg(arg)
+    s.isEmpty || s.exists(_.mappings.exists { case (srcIndex, _) => srcIndex == arg.order })
   }
 
-  private def isDefined(srcNode: nodes.StoredNode)(implicit semantics: Semantics) = {
-    Some(srcNode)
-      .collect {
-        case arg: nodes.Expression =>
-          val s = semanticsForCallByArg(arg)
-          s.isEmpty || s.exists(_.mappings.exists { case (_, dstIndex) => dstIndex == arg.order })
-      }
-      .getOrElse(true)
+  private def isDefined(arg: nodes.Expression)(implicit semantics: Semantics) = {
+    val s = semanticsForCallByArg(arg)
+    s.isEmpty || s.exists(_.mappings.exists { case (_, dstIndex) => dstIndex == arg.order })
   }
 
   private def semanticsForCallByArg(arg: nodes.Expression)(implicit semantics: Semantics): List[FlowSemantic] = {

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -135,9 +135,7 @@ object Engine {
       case argument: nodes.Expression =>
         val (arguments, nonArguments) = ddgInE(curNode, path).partition(_.outNode().isInstanceOf[nodes.Expression])
         val elemsForArguments = arguments.flatMap { e =>
-          val parentNode = e.outNode()
-          elemForArgument(parentNode.asInstanceOf[nodes.Expression], argument).map(x =>
-            x.copy(inEdgeLabel = Some(e.property(EdgeKeys.VARIABLE)).getOrElse("")))
+          elemForArgument(e, argument)
         }
         val elems = elemsForArguments ++ nonArguments.map(edgeToPathElement)
         elems
@@ -167,8 +165,9 @@ object Engine {
     * field to specify whether it should be visible in the flow or not, a decision
     * that can also only be made by looking at both the parent and the child.
     * */
-  private def elemForArgument(parentNode: nodes.Expression, curNode: nodes.Expression)(
+  private def elemForArgument(e: Edge, curNode: nodes.Expression)(
       implicit semantics: Semantics): Option[PathElement] = {
+    val parentNode = e.outNode().asInstanceOf[nodes.Expression]
     val parentNodeCall = parentNode.start.inCall.l
     val sameCallSite = parentNode.start.inCall.l == curNode.start.inCall.l
 
@@ -183,7 +182,7 @@ object Engine {
         parentNode.isDefined
       }
 
-      Some(PathElement(parentNode, visible))
+      Some(PathElement(parentNode, visible, inEdgeLabel = e.label()))
     } else {
       None
     }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -60,4 +60,7 @@ case class ReachableByResult(path: List[PathElement], callDepth: Int = 0, partia
     }.distinct
 }
 
-case class PathElement(node: nodes.TrackingPoint, visible: Boolean = true, resolved: Boolean = true)
+case class PathElement(node: nodes.TrackingPoint,
+                       visible: Boolean = true,
+                       resolved: Boolean = true,
+                       inEdgeLabel: String = "")

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
@@ -20,10 +20,11 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       |""".stripMargin
 
   "A PdgDotGenerator" should {
-    "create a dot graph with 44 edges" in {
+    "create a dot graph with 40 edges" in {
+      implicit val s = semantics
       val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
       lines.head.startsWith("digraph foo") shouldBe true
-      lines.count(x => x.contains("->")) shouldBe 44
+      lines.count(x => x.contains("->")) shouldBe 40
       lines.last.startsWith("}") shouldBe true
     }
   }


### PR DESCRIPTION
* Introduce `ddgIn` and `ddgInPathElem` to walk backwards in the data dependence graph, taking into account semantics
* Ensure that plotting routing makes use of `ddgInPathElement` so that it, too, honors semantics