### PR TITLE
A pass for dumping ASTs of all methods

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
@@ -6,7 +6,7 @@ import overflowdb.traversal._
 
 object DotAstGenerator {
 
-  def toDotAst[T <: nodes.AstNode](traversal: Traversal[T]): Traversal[String] =
+  def dotAst[T <: nodes.AstNode](traversal: Traversal[T]): Traversal[String] =
     traversal.map(dotAst)
 
   def dotAst(astRoot: nodes.AstNode): String = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -10,7 +10,7 @@ import scala.jdk.CollectionConverters._
 
 object DotCfgGenerator {
 
-  def toDotCfg(traversal: Traversal[nodes.Method]): Traversal[String] =
+  def dotCfg(traversal: Traversal[nodes.Method]): Traversal[String] =
     traversal.map(dotGraph(_, expand, cfgNodeShouldBeDisplayed))
 
   def dotGraph(method: nodes.Method,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
@@ -8,7 +8,7 @@ import scala.language.postfixOps
 
 class AstNodeDot[NodeType <: nodes.AstNode](val traversal: Traversal[NodeType]) extends AnyVal {
 
-  def dotAst: Traversal[String] = DotAstGenerator.toDotAst(traversal)
+  def dotAst: Traversal[String] = DotAstGenerator.dotAst(traversal)
 
   def plotDotAst(implicit viewer: ImageViewer): Unit = {
     Shared.plotAndDisplay(dotAst.l, viewer)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
@@ -6,7 +6,7 @@ import overflowdb.traversal.Traversal
 
 class CfgNodeDot(val traversal: Traversal[nodes.Method]) extends AnyVal {
 
-  def dotCfg: Traversal[String] = DotCfgGenerator.toDotCfg(traversal)
+  def dotCfg: Traversal[String] = DotCfgGenerator.dotCfg(traversal)
 
   def plotDotCfg(implicit viewer: ImageViewer): Unit = {
     Shared.plotAndDisplay(dotCfg.l, viewer)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpAst.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpAst.scala
@@ -1,0 +1,32 @@
+package io.shiftleft.semanticcpg.layers
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal._
+
+case class DumpOptions(var outDir: String) extends LayerCreatorOptions {}
+
+object DumpAst {
+
+  val overlayName = "dumpAst"
+
+  val description = "Dump abstract syntax trees to out/"
+
+  def defaultOpts: DumpOptions = DumpOptions("out")
+}
+
+class DumpAst(options: DumpOptions) extends LayerCreator {
+  override val overlayName: String = DumpAst.overlayName
+  override val description: String = DumpAst.description
+
+  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+    val cpg = context.cpg
+    cpg.method.zipWithIndex.foreach {
+      case (method, i) =>
+        val str = method.start.dotAst.head
+        (File(options.outDir) / s"${i}-ast.dot").write(str)
+    }
+  }
+
+  override def probe(cpg: Cpg): Boolean = false
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpAstTests.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.semanticcpg.layers
+
+import better.files.File
+import io.shiftleft.semanticcpg.testing.MockCpg
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DumpAstTests extends AnyWordSpec with Matchers {
+
+  "DumpAst" should {
+
+    "create two dot files for a CPG containing two methods" in {
+      val cpg = MockCpg()
+        .withMetaData()
+        .withMethod("foo")
+        .withMethod("bar")
+        .cpg
+
+      val context = new LayerCreatorContext(cpg)
+      new Scpg().run(context)
+      File.usingTemporaryDirectory("dumpast") { tmpDir =>
+        val opts = DumpOptions(tmpDir.path.toString)
+        new DumpAst(opts).run(context)
+        (tmpDir / "0-ast.dot").exists shouldBe true
+        (tmpDir / "1-ast.dot").exists shouldBe true
+        (tmpDir / "0-ast.dot").size should not be 0
+        (tmpDir / "1-ast.dot").size should not be 0
+      }
+    }
+
+  }
+
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/ScpgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/ScpgTests.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class EnhancedBaseCreatorTests extends AnyWordSpec with Matchers {
+class ScpgTests extends AnyWordSpec with Matchers {
 
   "EnhancedBaseCreator" should {
 


### PR DESCRIPTION
One can now issue
```
run.dumpast
```
to dump ASTs for each method to the directory `out`. The directory can be configured via `opts.dumpast.outDir`.
