### PR TITLE
Bump Ammonite version

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -47,7 +47,7 @@ val BetterFilesVersion = "3.8.0"
 val CaskVersion = "0.6.7"
 val CatsVersion = "2.0.0"
 val CirceVersion = "0.12.2"
-val AmmoniteVersion = "1.8.1"
+val AmmoniteVersion = "2.0.4"
 val ZeroturnaroundVersion = "1.13"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Downstream, internally, we are already using `2.0.4`, so the upgrade
should be relatively painless.
Postponing the upgrade to `2.2.0` since it would require bumping Scala
version (`2.13.2` or `2.13.3`) as well.

Test changes are cosmetic due to API/implementation changes of ammonite.