### PR TITLE
Decouple DDG generation from Dot Serialization

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DdgGenerator.scala
@@ -1,0 +1,70 @@
+package io.shiftleft.dataflowengineoss.dotgenerator
+
+import io.shiftleft.codepropertygraph.generated.{EdgeKeys, EdgeTypes, nodes}
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
+import overflowdb.Node
+import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.dataflowengineoss.language._
+
+class DdgGenerator {
+
+  def createDdg(methodNode: nodes.Method)(implicit semantics: Semantics): Ddg = {
+    val entryNode = methodNode
+    val paramNodes = methodNode.parameter.l
+    val allOtherNodes = methodNode.start.cfgNode.l
+    val exitNode = methodNode.methodReturn
+    val allNodes: List[nodes.StoredNode] = List(entryNode, exitNode) ++ paramNodes ++ allOtherNodes
+    val visibleNodes = allNodes.filter(shouldBeDisplayed)
+
+    val edges = visibleNodes.map { dstNode =>
+      inEdgesToDisplay(dstNode)
+    }
+
+    val allIdsReferencedByEdges = edges.flatten.flatMap { edge: Edge =>
+      Set(edge.src.id, edge.dst.id)
+    }
+
+    Ddg(visibleNodes
+          .filter(node => allIdsReferencedByEdges.contains(node.id)),
+        edges.flatten)
+  }
+
+  private def shouldBeDisplayed(v: Node): Boolean = !(
+    v.isInstanceOf[nodes.Block] ||
+      v.isInstanceOf[nodes.ControlStructure] ||
+      v.isInstanceOf[nodes.JumpTarget]
+  )
+
+  private def inEdgesToDisplay(dstNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List())(
+      implicit semantics: Semantics): List[Edge] = {
+    if (visited.contains(dstNode)) {
+      List()
+    } else {
+      val parents = expand(dstNode)
+      val (visible, invisible) = parents.partition(x => shouldBeDisplayed(x.src))
+      visible.toList ++ invisible.toList.flatMap { n =>
+        inEdgesToDisplay(n.src, visited ++ List(dstNode)).map(y => Edge(y.src, dstNode))
+      }
+    }
+  }
+
+  private def expand(v: nodes.StoredNode)(implicit semantics: Semantics): Iterator[Edge] = {
+
+    val allInEdges = v
+      .inE(EdgeTypes.REACHING_DEF)
+      .map(x => Edge(x.outNode.asInstanceOf[nodes.StoredNode], v, x.property(EdgeKeys.VARIABLE)))
+
+    v match {
+      case trackingPoint: nodes.TrackingPoint =>
+        trackingPoint.ddgInPathElem
+          .map(x => Edge(x.node.asInstanceOf[nodes.StoredNode], v, x.outEdgeLabel))
+          .iterator ++ allInEdges.filter(_.src.isInstanceOf[nodes.Method]).iterator
+      case _ =>
+        allInEdges.iterator
+    }
+
+  }
+
+}

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -25,7 +25,7 @@ object DotDdgGenerator {
     val paramNodes = methodNode.parameter.l
     val allOtherNodes = methodNode.start.cfgNode.l
     val exitNode = methodNode.methodReturn
-    val allNodes: List[nodes.StoredNode] = List(entryNode, exitNode) ++ allOtherNodes ++ paramNodes
+    val allNodes: List[nodes.StoredNode] = List(entryNode, exitNode) ++ paramNodes ++ allOtherNodes
     val visibleNodes = allNodes.filter(shouldBeDisplayed)
 
     val edges = visibleNodes.map { dstNode =>
@@ -36,19 +36,12 @@ object DotDdgGenerator {
       Set(edge.src.id, edge.dst.id)
     }
 
-    val nodeStrings = visibleNodes.map { node =>
-      if (allIdsReferencedByEdges.contains(node.id)) {
-        s""""${node.id}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
-      } else {
-        ""
-      }
-    }
+    val nodeStrings = visibleNodes
+      .filter(node => allIdsReferencedByEdges.contains(node.id))
+      .map(Shared.nodeToDot)
 
     val edgeStrings = edges.flatMap { edges: List[Edge] =>
-      edges.map(
-        edge =>
-          s"""  "${edge.src.id}" -> "${edge.dst.id}" """ +
-            Some(s""" [ label = "${Shared.escape(edge.label)}"] """).filter(_ => edge.label != "").getOrElse(""))
+      edges.map(Shared.edgeToDot)
     }
 
     nodeStrings ++ edgeStrings

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -7,10 +7,62 @@ import io.shiftleft.semanticcpg.dotgenerator.Shared
 import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
 import overflowdb.Node
 import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language._
 
 object DotDdgGenerator {
 
-  def expand(v: nodes.StoredNode)(implicit semantics: Semantics): Iterator[Edge] = {
+  def toDotDdg(traversal: Traversal[nodes.Method])(implicit semantics: Semantics): Traversal[String] =
+    traversal.map(dotGraph)
+
+  private def dotGraph(method: nodes.Method)(implicit semantics: Semantics): String = {
+    val sb = Shared.namedGraphBegin(method)
+    sb.append(nodesAndEdges(method).mkString("\n"))
+    Shared.graphEnd(sb)
+  }
+
+  private def nodesAndEdges(methodNode: nodes.Method)(implicit semantics: Semantics): List[String] = {
+    val vertices = methodNode.start.cfgNode.l ++ List(methodNode, methodNode.methodReturn) ++ methodNode.parameter.l
+    val verticesToDisplay = vertices.filter(cfgNodeShouldBeDisplayed)
+
+    def edgesToDisplay(dstNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List()): List[Edge] = {
+      if (visited.contains(dstNode)) {
+        List()
+      } else {
+        val parents = expand(dstNode).filter(x => vertices.contains(x.src))
+        val (visible, invisible) = parents.partition(x => cfgNodeShouldBeDisplayed(x.src))
+        visible.toList ++ invisible.toList.flatMap { n =>
+          edgesToDisplay(n.src, visited ++ List(dstNode)).map(y => Edge(y.src, dstNode))
+        }
+      }
+    }
+
+    val edges = verticesToDisplay.map { v =>
+      edgesToDisplay(v)
+    }
+
+    val allIdsReferencedByEdges = edges.flatten.flatMap { edge =>
+      Set(edge.src.id, edge.dst.id)
+    }
+
+    val nodeStrings = verticesToDisplay.map { node =>
+      if (allIdsReferencedByEdges.contains(node.id)) {
+        s""""${node.id}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
+      } else {
+        ""
+      }
+    }
+
+    val edgeStrings = edges.flatMap { edges: List[Edge] =>
+      edges.map(
+        edge =>
+          s"""  "${edge.src.id}" -> "${edge.dst.id}" """ +
+            Some(s""" [ label = "${Shared.escape(edge.label)}"] """).filter(_ => edge.label != "").getOrElse(""))
+    }
+
+    nodeStrings ++ edgeStrings
+  }
+
+  private def expand(v: nodes.StoredNode)(implicit semantics: Semantics): Iterator[Edge] = {
 
     val allInEdges = v
       .inE(EdgeTypes.REACHING_DEF)
@@ -31,13 +83,10 @@ object DotDdgGenerator {
 
   }
 
-  def cfgNodeShouldBeDisplayed(v: Node): Boolean = !(
+  private def cfgNodeShouldBeDisplayed(v: Node): Boolean = !(
     v.isInstanceOf[nodes.Block] ||
       v.isInstanceOf[nodes.ControlStructure] ||
       v.isInstanceOf[nodes.JumpTarget]
   )
-
-  def toDotDdg(traversal: Traversal[nodes.Method])(implicit semantics: Semantics): Traversal[String] =
-    traversal.map(Shared.dotGraph(_, expand, cfgNodeShouldBeDisplayed))
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -29,7 +29,7 @@ object DotDdgGenerator {
     val visibleNodes = allNodes.filter(shouldBeDisplayed)
 
     val edges = visibleNodes.map { dstNode =>
-      inEdgesToDisplay(allNodes, dstNode)
+      inEdgesToDisplay(dstNode)
     }
 
     val allIdsReferencedByEdges = edges.flatten.flatMap { edge: Edge =>
@@ -40,9 +40,7 @@ object DotDdgGenerator {
       .filter(node => allIdsReferencedByEdges.contains(node.id))
       .map(Shared.nodeToDot)
 
-    val edgeStrings = edges.flatMap { edges: List[Edge] =>
-      edges.map(Shared.edgeToDot)
-    }
+    val edgeStrings = edges.flatten.map(Shared.edgeToDot)
 
     nodeStrings ++ edgeStrings
   }
@@ -53,16 +51,15 @@ object DotDdgGenerator {
       v.isInstanceOf[nodes.JumpTarget]
   )
 
-  private def inEdgesToDisplay(vertices: List[nodes.StoredNode],
-                               dstNode: nodes.StoredNode,
-                               visited: List[nodes.StoredNode] = List())(implicit semantics: Semantics): List[Edge] = {
+  private def inEdgesToDisplay(dstNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List())(
+      implicit semantics: Semantics): List[Edge] = {
     if (visited.contains(dstNode)) {
       List()
     } else {
-      val parents = expand(dstNode).filter(x => vertices.contains(x.src))
+      val parents = expand(dstNode)
       val (visible, invisible) = parents.partition(x => shouldBeDisplayed(x.src))
       visible.toList ++ invisible.toList.flatMap { n =>
-        inEdgesToDisplay(vertices, n.src, visited ++ List(dstNode)).map(y => Edge(y.src, dstNode))
+        inEdgesToDisplay(n.src, visited ++ List(dstNode)).map(y => Edge(y.src, dstNode))
       }
     }
   }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -1,13 +1,12 @@
 package io.shiftleft.dataflowengineoss.dotgenerator
 
-import io.shiftleft.codepropertygraph.generated.{EdgeKeys, EdgeTypes, nodes}
-import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.dotgenerator.Shared
 import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
-import overflowdb.Node
 import overflowdb.traversal._
-import io.shiftleft.semanticcpg.language._
+
+case class Ddg(vertices: List[nodes.StoredNode], edges: List[Edge])
 
 object DotDdgGenerator {
 
@@ -16,69 +15,11 @@ object DotDdgGenerator {
 
   private def dotGraphForMethod(method: nodes.Method)(implicit semantics: Semantics): String = {
     val sb = Shared.namedGraphBegin(method)
-    sb.append(nodesAndEdges(method).mkString("\n"))
+    val ddgGenerator = new DdgGenerator()
+    val ddg = ddgGenerator.createDdg(method)
+    val lines = ddg.vertices.map(Shared.nodeToDot) ++ ddg.edges.map(Shared.edgeToDot)
+    sb.append(lines.mkString("\n"))
     Shared.graphEnd(sb)
-  }
-
-  private def nodesAndEdges(methodNode: nodes.Method)(implicit semantics: Semantics): List[String] = {
-    val entryNode = methodNode
-    val paramNodes = methodNode.parameter.l
-    val allOtherNodes = methodNode.start.cfgNode.l
-    val exitNode = methodNode.methodReturn
-    val allNodes: List[nodes.StoredNode] = List(entryNode, exitNode) ++ paramNodes ++ allOtherNodes
-    val visibleNodes = allNodes.filter(shouldBeDisplayed)
-
-    val edges = visibleNodes.map { dstNode =>
-      inEdgesToDisplay(dstNode)
-    }
-
-    val allIdsReferencedByEdges = edges.flatten.flatMap { edge: Edge =>
-      Set(edge.src.id, edge.dst.id)
-    }
-
-    val nodeStrings = visibleNodes
-      .filter(node => allIdsReferencedByEdges.contains(node.id))
-      .map(Shared.nodeToDot)
-
-    val edgeStrings = edges.flatten.map(Shared.edgeToDot)
-
-    nodeStrings ++ edgeStrings
-  }
-
-  private def shouldBeDisplayed(v: Node): Boolean = !(
-    v.isInstanceOf[nodes.Block] ||
-      v.isInstanceOf[nodes.ControlStructure] ||
-      v.isInstanceOf[nodes.JumpTarget]
-  )
-
-  private def inEdgesToDisplay(dstNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List())(
-      implicit semantics: Semantics): List[Edge] = {
-    if (visited.contains(dstNode)) {
-      List()
-    } else {
-      val parents = expand(dstNode)
-      val (visible, invisible) = parents.partition(x => shouldBeDisplayed(x.src))
-      visible.toList ++ invisible.toList.flatMap { n =>
-        inEdgesToDisplay(n.src, visited ++ List(dstNode)).map(y => Edge(y.src, dstNode))
-      }
-    }
-  }
-
-  private def expand(v: nodes.StoredNode)(implicit semantics: Semantics): Iterator[Edge] = {
-
-    val allInEdges = v
-      .inE(EdgeTypes.REACHING_DEF)
-      .map(x => Edge(x.outNode.asInstanceOf[nodes.StoredNode], v, x.property(EdgeKeys.VARIABLE)))
-
-    v match {
-      case trackingPoint: nodes.TrackingPoint =>
-        trackingPoint.ddgInPathElem
-          .map(x => Edge(x.node.asInstanceOf[nodes.StoredNode], v, x.outEdgeLabel))
-          .iterator ++ allInEdges.filter(_.src.isInstanceOf[nodes.Method]).iterator
-      case _ =>
-        allInEdges.iterator
-    }
-
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -146,8 +146,9 @@ object Engine {
   }
 
   private def edgeToPathElement(e: Edge): PathElement = {
-    PathElement(e.outNode().asInstanceOf[nodes.TrackingPoint],
-                inEdgeLabel = Some(e.property(EdgeKeys.VARIABLE)).getOrElse(""))
+    val parentNode = e.outNode().asInstanceOf[nodes.TrackingPoint]
+    val outLabel = Some(e.property(EdgeKeys.VARIABLE)).getOrElse("")
+    PathElement(parentNode, outEdgeLabel = outLabel)
   }
 
   private def ddgInE(dstNode: nodes.TrackingPoint, path: List[PathElement]): List[Edge] = {
@@ -183,7 +184,7 @@ object Engine {
         parentNode.isDefined
       }
 
-      Some(PathElement(parentNode, visible, inEdgeLabel = Some(e.property(EdgeKeys.VARIABLE)).getOrElse("")))
+      Some(PathElement(parentNode, visible, outEdgeLabel = Some(e.property(EdgeKeys.VARIABLE)).getOrElse("")))
     } else {
       None
     }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -60,7 +60,17 @@ case class ReachableByResult(path: List[PathElement], callDepth: Int = 0, partia
     }.distinct
 }
 
+/**
+  * We represent data flows as sequences of path elements, where each
+  * path element consists of a node, flags and the label of its
+  * outgoing edge.
+  *
+  * @param node The parent node
+  * @param visible whether this path element should be shown in the flow
+  * @param resolved whether we have resolved the method call this argument belongs to
+  * @param outEdgeLabel label of the outgoing DDG edge
+  * */
 case class PathElement(node: nodes.TrackingPoint,
                        visible: Boolean = true,
                        resolved: Boolean = true,
-                       inEdgeLabel: String = "")
+                       outEdgeLabel: String = "")

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
@@ -40,7 +40,7 @@ class TrackingPointTests extends DataFlowCodeToCpgSuite {
   "allow traversing from argument back to param while inspecting edge" in {
     cpg.method("sink").parameter.argument.ddgInPathElem.l match {
       case List(pathElem) =>
-        pathElem.inEdgeLabel shouldBe "y"
+        pathElem.outEdgeLabel shouldBe "y"
         pathElem.node.isInstanceOf[nodes.MethodParameterIn] shouldBe true
       case _ => fail
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -1,15 +1,70 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
+import io.shiftleft.semanticcpg.dotgenerator.Shared.{Edge, escape}
 import overflowdb.Node
 import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language._
+
 import scala.jdk.CollectionConverters._
 
 object DotCfgGenerator {
 
   def toDotCfg(traversal: Traversal[nodes.Method]): Traversal[String] =
-    traversal.map(Shared.dotGraph(_, expand, cfgNodeShouldBeDisplayed))
+    traversal.map(dotGraph(_, expand, cfgNodeShouldBeDisplayed))
+
+  def dotGraph(method: nodes.Method,
+               expand: nodes.StoredNode => Iterator[Edge],
+               cfgNodeShouldBeDisplayed: Node => Boolean,
+  ): String = {
+    val sb = Shared.namedGraphBegin(method)
+    sb.append(nodesAndEdges(method, expand, cfgNodeShouldBeDisplayed).mkString("\n"))
+    Shared.graphEnd(sb)
+  }
+
+  private def nodesAndEdges(methodNode: nodes.Method,
+                            expand: nodes.StoredNode => Iterator[Edge],
+                            cfgNodeShouldBeDisplayed: Node => Boolean): List[String] = {
+    val vertices = methodNode.start.cfgNode.l ++ List(methodNode, methodNode.methodReturn) ++ methodNode.parameter.l
+    val verticesToDisplay = vertices.filter(cfgNodeShouldBeDisplayed)
+
+    def edgesToDisplay(srcNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List()): List[Edge] = {
+      if (visited.contains(srcNode)) {
+        List()
+      } else {
+        val children = expand(srcNode).filter(x => vertices.contains(x.dst))
+        val (visible, invisible) = children.partition(x => cfgNodeShouldBeDisplayed(x.dst))
+        visible.toList ++ invisible.toList.flatMap { n =>
+          edgesToDisplay(n.dst, visited ++ List(srcNode)).map(y => Edge(srcNode, y.dst))
+        }
+      }
+    }
+
+    val edges = verticesToDisplay.map { v =>
+      edgesToDisplay(v)
+    }
+
+    val allIdsReferencedByEdges = edges.flatten.flatMap { edge =>
+      Set(edge.src.id, edge.dst.id)
+    }
+
+    val nodeStrings = verticesToDisplay.map { node =>
+      if (allIdsReferencedByEdges.contains(node.id)) {
+        s""""${node.id}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
+      } else {
+        ""
+      }
+    }
+
+    val edgeStrings = edges.flatMap { edges: List[Edge] =>
+      edges.map(
+        edge =>
+          s"""  "${edge.src.id}" -> "${edge.dst.id}" """ +
+            Some(s""" [ label = "${escape(edge.label)}"] """).filter(_ => edge.label != "").getOrElse(""))
+    }
+
+    nodeStrings ++ edgeStrings
+  }
 
   protected def expand(v: nodes.StoredNode): Iterator[Edge] = {
     v._cfgOut.asScala

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
@@ -108,7 +108,7 @@ object Shared {
     }
   }
 
-  private def escape(str: String): String = {
+  def escape(str: String): String = {
     str.replaceAllLiterally("\"", "\\\"")
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
@@ -72,7 +72,7 @@ object Shared {
     sb.append(s"digraph $name {  \n")
   }
 
-  def stringRepr(vertex: nodes.AstNode): String = {
+  def stringRepr(vertex: nodes.StoredNode): String = {
     escape(
       vertex match {
         case call: nodes.Call               => (call.name, call.code).toString

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/Shared.scala
@@ -1,67 +1,12 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import overflowdb.Node
-import overflowdb.traversal._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.utils.MemberAccess
 
 object Shared {
 
   case class Edge(src: nodes.StoredNode, dst: nodes.StoredNode, label: String = "")
-
-  def dotGraph(method: nodes.Method,
-               expand: nodes.StoredNode => Iterator[Edge],
-               cfgNodeShouldBeDisplayed: Node => Boolean,
-  ): String = {
-    val sb = Shared.namedGraphBegin(method)
-    sb.append(nodesAndEdges(method, expand, cfgNodeShouldBeDisplayed).mkString("\n"))
-    Shared.graphEnd(sb)
-  }
-
-  private def nodesAndEdges(methodNode: nodes.Method,
-                            expand: nodes.StoredNode => Iterator[Edge],
-                            cfgNodeShouldBeDisplayed: Node => Boolean): List[String] = {
-    val vertices = methodNode.start.cfgNode.l ++ List(methodNode, methodNode.methodReturn) ++ methodNode.parameter.l
-    val verticesToDisplay = vertices.filter(cfgNodeShouldBeDisplayed)
-
-    def edgesToDisplay(srcNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List()): List[Edge] = {
-      if (visited.contains(srcNode)) {
-        List()
-      } else {
-        val children = expand(srcNode).filter(x => vertices.contains(x.dst))
-        val (visible, invisible) = children.partition(x => cfgNodeShouldBeDisplayed(x.dst))
-        visible.toList ++ invisible.toList.flatMap { n =>
-          edgesToDisplay(n.dst, visited ++ List(srcNode)).map(y => Edge(srcNode, y.dst))
-        }
-      }
-    }
-
-    val edges = verticesToDisplay.map { v =>
-      edgesToDisplay(v)
-    }
-
-    val allIdsReferencedByEdges = edges.flatten.flatMap { edge =>
-      Set(edge.src.id, edge.dst.id)
-    }
-
-    val nodeStrings = verticesToDisplay.map { node =>
-      if (allIdsReferencedByEdges.contains(node.id)) {
-        s""""${node.id}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
-      } else {
-        ""
-      }
-    }
-
-    val edgeStrings = edges.flatMap { edges: List[Edge] =>
-      edges.map(
-        edge =>
-          s"""  "${edge.src.id}" -> "${edge.dst.id}" """ +
-            Some(s""" [ label = "${escape(edge.label)}"] """).filter(_ => edge.label != "").getOrElse(""))
-    }
-
-    nodeStrings ++ edgeStrings
-  }
 
   def namedGraphBegin(root: nodes.AstNode): StringBuilder = {
     val sb = new StringBuilder
@@ -89,23 +34,28 @@ object Shared {
 
   def toCfgNode(node: nodes.StoredNode): nodes.CfgNode = {
     node match {
-      case node: nodes.Identifier => node.parentExpression.get
-      case node: nodes.MethodRef  => node.parentExpression.get
-      case node: nodes.Literal    => node.parentExpression.get
-
+      case node: nodes.Identifier        => node.parentExpression.get
+      case node: nodes.MethodRef         => node.parentExpression.get
+      case node: nodes.Literal           => node.parentExpression.get
       case node: nodes.MethodParameterIn => node.method
-
       case node: nodes.MethodParameterOut =>
         node.method.methodReturn
-
       case node: nodes.Call if MemberAccess.isGenericMemberAccessName(node.name) =>
         node.parentExpression.get
-
       case node: nodes.Call         => node
       case node: nodes.ImplicitCall => node
       case node: nodes.MethodReturn => node
       case node: nodes.Expression   => node
     }
+  }
+
+  def nodeToDot(node: nodes.StoredNode): String = {
+    s""""${node.id}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
+  }
+
+  def edgeToDot(edge: Edge): String = {
+    s"""  "${edge.src.id}" -> "${edge.dst.id}" """ +
+      Some(s""" [ label = "${Shared.escape(edge.label)}"] """).filter(_ => edge.label != "").getOrElse("")
   }
 
   def escape(str: String): String = {
@@ -116,11 +66,5 @@ object Shared {
     sb.append("\n}\n")
     sb.toString
   }
-
-}
-
-abstract class CfgBasedDotGenerator {
-
-  protected def expand(node: nodes.CfgNode): java.util.Iterator[nodes.StoredNode]
 
 }


### PR DESCRIPTION
This is in preparation for a DDG dumping script.

Currently, DDGs only existed implicitly in the CPG. One could retrieve them by using `ddgIn` and knowing exactly what one was doing. In addition to that, we had a component that created the DDG and serialized it into Dot. In preparation for supporting different output formats and following the single responsibility principle, I have decoupled DDG generation from Dot Serialization. Moreover, I have decoupled CFG and DDG plotting because the code originally written for CFG plotting didn't fit the use case of DDG plotting too well, making it hard to understand what was going on.