### PR TITLE
Dumping of CFGs and DDGs + simplification of DDG

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGenerator.scala
@@ -16,7 +16,7 @@ object DotDdgGenerator {
   private def dotGraphForMethod(method: nodes.Method)(implicit semantics: Semantics): String = {
     val sb = Shared.namedGraphBegin(method)
     val ddgGenerator = new DdgGenerator()
-    val ddg = ddgGenerator.createDdg(method)
+    val ddg = ddgGenerator.generate(method)
     val lines = ddg.vertices.map(Shared.nodeToDot) ++ ddg.edges.map(Shared.edgeToDot)
     sb.append(lines.mkString("\n"))
     Shared.graphEnd(sb)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdg.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdg.scala
@@ -1,0 +1,36 @@
+package io.shiftleft.dataflowengineoss.layers.dataflows
+
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+import overflowdb.traversal._
+import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+
+case class DdgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
+
+object DumpDdg {
+
+  val overlayName = "dumpDdg"
+
+  val description = "Dump data dependence graphs to out/"
+
+  def defaultOpts: DdgDumpOptions = DdgDumpOptions("out")
+}
+
+class DumpDdg(options: DdgDumpOptions)(implicit semantics: Semantics) extends LayerCreator {
+  override val overlayName: String = DumpDdg.overlayName
+  override val description: String = DumpDdg.description
+
+  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+    val cpg = context.cpg
+    cpg.method.zipWithIndex.foreach {
+      case (method, i) =>
+        val str = method.start.dotDdg.head
+        (File(options.outDir) / s"${i}-ddg.dot").write(str)
+    }
+  }
+
+  override def probe(cpg: Cpg): Boolean = false
+}

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotDdgGeneratorTests.scala
@@ -19,11 +19,11 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       |""".stripMargin
 
   "A PdgDotGenerator" should {
-    "create a dot graph with 40 edges" in {
+    "create a dot graph with 24 edges" in {
       implicit val s = semantics
       val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
       lines.head.startsWith("digraph foo") shouldBe true
-      lines.count(x => x.contains("->")) shouldBe 40
+      lines.count(x => x.contains("->")) shouldBe 24
       lines.last.startsWith("}") shouldBe true
     }
   }
@@ -42,7 +42,7 @@ class DotDdgGeneratorTests2 extends DataFlowCodeToCpgSuite {
   "create correct dot graph" in {
     implicit val s = semantics
     val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
-    lines.count(x => x.contains("->") && x.contains("\"x\"")) shouldBe 5
+    lines.count(x => x.contains("->") && x.contains("\"x\"")) shouldBe 2
   }
 
 }

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdgTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdgTests.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.dataflowengineoss.layers.dataflows
+
+import better.files.File
+import io.shiftleft.dataflowengineoss.language.DataFlowCodeToCpgSuite
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+
+class DumpDdgTests extends DataFlowCodeToCpgSuite {
+
+  override val code =
+    """
+      |int foo() {}
+      |int bar() {}
+      |""".stripMargin
+
+  "DumpDdg" should {
+
+    "create two dot files for a CPG containing two methods" in {
+
+      File.usingTemporaryDirectory("dumpast") { tmpDir =>
+        val opts = DdgDumpOptions(tmpDir.path.toString)
+        implicit val s = semantics
+        val layerContext = new LayerCreatorContext(cpg)
+        new DumpDdg(opts).run(layerContext)
+        (tmpDir / "0-ddg.dot").exists shouldBe true
+        (tmpDir / "1-ddg.dot").exists shouldBe true
+        (tmpDir / "0-ddg.dot").size should not be 0
+        (tmpDir / "1-ddg.dot").size should not be 0
+      }
+    }
+
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CdgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CdgGenerator.scala
@@ -1,0 +1,16 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
+import scala.jdk.CollectionConverters._
+
+class CdgGenerator extends CfgGenerator {
+
+  override def expand(v: nodes.StoredNode): Iterator[Edge] = {
+    v._cdgOut()
+      .asScala
+      .filter(_.isInstanceOf[nodes.StoredNode])
+      .map(node => Edge(v, node))
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
@@ -7,6 +7,8 @@ import overflowdb.traversal._
 import io.shiftleft.semanticcpg.language._
 import scala.jdk.CollectionConverters._
 
+case class Cfg(vertices: List[nodes.StoredNode], edges: List[Edge])
+
 class CfgGenerator {
 
   def generate(methodNode: nodes.Method): Cfg = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
@@ -1,0 +1,58 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
+import overflowdb.Node
+import overflowdb.traversal._
+import io.shiftleft.semanticcpg.language._
+import scala.jdk.CollectionConverters._
+
+class CfgGenerator {
+
+  def generate(methodNode: nodes.Method): Cfg = {
+    val vertices = methodNode.start.cfgNode.l ++ List(methodNode, methodNode.methodReturn) ++ methodNode.parameter.l
+    val verticesToDisplay = vertices.filter(cfgNodeShouldBeDisplayed)
+
+    def edgesToDisplay(srcNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List()): List[Edge] = {
+      if (visited.contains(srcNode)) {
+        List()
+      } else {
+        val children = expand(srcNode).filter(x => vertices.contains(x.dst))
+        val (visible, invisible) = children.partition(x => cfgNodeShouldBeDisplayed(x.dst))
+        visible.toList ++ invisible.toList.flatMap { n =>
+          edgesToDisplay(n.dst, visited ++ List(srcNode)).map(y => Edge(srcNode, y.dst))
+        }
+      }
+    }
+
+    val edges = verticesToDisplay.map { v =>
+      edgesToDisplay(v)
+    }
+
+    val allIdsReferencedByEdges = edges.flatten.flatMap { edge =>
+      Set(edge.src.id, edge.dst.id)
+    }
+
+    Cfg(
+      verticesToDisplay
+        .filter(node => allIdsReferencedByEdges.contains(node.id)),
+      edges.flatten
+    )
+  }
+
+  protected def expand(v: nodes.StoredNode): Iterator[Edge] = {
+    v._cfgOut.asScala
+      .filter(_.isInstanceOf[nodes.StoredNode])
+      .map(node => Edge(v, node))
+  }
+
+  def cfgNodeShouldBeDisplayed(v: Node): Boolean = !(
+    v.isInstanceOf[nodes.Literal] ||
+      v.isInstanceOf[nodes.Identifier] ||
+      v.isInstanceOf[nodes.Block] ||
+      v.isInstanceOf[nodes.ControlStructure] ||
+      v.isInstanceOf[nodes.JumpTarget] ||
+      v.isInstanceOf[nodes.MethodParameterIn]
+  )
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotAstGenerator.scala
@@ -22,9 +22,7 @@ object DotAstGenerator {
     val vertices = astRoot.ast.filter(shouldBeDisplayed).l
     val edges = vertices.map(v => (v.id, v.start.astChildren.filter(shouldBeDisplayed).id.l))
 
-    val nodeStrings = vertices.map { node =>
-      s""""${node.id}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
-    }
+    val nodeStrings = vertices.map(Shared.nodeToDot)
 
     val edgeStrings = edges.flatMap {
       case (id, childIds) =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCdgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCdgGenerator.scala
@@ -1,0 +1,20 @@
+package io.shiftleft.semanticcpg.dotgenerator
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import overflowdb.traversal._
+
+object DotCdgGenerator {
+
+  def dotCdg(traversal: Traversal[nodes.Method]): Traversal[String] =
+    traversal.map(dotCdg)
+
+  def dotCdg(method: nodes.Method): String = {
+    val sb = Shared.namedGraphBegin(method)
+    val cdg = new CdgGenerator().generate(method)
+    val nodeStrings = cdg.vertices.map(Shared.nodeToDot)
+    val edgeStrings = cdg.edges.map(Shared.edgeToDot)
+    sb.append((nodeStrings ++ edgeStrings).mkString("\n"))
+    Shared.graphEnd(sb)
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -1,84 +1,23 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.dotgenerator.Shared.{Edge, escape}
-import overflowdb.Node
+import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
 import overflowdb.traversal._
-import io.shiftleft.semanticcpg.language._
 
-import scala.jdk.CollectionConverters._
+case class Cfg(vertices: List[nodes.StoredNode], edges: List[Edge])
 
 object DotCfgGenerator {
 
   def dotCfg(traversal: Traversal[nodes.Method]): Traversal[String] =
-    traversal.map(dotGraph(_, expand, cfgNodeShouldBeDisplayed))
+    traversal.map(dotCfg)
 
-  def dotGraph(method: nodes.Method,
-               expand: nodes.StoredNode => Iterator[Edge],
-               cfgNodeShouldBeDisplayed: Node => Boolean,
-  ): String = {
+  def dotCfg(method: nodes.Method): String = {
     val sb = Shared.namedGraphBegin(method)
-    sb.append(nodesAndEdges(method, expand, cfgNodeShouldBeDisplayed).mkString("\n"))
+    val cfg = new CfgGenerator().generate(method)
+    val nodeStrings = cfg.vertices.map(Shared.nodeToDot)
+    val edgeStrings = cfg.edges.map(Shared.edgeToDot)
+    sb.append((nodeStrings ++ edgeStrings).mkString("\n"))
     Shared.graphEnd(sb)
   }
-
-  private def nodesAndEdges(methodNode: nodes.Method,
-                            expand: nodes.StoredNode => Iterator[Edge],
-                            cfgNodeShouldBeDisplayed: Node => Boolean): List[String] = {
-    val vertices = methodNode.start.cfgNode.l ++ List(methodNode, methodNode.methodReturn) ++ methodNode.parameter.l
-    val verticesToDisplay = vertices.filter(cfgNodeShouldBeDisplayed)
-
-    def edgesToDisplay(srcNode: nodes.StoredNode, visited: List[nodes.StoredNode] = List()): List[Edge] = {
-      if (visited.contains(srcNode)) {
-        List()
-      } else {
-        val children = expand(srcNode).filter(x => vertices.contains(x.dst))
-        val (visible, invisible) = children.partition(x => cfgNodeShouldBeDisplayed(x.dst))
-        visible.toList ++ invisible.toList.flatMap { n =>
-          edgesToDisplay(n.dst, visited ++ List(srcNode)).map(y => Edge(srcNode, y.dst))
-        }
-      }
-    }
-
-    val edges = verticesToDisplay.map { v =>
-      edgesToDisplay(v)
-    }
-
-    val allIdsReferencedByEdges = edges.flatten.flatMap { edge =>
-      Set(edge.src.id, edge.dst.id)
-    }
-
-    val nodeStrings = verticesToDisplay.map { node =>
-      if (allIdsReferencedByEdges.contains(node.id)) {
-        s""""${node.id}" [label = "${Shared.stringRepr(node)}" ]""".stripMargin
-      } else {
-        ""
-      }
-    }
-
-    val edgeStrings = edges.flatMap { edges: List[Edge] =>
-      edges.map(
-        edge =>
-          s"""  "${edge.src.id}" -> "${edge.dst.id}" """ +
-            Some(s""" [ label = "${escape(edge.label)}"] """).filter(_ => edge.label != "").getOrElse(""))
-    }
-
-    nodeStrings ++ edgeStrings
-  }
-
-  protected def expand(v: nodes.StoredNode): Iterator[Edge] = {
-    v._cfgOut.asScala
-      .filter(_.isInstanceOf[nodes.StoredNode])
-      .map(node => Edge(v, node))
-  }
-
-  def cfgNodeShouldBeDisplayed(v: Node): Boolean = !(
-    v.isInstanceOf[nodes.Literal] ||
-      v.isInstanceOf[nodes.Identifier] ||
-      v.isInstanceOf[nodes.Block] ||
-      v.isInstanceOf[nodes.ControlStructure] ||
-      v.isInstanceOf[nodes.JumpTarget] ||
-      v.isInstanceOf[nodes.MethodParameterIn]
-  )
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotCfgGenerator.scala
@@ -1,10 +1,7 @@
 package io.shiftleft.semanticcpg.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.dotgenerator.Shared.Edge
 import overflowdb.traversal._
-
-case class Cfg(vertices: List[nodes.StoredNode], edges: List[Edge])
 
 object DotCfgGenerator {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
@@ -14,4 +14,8 @@ class CfgNodeDot(val traversal: Traversal[nodes.Method]) extends AnyVal {
     Shared.plotAndDisplay(dotCfg.l, viewer)
   }
 
+  def plotDotCdg(implicit viewer: ImageViewer): Unit = {
+    Shared.plotAndDisplay(dotCdg.l, viewer)
+  }
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
@@ -1,12 +1,14 @@
 package io.shiftleft.semanticcpg.language.dotextension
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.dotgenerator.DotCfgGenerator
+import io.shiftleft.semanticcpg.dotgenerator.{DotCdgGenerator, DotCfgGenerator}
 import overflowdb.traversal.Traversal
 
 class CfgNodeDot(val traversal: Traversal[nodes.Method]) extends AnyVal {
 
   def dotCfg: Traversal[String] = DotCfgGenerator.dotCfg(traversal)
+
+  def dotCdg: Traversal[String] = DotCdgGenerator.dotCdg(traversal)
 
   def plotDotCfg(implicit viewer: ImageViewer): Unit = {
     Shared.plotAndDisplay(dotCfg.l, viewer)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpAst.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpAst.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
-case class DumpOptions(var outDir: String) extends LayerCreatorOptions {}
+case class AstDumpOptions(var outDir: String) extends LayerCreatorOptions {}
 
 object DumpAst {
 
@@ -12,10 +12,10 @@ object DumpAst {
 
   val description = "Dump abstract syntax trees to out/"
 
-  def defaultOpts: DumpOptions = DumpOptions("out")
+  def defaultOpts: AstDumpOptions = AstDumpOptions("out")
 }
 
-class DumpAst(options: DumpOptions) extends LayerCreator {
+class DumpAst(options: AstDumpOptions) extends LayerCreator {
   override val overlayName: String = DumpAst.overlayName
   override val description: String = DumpAst.description
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCdg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCdg.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.semanticcpg.layers
+
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal._
+
+case class CdgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
+
+object DumpCdg {
+
+  val overlayName = "dumpCdg"
+
+  val description = "Dump control dependence graph to out/"
+
+  def defaultOpts: CdgDumpOptions = CdgDumpOptions("out")
+}
+
+class DumpCdg(options: CdgDumpOptions) extends LayerCreator {
+  override val overlayName: String = DumpCdg.overlayName
+  override val description: String = DumpCdg.description
+
+  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+    val cpg = context.cpg
+    cpg.method.zipWithIndex.foreach {
+      case (method, i) =>
+        val str = method.start.dotCdg.head
+        (File(options.outDir) / s"${i}-cdg.dot").write(str)
+    }
+  }
+
+  override def probe(cpg: Cpg): Boolean = false
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCfg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCfg.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.semanticcpg.layers
+
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal._
+
+case class CfgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
+
+object DumpCfg {
+
+  val overlayName = "dumpCfg"
+
+  val description = "Dump control flow graph to out/"
+
+  def defaultOpts: CfgDumpOptions = CfgDumpOptions("out")
+}
+
+class DumpCfg(options: CfgDumpOptions) extends LayerCreator {
+  override val overlayName: String = DumpCfg.overlayName
+  override val description: String = DumpCfg.description
+
+  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+    val cpg = context.cpg
+    cpg.method.zipWithIndex.foreach {
+      case (method, i) =>
+        val str = method.start.dotCfg.head
+        (File(options.outDir) / s"${i}-cfg.dot").write(str)
+    }
+  }
+
+  override def probe(cpg: Cpg): Boolean = false
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCdgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCdgTests.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.semanticcpg.layers
+
+import better.files.File
+import io.shiftleft.semanticcpg.testing.MockCpg
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DumpCdgTests extends AnyWordSpec with Matchers {
+
+  "DumpCdg" should {
+
+    "create two dot files for a CPG containing two methods" in {
+      val cpg = MockCpg()
+        .withMetaData()
+        .withMethod("foo")
+        .withMethod("bar")
+        .cpg
+
+      val context = new LayerCreatorContext(cpg)
+      new Scpg().run(context)
+      File.usingTemporaryDirectory("dumpcdg") { tmpDir =>
+        val opts = CdgDumpOptions(tmpDir.path.toString)
+        new DumpCdg(opts).run(context)
+        (tmpDir / "0-cdg.dot").exists shouldBe true
+        (tmpDir / "1-cdg.dot").exists shouldBe true
+        (tmpDir / "0-cdg.dot").size should not be 0
+        (tmpDir / "1-cdg.dot").size should not be 0
+      }
+    }
+
+  }
+
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCfgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCfgTests.scala
@@ -5,9 +5,9 @@ import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class DumpAstTests extends AnyWordSpec with Matchers {
+class DumpCfgTests extends AnyWordSpec with Matchers {
 
-  "DumpAst" should {
+  "DumpCfg" should {
 
     "create two dot files for a CPG containing two methods" in {
       val cpg = MockCpg()
@@ -18,13 +18,13 @@ class DumpAstTests extends AnyWordSpec with Matchers {
 
       val context = new LayerCreatorContext(cpg)
       new Scpg().run(context)
-      File.usingTemporaryDirectory("dumpast") { tmpDir =>
-        val opts = AstDumpOptions(tmpDir.path.toString)
-        new DumpAst(opts).run(context)
-        (tmpDir / "0-ast.dot").exists shouldBe true
-        (tmpDir / "1-ast.dot").exists shouldBe true
-        (tmpDir / "0-ast.dot").size should not be 0
-        (tmpDir / "1-ast.dot").size should not be 0
+      File.usingTemporaryDirectory("dumpcfg") { tmpDir =>
+        val opts = CfgDumpOptions(tmpDir.path.toString)
+        new DumpCfg(opts).run(context)
+        (tmpDir / "0-cfg.dot").exists shouldBe true
+        (tmpDir / "1-cfg.dot").exists shouldBe true
+        (tmpDir / "0-cfg.dot").size should not be 0
+        (tmpDir / "1-cfg.dot").size should not be 0
       }
     }
 


### PR DESCRIPTION
Re: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/972

* dump CFGs with `run.dumpcfg`
* dump DDGs with `run.dumpddg`
* simplify DDGs by mapping arguments to surrounding calls
* Cleanup of AST/CFG dot generators
* new CDG generation + plotting + dumping with `run.dumpcdg`

Final feature should be dumping of the 2014 intraprocedural CPG. This will require a bit more cleanup and will be implemented in a follow-up PR.