### PR TITLE
Introduce `HASH` field in `META_DATA` node.

### DIFF
--- a/codepropertygraph/src/main/resources/schemas/base.json
+++ b/codepropertygraph/src/main/resources/schemas/base.json
@@ -10,6 +10,7 @@
         { "id" : 13, "name": "VERSION", "comment" : "A version, given as a string", "valueType" : "string", "cardinality" : "one"},
 	{ "id" : 118, "name" : "OVERLAYS", "comment" : "Names of overlays applied to this graph, in order of application", "valueType" : "string", "cardinality" : "list"},
 	{ "id" : 119, "name" : "POLICY_DIRECTORIES", "comment": "Sub directories of the policy directory that should be loaded when processing the CPG", "valueType" : "string", "cardinality" : "list"},
+	{ "id" : 120, "name" : "HASH", "comment" : "Hash value of the artifact that this CPG is built from.", "valueType": "string", "cardinality" : "one"},
 
         // Properties that indicate where the code can be found
 
@@ -67,7 +68,7 @@
         {
             "id" : 39,
             "name" : "META_DATA",
-            "keys" : ["LANGUAGE", "VERSION", "OVERLAYS", "POLICY_DIRECTORIES"],
+            "keys" : ["LANGUAGE", "VERSION", "OVERLAYS", "POLICY_DIRECTORIES", "HASH"],
             "comment" : "Node to save meta data about the graph on its properties. Exactly one node of this type per graph",
             "outEdges" : []
         },


### PR DESCRIPTION
We need a field to store an artifact hash - populated in a frontend-dependent manner. See discussion at https://github.com/ShiftLeftSecurity/product/issues/5641