### PR TITLE
Plotting and dumping of CPG'14

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotCpg14Generator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DotCpg14Generator.scala
@@ -2,18 +2,20 @@ package io.shiftleft.dataflowengineoss.dotgenerator
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
-import io.shiftleft.semanticcpg.dotgenerator.{CdgGenerator, DotSerializer}
+import io.shiftleft.semanticcpg.dotgenerator.{AstGenerator, CdgGenerator, CfgGenerator, DotSerializer}
 import overflowdb.traversal.Traversal
 
-object DotPdgGenerator {
+object DotCpg14Generator {
 
-  def toDotPdg(traversal: Traversal[nodes.Method])(implicit semantics: Semantics): Traversal[String] =
+  def toDotCpg14(traversal: Traversal[nodes.Method])(implicit semantics: Semantics): Traversal[String] =
     traversal.map(dotGraphForMethod)
 
   private def dotGraphForMethod(method: nodes.Method)(implicit semantics: Semantics): String = {
+    val ast = new AstGenerator().generate(method)
+    val cfg = new CfgGenerator().generate(method)
     val ddg = new DdgGenerator().generate(method)
     val cdg = new CdgGenerator().generate(method)
-    DotSerializer.dotGraph(method, ddg.++(cdg), withEdgeTypes = true)
+    DotSerializer.dotGraph(method, ast ++ cfg ++ ddg ++ cdg, withEdgeTypes = true)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/dotextension/DdgNodeDot.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/dotextension/DdgNodeDot.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.dataflowengineoss.language.dotextension
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.dataflowengineoss.dotgenerator.{DotDdgGenerator, DotPdgGenerator}
+import io.shiftleft.dataflowengineoss.dotgenerator.{DotCpg14Generator, DotDdgGenerator, DotPdgGenerator}
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language.dotextension.{ImageViewer, Shared}
@@ -13,7 +13,18 @@ class DdgNodeDot(val traversal: Traversal[nodes.Method]) extends AnyVal {
 
   def dotPdg(implicit semantics: Semantics): Traversal[String] = DotPdgGenerator.toDotPdg(traversal)
 
+  def dotCpg14(implicit semantics: Semantics): Traversal[String] = DotCpg14Generator.toDotCpg14(traversal)
+
+  def plotDotDdg(implicit viewer: ImageViewer, semantics: Semantics): Unit = {
+    Shared.plotAndDisplay(traversal.dotDdg.l, viewer)
+  }
+
   def plotDotPdg(implicit viewer: ImageViewer, semantics: Semantics): Unit = {
     Shared.plotAndDisplay(traversal.dotPdg.l, viewer)
   }
+
+  def plotDotCpg14(implicit viewer: ImageViewer, semantics: Semantics): Unit = {
+    Shared.plotAndDisplay(traversal.dotCpg14.l, viewer)
+  }
+
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14.scala
@@ -1,0 +1,36 @@
+package io.shiftleft.dataflowengineoss.layers.dataflows
+
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+import overflowdb.traversal._
+import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+
+case class Cpg14DumpOptions(var outDir: String) extends LayerCreatorOptions {}
+
+object DumpCpg14 {
+
+  val overlayName = "dumpCpg14"
+
+  val description = "Dump Code Property Graph (2014) to out/"
+
+  def defaultOpts: Cpg14DumpOptions = Cpg14DumpOptions("out")
+}
+
+class DumpCpg14(options: Cpg14DumpOptions)(implicit semantics: Semantics) extends LayerCreator {
+  override val overlayName: String = DumpDdg.overlayName
+  override val description: String = DumpDdg.description
+
+  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+    val cpg = context.cpg
+    cpg.method.zipWithIndex.foreach {
+      case (method, i) =>
+        val str = method.start.dotCpg14.head
+        (File(options.outDir) / s"${i}-cpg.dot").write(str)
+    }
+  }
+
+  override def probe(cpg: Cpg): Boolean = false
+}

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14Tests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14Tests.scala
@@ -1,0 +1,33 @@
+package io.shiftleft.dataflowengineoss.layers.dataflows
+
+import better.files.File
+import io.shiftleft.dataflowengineoss.language.DataFlowCodeToCpgSuite
+import io.shiftleft.semanticcpg.layers.LayerCreatorContext
+
+class DumpCpg14Tests extends DataFlowCodeToCpgSuite {
+
+  override val code =
+    """
+      |int foo() {}
+      |int bar() {}
+      |""".stripMargin
+
+  "DumpCpg14" should {
+
+    "create two dot files for a CPG containing two methods" in {
+
+      File.usingTemporaryDirectory("dumpast") { tmpDir =>
+        val opts = Cpg14DumpOptions(tmpDir.path.toString)
+        implicit val s = semantics
+        val layerContext = new LayerCreatorContext(cpg)
+        new DumpCpg14(opts).run(layerContext)
+        (tmpDir / "0-cpg.dot").exists shouldBe true
+        (tmpDir / "1-cpg.dot").exists shouldBe true
+        (tmpDir / "0-cpg.dot").size should not be 0
+        (tmpDir / "1-cpg.dot").size should not be 0
+      }
+    }
+
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -8,7 +8,7 @@ object DotSerializer {
 
   case class Graph(vertices: List[nodes.StoredNode], edges: List[Edge]) {
 
-    def merge(other: Graph): Graph = {
+    def ++(other: Graph): Graph = {
       Graph((this.vertices ++ other.vertices).distinct, (this.edges ++ other.edges).distinct)
     }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -74,7 +74,7 @@ object DotSerializer {
     } else {
       DotSerializer.escape(edge.label)
     }
-    val labelStr = Some(s""" [ label = "$edgeLabel"] """).filter(_ => edge.label != "").getOrElse("")
+    val labelStr = Some(s""" [ label = "$edgeLabel"] """).filter(_ => edgeLabel != "").getOrElse("")
     s"""  "${edge.src.id}" -> "${edge.dst.id}" """ + labelStr
   }
 


### PR DESCRIPTION
Plotting and dumping of the intra procedural code property graph as presented in the 2014 paper "*Modeling and Discovering Vulnerabilities with Code Property Graphs*".

After `run.ossdataflow`, you can

* `run.dumpcpg14` to dump all cpgs to directory `out`
* `cpg.method("$name").plotDotCpg14` to plot the CPG

You can dump/plot AST, CFG, CDG, DDG, or the PDG individually using `run.dumpast`, `run.dumpcfg`, ... and `cpg.method("$name").plotDotAst`, `cpg.method("$name").plotDotCfg`, ...

Sample:

![cpg14](https://user-images.githubusercontent.com/1379115/94349358-ffd6ad00-0043-11eb-811c-9e73e683832c.png)
