### PR TITLE
Do not return invisible edges in `expandIn`

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -131,7 +131,7 @@ object Engine {
 
   def expandIn(curNode: nodes.TrackingPoint, path: List[PathElement])(
       implicit semantics: Semantics): List[PathElement] = {
-    curNode match {
+    val elems = curNode match {
       case argument: nodes.Expression =>
         val (arguments, nonArguments) = ddgInE(curNode, path).partition(_.outNode().isInstanceOf[nodes.Expression])
         val elemsForArguments = arguments.flatMap { e =>
@@ -142,6 +142,7 @@ object Engine {
       case _ =>
         ddgInE(curNode, path).map(edgeToPathElement)
     }
+    elems.filter(_.visible) ++ elems.filterNot(_.visible).flatMap(x => expandIn(x.node, x :: path))
   }
 
   private def edgeToPathElement(e: Edge): PathElement = {

--- a/dataflowengineoss/src/test/resources/default.semantics
+++ b/dataflowengineoss/src/test/resources/default.semantics
@@ -29,3 +29,4 @@
 "<operator>.getElementPtr" 1->-1
 "<operator>.addition" 1->-1 2->-1
 "<operator>.conditional" 2->-1 3->-1
+"woo" 1->-1

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
@@ -5,7 +5,6 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.dataflowengineoss.language._
 
 class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
-
   override val code =
     """
       |int foo(int param1, char *param2) {
@@ -27,6 +26,23 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       lines.count(x => x.contains("->")) shouldBe 40
       lines.last.startsWith("}") shouldBe true
     }
+  }
+}
+
+class DotDdgGeneratorTests2 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
+      |int foo() {
+      |int x = 42;
+      |woo(x);
+      |baz(x);
+      |}
+      |""".stripMargin
+
+  "create correct dot graph" in {
+    implicit val s = semantics
+    val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
+    lines.count(x => x.contains("->") && x.contains("\"x\"")) shouldBe 5
   }
 
 }

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/DataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/DataFlowTests.scala
@@ -48,7 +48,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
   "should find flows from identifiers to return values of `flow`" in {
     val source = cpg.identifier
     val sink = cpg.method.name("flow").methodReturn
-    sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 8
+    sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 7
   }
 
   "find flows from z to method returns of flow" in {

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/FreeListDataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/FreeListDataFlowTests.scala
@@ -48,7 +48,7 @@ class FreeListDataFlowTests extends DataFlowCodeToCpgSuite {
   "should find flows from identifiers to return values of `flow`" in {
     val source = cpg.identifier
     val sink = cpg.method.name("flow").methodReturn
-    sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 8
+    sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 7
   }
 
   "find flows from z to method returns of flow" in {


### PR DESCRIPTION
Fixes #955 - the DDGs now look correct, however, I think we should condense them a bit in a next step. Right now, we show edges between arguments of calls and we'd be closer to the literature if we used edges between surrounding statements, that is, calls.
