### PR TITLE
Tuning and testing of `ddgIn` and `ddgInPathElem`

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -20,8 +20,7 @@ object DotDdgGenerator {
 
     v match {
       case trackingPoint: nodes.TrackingPoint =>
-        trackingPoint
-          .ddgInPathElem()
+        trackingPoint.ddgInPathElem
           .map(x => Edge(x.node.asInstanceOf[nodes.StoredNode], v, x.inEdgeLabel))
           .iterator ++ edgesFromMethods.iterator
       case _ =>

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -1,7 +1,8 @@
 package io.shiftleft.dataflowengineoss.language
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.dataflowengineoss.queryengine.{Engine, EngineContext, ReachableByResult}
+import io.shiftleft.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement, ReachableByResult}
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
@@ -21,6 +22,10 @@ class TrackingPoint(val traversal: Traversal[nodes.TrackingPoint]) extends AnyVa
     * */
   def cfgNode: Traversal[nodes.CfgNode] =
     traversal.map(_.cfgNode)
+
+  def ddgIn(implicit semantics: Semantics): Traversal[nodes.TrackingPoint] = traversal.flatMap(_.ddgIn)
+
+  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = traversal.flatMap(_.ddgInPathElem)
 
   def reachableBy[NodeType <: nodes.TrackingPoint](sourceTravs: Traversal[NodeType]*)(
       implicit context: EngineContext): Traversal[NodeType] = {

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -30,20 +30,24 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
       implicit context: EngineContext): Traversal[NodeType] =
     node.start.reachableBy(sourceTravs: _*)
 
+  def ddgIn(implicit semantics: Semantics): Traversal[TrackingPoint] = ddgIn(List())
+
+  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = ddgInPathElem(List())
+
   /**
     * Traverse back in the data dependence graph by one step, taking into account semantics
-    * @param path optional list of path elements that have been expended already
+    * @param path optional list of path elements that have been expanded already
     * */
-  def ddgIn(path: List[PathElement] = List())(implicit semantics: Semantics): Traversal[TrackingPoint] = {
+  def ddgIn(path: List[PathElement])(implicit semantics: Semantics): Traversal[TrackingPoint] = {
     ddgInPathElem(path).map(_.node)
   }
 
   /**
     * Traverse back in the data dependence graph by one step and generate corresponding PathElement,
     * taking into account semantics
-    * @param path optional list of path elements that have been expended already
+    * @param path optional list of path elements that have been expanded already
     * */
-  def ddgInPathElem(path: List[PathElement] = List())(implicit semantics: Semantics): Traversal[PathElement] = {
+  def ddgInPathElem(path: List[PathElement])(implicit semantics: Semantics): Traversal[PathElement] = {
     Engine.expandIn(node, path).to(Traversal)
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -104,7 +104,11 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
   }
 
   private def nodeToEdgeLabel(node: nodes.StoredNode): String = {
-    Some(node).collect { case n: nodes.CfgNode => n.code }.getOrElse("")
+    node match {
+      case n: nodes.CfgNode           => n.code
+      case n: nodes.MethodParameterIn => n.name
+      case _                          => ""
+    }
   }
 
 }

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
@@ -1,0 +1,49 @@
+package io.shiftleft.dataflowengineoss.language
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+
+class TrackingPointTests extends DataFlowCodeToCpgSuite {
+
+  implicit val resolver: NoResolve.type = NoResolve
+  implicit val s: Semantics = semantics
+
+  override val code =
+    """
+      |int foo(int y) {
+      | int x = source();
+      | x += y;
+      | sink(y);
+      |}
+      |""".stripMargin
+
+  "allow traversing from argument of sink back to param via `ddgIn`" in {
+    cpg.method("sink").parameter.argument.ddgIn.l match {
+      case List(param: nodes.MethodParameterIn) =>
+        param.name shouldBe "y"
+      case _ => fail
+    }
+  }
+
+  "allow traversing from argument node to param via `ddgIn`" in {
+    cpg.method("sink").parameter.argument.l match {
+      case List(t: nodes.TrackingPoint) =>
+        t.code shouldBe "y"
+        t.ddgIn.l match {
+          case List(param: nodes.MethodParameterIn) =>
+            param.name shouldBe "y"
+        }
+      case _ => fail
+    }
+  }
+
+  "allow traversing from argument back to param while inspecting edge" in {
+    cpg.method("sink").parameter.argument.ddgInPathElem.l match {
+      case List(pathElem) =>
+        pathElem.inEdgeLabel shouldBe "y"
+        pathElem.node.isInstanceOf[nodes.MethodParameterIn] shouldBe true
+      case _ => fail
+    }
+  }
+
+}


### PR DESCRIPTION
* Allow calling `ddgIn` and `ddgInPathElem` on traversals as opposed to just nodes
* Allow calling these two methods without paratheses
* Unit tests that illustrate usage
* Fix bug: edge labels for DDG edges from parameters were missing.
