### PR TITLE
resolve cyclic cpg<->fuzzyc dependency by using fuzzyc binary

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,7 @@ lazy val dataflowengineoss = Projects.dataflowengineoss
 lazy val cpgvalidator = Projects.cpgvalidator
 lazy val console = Projects.console
 lazy val queries = Projects.queries
+lazy val fuzzyc2cpg = Projects.fuzzyc2cpg
 
 ThisBuild/scalacOptions ++= Seq(
   "-deprecation",

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -67,3 +67,6 @@ publishArtifact in (Test, packageBin) := true
 
 // execute tests in root project so that they work in sbt *and* intellij
 Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value
+
+// stage fuzzyc2cpg before test
+Test/compile := (Test/compile).dependsOn(Projects.fuzzyc2cpg/stage).value

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -64,3 +64,6 @@ libraryDependencies ++= Seq(
 )
 
 publishArtifact in (Test, packageBin) := true
+
+// execute tests in root project so that they work in sbt *and* intellij
+Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -60,7 +60,6 @@ libraryDependencies ++= Seq(
   "org.zeroturnaround"   %  "zt-zip"        % ZeroturnaroundVersion,
   "com.lihaoyi"          %% "ammonite"      % AmmoniteVersion cross CrossVersion.full,
   "com.lihaoyi" 	       %% "cask" 	        % CaskVersion,
-  "io.shiftleft"         %% "fuzzyc2cpg"    % Versions.fuzzyc2cpg % Test exclude("ch.qos.logback", "logback-classic"),
   "org.scalatest"        %% "scalatest"     % Versions.scalatest % Test
 )
 

--- a/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
@@ -7,7 +7,6 @@ import better.files.File
 import io.shiftleft.console.cpgcreation.{CpgGenerator, LanguageFrontend}
 import io.shiftleft.console.{Console, ConsoleConfig, DefaultAmmoniteExecutor, InstallConfig}
 import io.shiftleft.console.workspacehandling.{Project, ProjectFile, WorkspaceLoader}
-import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
 
 object ConsoleFixture {
   def apply[T <: Console[Project]](constructor: String => T = { x =>
@@ -45,25 +44,27 @@ class TestCpgGenerator(config: ConsoleConfig) extends CpgGenerator(config) {
   override def createFrontendByPath(
       inputPath: String,
   ): Option[LanguageFrontend] = {
-    Some(new FuzzyCTestingFrontend)
+    // Some(new FuzzyCTestingFrontend)
+    ???
   }
 
   override def createFrontendByLanguage(language: String): Option[LanguageFrontend] = {
-    Some(new FuzzyCTestingFrontend)
+    // Some(new FuzzyCTestingFrontend)
+    ???
   }
 
-  private class FuzzyCTestingFrontend extends LanguageFrontend {
+  // private class FuzzyCTestingFrontend extends LanguageFrontend {
 
-    override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
-      val fuzzyc = new FuzzyC2Cpg()
-      File(inputPath).list.foreach(println(_))
-      val cpg = fuzzyc.runAndOutput(Set(inputPath), Set(".c"), Some(outputPath))
-      cpg.close()
-      Some(outputPath)
-    }
+  //   override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
+  //     val fuzzyc = new FuzzyC2Cpg()
+  //     File(inputPath).list.foreach(println(_))
+  //     val cpg = fuzzyc.runAndOutput(Set(inputPath), Set(".c"), Some(outputPath))
+  //     cpg.close()
+  //     Some(outputPath)
+  //   }
 
-    def isAvailable: Boolean = true
+  //   def isAvailable: Boolean = true
 
-  }
+  // }
 
 }

--- a/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
@@ -8,6 +8,8 @@ import io.shiftleft.console.cpgcreation.{CpgGenerator, LanguageFrontend}
 import io.shiftleft.console.{Console, ConsoleConfig, DefaultAmmoniteExecutor, InstallConfig}
 import io.shiftleft.console.workspacehandling.{Project, ProjectFile, WorkspaceLoader}
 
+import scala.sys.process.Process
+
 object ConsoleFixture {
   def apply[T <: Console[Project]](constructor: String => T = { x =>
     new TestConsole(x)
@@ -44,27 +46,31 @@ class TestCpgGenerator(config: ConsoleConfig) extends CpgGenerator(config) {
   override def createFrontendByPath(
       inputPath: String,
   ): Option[LanguageFrontend] = {
-    // Some(new FuzzyCTestingFrontend)
-    ???
+    Some(new FuzzyCTestingFrontend)
   }
 
   override def createFrontendByLanguage(language: String): Option[LanguageFrontend] = {
-    // Some(new FuzzyCTestingFrontend)
-    ???
+    Some(new FuzzyCTestingFrontend)
   }
 
-  // private class FuzzyCTestingFrontend extends LanguageFrontend {
+  private class FuzzyCTestingFrontend extends LanguageFrontend {
 
-  //   override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
-  //     val fuzzyc = new FuzzyC2Cpg()
-  //     File(inputPath).list.foreach(println(_))
-  //     val cpg = fuzzyc.runAndOutput(Set(inputPath), Set(".c"), Some(outputPath))
-  //     cpg.close()
-  //     Some(outputPath)
-  //   }
+    override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
+      val p = Process(
+        List(
+          "./fuzzyc2cpg.sh",
+          inputPath,
+          "--output",
+          outputPath
+        )
+      ).run()
+      assert(p.exitValue() == 0, s"fuzzyc exited with code ${p.exitValue}")
 
-  //   def isAvailable: Boolean = true
+      Some(outputPath)
+    }
 
-  // }
+    def isAvailable: Boolean = true
+
+  }
 
 }

--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -7,7 +7,6 @@ val antlrVersion = "4.7.2"
 libraryDependencies ++= Seq(
   "org.antlr"     %  "antlr4-runtime" % antlrVersion,
   "org.scalatest" %% "scalatest"      % Versions.scalatest % Test,
-  "io.shiftleft"  %% "fuzzyc2cpg"     % Versions.fuzzyc2cpg % Test exclude("ch.qos.logback", "logback-classic"),
 )
 
 enablePlugins(Antlr4Plugin)

--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -15,3 +15,6 @@ Antlr4 / antlr4PackageName := Some("io.shiftleft.dataflowengineoss")
 Antlr4 / antlr4Version := antlrVersion
 Antlr4 / javaSource := (sourceManaged in Compile).value
 sources in (Compile, doc) ~= (_ filter (_ => false))
+
+// execute tests in root project so that they work in sbt *and* intellij
+Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/fuzzyc2cpg.sh
+++ b/fuzzyc2cpg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+SCRIPT_ABS_PATH=$(readlink -f "$0")
+SCRIPT_ABS_DIR=$(dirname $SCRIPT_ABS_PATH)
+
+$SCRIPT_ABS_DIR/fuzzyc2cpg/target/universal/stage/bin/fuzzyc2cpg-wrapper $@
+

--- a/fuzzyc2cpg/build.sbt
+++ b/fuzzyc2cpg/build.sbt
@@ -1,0 +1,5 @@
+name := "fuzzyc2cpg-wrapper"
+
+libraryDependencies += "io.shiftleft" %% "fuzzyc2cpg" % Versions.fuzzyc2cpg
+
+enablePlugins(JavaAppPackaging)

--- a/fuzzyc2cpg/src/main/scala/Fuzzyc2cpg.scala
+++ b/fuzzyc2cpg/src/main/scala/Fuzzyc2cpg.scala
@@ -1,0 +1,3 @@
+object Fuzzyc2cpg extends App {
+  io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg.main(args)
+}

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -8,4 +8,5 @@ object Projects {
   lazy val cpgvalidator = project.in(file("cpgvalidator"))
   lazy val console = project.in(file("console"))
   lazy val queries = project.in(file("queries"))
+  lazy val fuzzyc2cpg = project.in(file("fuzzyc2cpg"))
 }

--- a/queries/build.sbt
+++ b/queries/build.sbt
@@ -5,5 +5,4 @@ dependsOn(Projects.semanticcpg % "compile -> compile; test -> test",
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest"  % Versions.scalatest % Test,
-  "io.shiftleft"  %% "fuzzyc2cpg" % Versions.fuzzyc2cpg % Test exclude("ch.qos.logback", "logback-classic"),
 )

--- a/queries/build.sbt
+++ b/queries/build.sbt
@@ -6,3 +6,6 @@ dependsOn(Projects.semanticcpg % "compile -> compile; test -> test",
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest"  % Versions.scalatest % Test,
 )
+
+// execute tests in root project so that they work in sbt *and* intellij
+Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -6,7 +6,6 @@ libraryDependencies ++= Seq(
   "org.json4s"             %% "json4s-native"            % "3.6.7",
   "org.scala-lang.modules" %% "scala-collection-contrib" % "0.2.1",
   "org.scalatest"          %% "scalatest"                % Versions.scalatest,
-  "io.shiftleft"           %% "fuzzyc2cpg"               % Versions.fuzzyc2cpg % Test exclude("ch.qos.logback", "logback-classic"),
 )
 
 scalacOptions in (Compile, doc) ++= Seq(

--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -20,3 +20,6 @@ publishArtifact in (Test, packageBin) := true
 
 // execute tests in root project so that they work in sbt *and* intellij
 Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value
+
+// stage fuzzyc2cpg before test
+Test/compile := (Test/compile).dependsOn(Projects.fuzzyc2cpg/stage).value

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/LanguageFrontend.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/testfixtures/LanguageFrontend.scala
@@ -3,7 +3,6 @@ package io.shiftleft.semanticcpg.testfixtures
 import java.io.File
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
 
 /**
   * LanguageFrontend encapsulates the logic that translates the source code directory
@@ -31,8 +30,9 @@ object LanguageFrontend {
     def execute(sourceCodePath: File): Cpg = {
       val cpgFile = File.createTempFile("fuzzyc", ".zip")
       cpgFile.deleteOnExit()
-      val fuzzyc2Cpg = new FuzzyC2Cpg()
-      fuzzyc2Cpg.runAndOutput(Set(sourceCodePath.getAbsolutePath), Set(fileSuffix), Some(cpgFile.getAbsolutePath))
+      // val fuzzyc2Cpg = new FuzzyC2Cpg()
+      // fuzzyc2Cpg.runAndOutput(Set(sourceCodePath.getAbsolutePath), Set(fileSuffix), Some(cpgFile.getAbsolutePath))
+      ???
     }
     override val fileSuffix: String = ".c"
   }


### PR DESCRIPTION
* instead of having both in the same path we now use fuzzyc as a separate subproject with it's own classpath
* all dependent subprojects ensure that fuzzyc is staged before they run their tests
* works from sbt and intellij
* once this is approved/merged i'll apply the same mechanism to the codescience build, which has the same issue