### PR TITLE
Add POST_EXECUTION_CALL node for library modeling.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -65,6 +65,14 @@ object LocationCreator {
           implicitCall.lineNumber,
           implicitCall.method
         )
+      case postExecutionCall: nodes.PostExecutionCall =>
+        apply(
+          postExecutionCall,
+          postExecutionCall.code,
+          postExecutionCall.label,
+          postExecutionCall.lineNumber,
+          postExecutionCall.method
+        )
       case method: nodes.Method =>
         apply(
           method,


### PR DESCRIPTION
A POST_EXECUTION_CALL node indicates the existence of a call executed
on a return value or out parameter of a method after this method has
been executed. This is used to model framework code calling functors
returned from user code. The outgoing REF edge indicates on which
returned entitity the call will happen.