### PR TITLE
Add POST_EXECUTION_CALL node for library modeling.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements-internal.json
@@ -622,7 +622,10 @@
         {
             "name": "IMPLICIT_CALL", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"]
         },
-        {
+      {
+        "name": "POST_EXECUTION_CALL", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"]
+      },
+      {
             "name": "ANNOTATION_LITERAL", "keys" : ["DEPTH_FIRST_ORDER", "INTERNAL_FLAGS"]
         },
         {

--- a/codepropertygraph/src/main/resources/schemas/enhancements.json
+++ b/codepropertygraph/src/main/resources/schemas/enhancements.json
@@ -20,8 +20,17 @@
         "is": ["CALL_REPR", "TRACKING_POINT"],
         "outEdges" : []
       },
+      {
+        "id":3071,"name" : "POST_EXECUTION_CALL",
+        "keys" : ["CODE", "NAME", "SIGNATURE", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
+        "comment" : "Indicates the existence of a call executed on a return value or out parameter of a method after this method has been executed. This is used to model framework code calling functors returned from user code. The outgoing REF edge indicates on which returned entitity the call will happen.",
+        "is": ["CALL_REPR", "TRACKING_POINT"],
+        "outEdges" : [
+          {"edgeName": "REF", "inNodes": [{"name": "METHOD_RETURN"}, {"name": "METHOD_PARAMETER_OUT"}]}
+        ]
+      },
 
-        {"id":24, "name": "TAG",
+      {"id":24, "name": "TAG",
          "keys": ["NAME", "VALUE"],
          "comment": "A string tag",
          "outEdges": []
@@ -49,7 +58,8 @@
               {"name": "TYPE_DECL", "cardinality": "0-1:n"},
               {"name": "METHOD", "cardinality": "0-1:n"},
               {"name": "METHOD_PARAMETER_OUT"},
-              {"name": "IMPLICIT_CALL"}
+              {"name": "IMPLICIT_CALL"},
+              {"name": "POST_EXECUTION_CALL"}
             ]},
              {"edgeName": "REACHING_DEF", "inNodes": [
               {"name": "CALL"},

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
@@ -12,6 +12,7 @@ class WithinMethodMethods(val node: nodes.WithinMethod) extends AnyVal {
     case node: nodes.MethodParameterOut => walkUpAst(node)
     case node: nodes.MethodReturn       => walkUpAst(node)
     case node: nodes.ImplicitCall       => walkUpAst(node)
+    case node: nodes.PostExecutionCall  => walkUpAst(node)
     case node: nodes.Expression         => expressionToMethod(node)
   }
 


### PR DESCRIPTION
A POST_EXECUTION_CALL node indicates the existence of a call executed
on a return value or out parameter of a method after this method has
been executed. This is used to model framework code calling functors
returned from user code. The outgoing REF edge indicates on which
returned entitity the call will happen.