### PR TITLE
Algorithmic fixes to increase performance of DDG generation

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DdgGenerator.scala
@@ -60,9 +60,9 @@ class DdgGenerator {
       List()
     } else {
       val parents = expand(dstNode)
-      val (visible, invisible) = parents.partition(x => shouldBeDisplayed(x.src))
+      val (visible, invisible) = parents.partition(x => shouldBeDisplayed(x.src) && x.srcVisible)
       visible.toList ++ invisible.toList.flatMap { n =>
-        inEdgesToDisplay(n.src, visited ++ List(dstNode)).map(y => Edge(y.src, dstNode, edgeType = edgeType))
+        inEdgesToDisplay(n.src, visited ++ List(dstNode)).map(y => Edge(y.src, dstNode, y.srcVisible, edgeType = edgeType, label = y.label))
       }
     }
   }
@@ -71,12 +71,12 @@ class DdgGenerator {
 
     val allInEdges = v
       .inE(EdgeTypes.REACHING_DEF)
-      .map(x => Edge(x.outNode.asInstanceOf[nodes.StoredNode], v, x.property(EdgeKeys.VARIABLE), edgeType))
+      .map(x => Edge(x.outNode.asInstanceOf[nodes.StoredNode], v, true, x.property(EdgeKeys.VARIABLE), edgeType))
 
     v match {
       case trackingPoint: nodes.TrackingPoint =>
-        trackingPoint.ddgInPathElem
-          .map(x => Edge(x.node.asInstanceOf[nodes.StoredNode], v, x.outEdgeLabel, edgeType))
+        trackingPoint.ddgInPathElem(withInvisible = true)
+          .map(x => Edge(x.node.asInstanceOf[nodes.StoredNode], v, x.visible, x.outEdgeLabel, edgeType))
           .iterator ++ allInEdges.filter(_.src.isInstanceOf[nodes.Method]).iterator
       case _ =>
         allInEdges.iterator

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -6,6 +6,8 @@ import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
+import scala.collection.mutable
+
 /**
   * Base class for nodes that can occur in data flows
   * */
@@ -23,9 +25,19 @@ class TrackingPoint(val traversal: Traversal[nodes.TrackingPoint]) extends AnyVa
   def cfgNode: Traversal[nodes.CfgNode] =
     traversal.map(_.cfgNode)
 
-  def ddgIn(implicit semantics: Semantics): Traversal[nodes.TrackingPoint] = traversal.flatMap(_.ddgIn)
+  def ddgIn(implicit semantics: Semantics): Traversal[nodes.TrackingPoint] = {
+    val cache = mutable.HashMap[nodes.TrackingPoint, List[PathElement]]()
+    val result = traversal.flatMap(x => x.ddgIn(List(PathElement(x)), withInvisible = false, cache))
+    cache.clear
+    result
+  }
 
-  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = traversal.flatMap(_.ddgInPathElem)
+  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = {
+    val cache = mutable.HashMap[nodes.TrackingPoint, List[PathElement]]()
+    val result = traversal.flatMap(x => x.ddgInPathElem(List(PathElement(x)), withInvisible = false, cache))
+    cache.clear
+    result
+  }
 
   def reachableBy[NodeType <: nodes.TrackingPoint](sourceTravs: Traversal[NodeType]*)(
       implicit context: EngineContext): Traversal[NodeType] = {

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -30,9 +30,9 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
       implicit context: EngineContext): Traversal[NodeType] =
     node.start.reachableBy(sourceTravs: _*)
 
-  def ddgIn(implicit semantics: Semantics): Traversal[TrackingPoint] = ddgIn(List())
+  def ddgIn(implicit semantics: Semantics): Traversal[TrackingPoint] = ddgIn(List(PathElement(node)))
 
-  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = ddgInPathElem(List())
+  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = ddgInPathElem(List(PathElement(node)))
 
   /**
     * Traverse back in the data dependence graph by one step, taking into account semantics

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -48,7 +48,10 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
     * @param path optional list of path elements that have been expanded already
     * */
   def ddgInPathElem(path: List[PathElement])(implicit semantics: Semantics): Traversal[PathElement] = {
-    Engine.expandIn(node, path).to(Traversal)
+    val elems = Engine.expandIn(node, path)
+    (elems.filter(_.visible) ++ elems
+      .filterNot(_.visible)
+      .flatMap(x => x.node.ddgInPathElem(x :: path))).distinct.to(Traversal)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -30,17 +30,21 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
       implicit context: EngineContext): Traversal[NodeType] =
     node.start.reachableBy(sourceTravs: _*)
 
-  def ddgIn(implicit semantics: Semantics): Traversal[TrackingPoint] = ddgIn(List(PathElement(node)), withInvisible = false)
+  def ddgIn(implicit semantics: Semantics): Traversal[TrackingPoint] =
+    ddgIn(List(PathElement(node)), withInvisible = false)
 
-  def ddgInPathElem(withInvisible : Boolean)(implicit semantics: Semantics): Traversal[PathElement] = ddgInPathElem(List(PathElement(node)), withInvisible)
+  def ddgInPathElem(withInvisible: Boolean)(implicit semantics: Semantics): Traversal[PathElement] =
+    ddgInPathElem(List(PathElement(node)), withInvisible)
 
-  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = ddgInPathElem(List(PathElement(node)), withInvisible = false)
+  def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] =
+    ddgInPathElem(List(PathElement(node)), withInvisible = false)
 
   /**
     * Traverse back in the data dependence graph by one step, taking into account semantics
     * @param path optional list of path elements that have been expanded already
     * */
-  def ddgIn(path: List[PathElement], withInvisible: Boolean)(implicit semantics: Semantics): Traversal[TrackingPoint] = {
+  def ddgIn(path: List[PathElement], withInvisible: Boolean)(
+      implicit semantics: Semantics): Traversal[TrackingPoint] = {
     ddgInPathElem(path, withInvisible).map(_.node)
   }
 
@@ -49,11 +53,12 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
     * taking into account semantics
     * @param path optional list of path elements that have been expanded already
     * */
-  def ddgInPathElem(path: List[PathElement], withInvisible : Boolean)(implicit semantics: Semantics): Traversal[PathElement] = {
+  def ddgInPathElem(path: List[PathElement], withInvisible: Boolean)(
+      implicit semantics: Semantics): Traversal[PathElement] = {
     val elems = Engine.expandIn(node, path)
     if (withInvisible) {
       elems
-    } else{
+    } else {
       (elems.filter(_.visible) ++ elems
         .filterNot(_.visible)
         .flatMap(x => x.node.ddgInPathElem(x :: path, withInvisible = false))).distinct.to(Traversal)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -129,9 +129,9 @@ class Engine(context: EngineContext) {
 
 object Engine {
 
-  def expandIn(curNode: nodes.TrackingPoint, path: List[PathElement], withInvisible: Boolean = false)(
+  def expandIn(curNode: nodes.TrackingPoint, path: List[PathElement])(
       implicit semantics: Semantics): List[PathElement] = {
-    val elems = curNode match {
+    curNode match {
       case argument: nodes.Expression =>
         val (arguments, nonArguments) = ddgInE(curNode, path).partition(_.outNode().isInstanceOf[nodes.Expression])
         val elemsForArguments = arguments.flatMap { e =>
@@ -141,13 +141,6 @@ object Engine {
         elems
       case _ =>
         ddgInE(curNode, path).map(edgeToPathElement)
-    }
-    if (withInvisible) {
-      elems
-    } else {
-      elems.filter(_.visible) ++ elems
-        .filterNot(_.visible)
-        .flatMap(x => expandIn(x.node, x :: path, withInvisible = false))
     }
   }
 
@@ -274,7 +267,7 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
     val curNode = path.head.node
 
     val resultsForParents: List[ReachableByResult] = {
-      expandIn(curNode, path, withInvisible = true).flatMap { parent =>
+      expandIn(curNode, path).flatMap { parent =>
         table.createFromTable(parent :: path).getOrElse {
           results(parent :: path, sources, table)
           table.get(parent.node).get

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -179,7 +179,7 @@ object Engine {
       val visible = if (sameCallSite) {
         val semanticExists = parentNode.asInstanceOf[nodes.Expression].semanticsForCallByArg.nonEmpty
         val internalMethodsForCall = parentNodeCall.flatMap(methodsForCall).to(Traversal).internal
-        semanticExists || internalMethodsForCall.isEmpty
+        (semanticExists && parentNode.isDefined) || internalMethodsForCall.isEmpty
       } else {
         parentNode.isDefined
       }

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
@@ -21,7 +21,9 @@ class TrackingPointTests extends DataFlowCodeToCpgSuite {
     cpg.method("sink").parameter.argument.ddgIn.l match {
       case List(param: nodes.MethodParameterIn) =>
         param.name shouldBe "y"
-      case _ => fail
+      case x =>
+        println(x)
+        fail
     }
   }
 

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
@@ -21,9 +21,7 @@ class TrackingPointTests extends DataFlowCodeToCpgSuite {
     cpg.method("sink").parameter.argument.ddgIn.l match {
       case List(param: nodes.MethodParameterIn) =>
         param.name shouldBe "y"
-      case x =>
-        println(x)
-        fail
+      case _ => fail
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -13,7 +13,11 @@ object DotSerializer {
     }
 
   }
-  case class Edge(src: nodes.StoredNode, dst: nodes.StoredNode, srcVisible : Boolean = true, label: String = "", edgeType: String = "")
+  case class Edge(src: nodes.StoredNode,
+                  dst: nodes.StoredNode,
+                  srcVisible: Boolean = true,
+                  label: String = "",
+                  edgeType: String = "")
 
   def dotGraph(root: nodes.AstNode, graph: Graph, withEdgeTypes: Boolean = false): String = {
     val sb = DotSerializer.namedGraphBegin(root)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -13,7 +13,7 @@ object DotSerializer {
     }
 
   }
-  case class Edge(src: nodes.StoredNode, dst: nodes.StoredNode, label: String = "", edgeType: String = "")
+  case class Edge(src: nodes.StoredNode, dst: nodes.StoredNode, srcVisible : Boolean = true, label: String = "", edgeType: String = "")
 
   def dotGraph(root: nodes.AstNode, graph: Graph, withEdgeTypes: Boolean = false): String = {
     val sb = DotSerializer.namedGraphBegin(root)


### PR DESCRIPTION
This PR addresses a nasty algorithmic problem that was introduced in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/968  : 

When visiting a DDG node that should not be visible according to the semantic, we simply fast-forward to visible parents via a recursive function call. If we do not cache here, we end up spending most of the time determining visible parents for nodes. This PR introduces the necessary cache, making it possible to export all CPG'14s for VLC in a few minutes.

Added a similar cache for the `ddgIn` family of functions. In this case, we hold a cache for the traversal duration.