### PR TITLE
Publish (some) test artifacts

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -64,3 +64,4 @@ libraryDependencies ++= Seq(
   "org.scalatest"        %% "scalatest"     % Versions.scalatest % Test
 )
 
+publishArtifact in (Test, packageBin) := true

--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -17,6 +17,7 @@ scalacOptions in (Compile, doc) ++= Seq(
 )
 
 compile / javacOptions ++= Seq("-g") //debug symbols
+publishArtifact in (Test, packageBin) := true
 
 // execute tests in root project so that they work in sbt *and* intellij
 Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value


### PR DESCRIPTION
Follow up on https://github.com/ShiftLeftSecurity/codepropertygraph/pull/962
where I moved test classes to test directory root.
Apparently that broke some stuff that dependent on some of this test
infrastructure.

As requested in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/962#issuecomment-696513044