### PR TITLE
Return only sample flows in `reachableByFlows` + optimizations

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -26,15 +26,15 @@ class TrackingPoint(val traversal: Traversal[nodes.TrackingPoint]) extends AnyVa
     traversal.map(_.cfgNode)
 
   def ddgIn(implicit semantics: Semantics): Traversal[nodes.TrackingPoint] = {
-    val cache = mutable.HashMap[nodes.TrackingPoint, List[PathElement]]()
-    val result = traversal.flatMap(x => x.ddgIn(List(PathElement(x)), withInvisible = false, cache))
+    val cache = mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]]()
+    val result = traversal.flatMap(x => x.ddgIn(Vector(PathElement(x)), withInvisible = false, cache))
     cache.clear
     result
   }
 
   def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = {
-    val cache = mutable.HashMap[nodes.TrackingPoint, List[PathElement]]()
-    val result = traversal.flatMap(x => x.ddgInPathElem(List(PathElement(x)), withInvisible = false, cache))
+    val cache = mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]]()
+    val result = traversal.flatMap(x => x.ddgInPathElem(Vector(PathElement(x)), withInvisible = false, cache))
     cache.clear
     result
   }
@@ -66,7 +66,7 @@ class TrackingPoint(val traversal: Traversal[nodes.TrackingPoint]) extends AnyVa
     paths.to(Traversal)
   }
 
-  private def removeConsecutiveDuplicates[T](l: List[T]): List[T] = {
+  private def removeConsecutiveDuplicates[T](l: Vector[T]): List[T] = {
     l.headOption.map(x => x :: l.sliding(2).collect { case Seq(a, b) if a != b => b }.toList).getOrElse(List())
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -33,21 +33,21 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
     node.start.reachableBy(sourceTravs: _*)
 
   def ddgIn(implicit semantics: Semantics): Traversal[TrackingPoint] = {
-    val cache = mutable.HashMap[nodes.TrackingPoint, List[PathElement]]()
-    val result = ddgIn(List(PathElement(node)), withInvisible = false, cache)
+    val cache = mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]]()
+    val result = ddgIn(Vector(PathElement(node)), withInvisible = false, cache)
     cache.clear()
     result
   }
 
   def ddgInPathElem(withInvisible: Boolean,
-                    cache: mutable.HashMap[nodes.TrackingPoint, List[PathElement]] =
-                      mutable.HashMap[nodes.TrackingPoint, List[PathElement]]())(
+                    cache: mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]] =
+                      mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]]())(
       implicit semantics: Semantics): Traversal[PathElement] =
-    ddgInPathElem(List(PathElement(node)), withInvisible, cache)
+    ddgInPathElem(Vector(PathElement(node)), withInvisible, cache)
 
   def ddgInPathElem(implicit semantics: Semantics): Traversal[PathElement] = {
-    val cache = mutable.HashMap[nodes.TrackingPoint, List[PathElement]]()
-    val result = ddgInPathElem(List(PathElement(node)), withInvisible = false, cache)
+    val cache = mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]]()
+    val result = ddgInPathElem(Vector(PathElement(node)), withInvisible = false, cache)
     cache.clear()
     result
   }
@@ -56,9 +56,9 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
     * Traverse back in the data dependence graph by one step, taking into account semantics
     * @param path optional list of path elements that have been expanded already
     * */
-  def ddgIn(path: List[PathElement],
+  def ddgIn(path: Vector[PathElement],
             withInvisible: Boolean,
-            cache: mutable.HashMap[nodes.TrackingPoint, List[PathElement]])(
+            cache: mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]])(
       implicit semantics: Semantics): Traversal[TrackingPoint] = {
     ddgInPathElem(path, withInvisible, cache).map(_.node)
   }
@@ -68,18 +68,18 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
     * taking into account semantics
     * @param path optional list of path elements that have been expanded already
     * */
-  def ddgInPathElem(path: List[PathElement],
+  def ddgInPathElem(path: Vector[PathElement],
                     withInvisible: Boolean,
-                    cache: mutable.HashMap[nodes.TrackingPoint, List[PathElement]])(
+                    cache: mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]])(
       implicit semantics: Semantics): Traversal[PathElement] = {
     val result = ddgInPathElemInternal(path, withInvisible, cache).to(Traversal)
     result
   }
 
-  private def ddgInPathElemInternal(path: List[PathElement],
+  private def ddgInPathElemInternal(path: Vector[PathElement],
                                     withInvisible: Boolean,
-                                    cache: mutable.HashMap[nodes.TrackingPoint, List[PathElement]])(
-      implicit semantics: Semantics): List[PathElement] = {
+                                    cache: mutable.HashMap[nodes.TrackingPoint, Vector[PathElement]])(
+      implicit semantics: Semantics): Vector[PathElement] = {
 
     if (cache.contains(node)) {
       return cache(node)
@@ -91,7 +91,7 @@ class TrackingPointMethods[NodeType <: nodes.TrackingPoint](val node: NodeType) 
     } else {
       (elems.filter(_.visible) ++ elems
         .filterNot(_.visible)
-        .flatMap(x => x.node.ddgInPathElem(x :: path, withInvisible = false, cache))).distinct
+        .flatMap(x => x.node.ddgInPathElem(x +: path, withInvisible = false, cache))).distinct
     }
     cache.put(node, result)
     result

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -273,7 +273,10 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
     val resultsForParents: List[ReachableByResult] = {
       expandIn(curNode, path).iterator.flatMap { parent =>
         val pathFromParent = parent :: path
-        table.createFromTable(pathFromParent).getOrElse {
+        val cachedResult = table.createFromTable(pathFromParent)
+        if (cachedResult.isDefined) {
+          cachedResult.get
+        } else {
           results(pathFromParent, sources, table)
         }
       }.toList

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -301,7 +301,9 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
       endStates ++ retsToResolve
     }
 
-    val res = (resultsForParents ++ resultsForCurNode).distinct
+    val res = (resultsForParents ++ resultsForCurNode).distinctBy{ x =>
+      (x.path.headOption ++ x.path.lastOption, x.partial, x.callDepth)
+    }
     table.add(curNode, res)
     res
   }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -280,7 +280,7 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
     val resultsForCurNode = {
       val endStates = if (sources.contains(curNode.asInstanceOf[NodeType])) {
         List(ReachableByResult(path))
-      } else if (curNode.isInstanceOf[nodes.MethodParameterIn]) {
+      } else if ((task.callDepth != context.config.maxCallDepth) && curNode.isInstanceOf[nodes.MethodParameterIn]) {
         List(ReachableByResult(path, partial = true))
       } else {
         List()
@@ -288,7 +288,10 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
 
       val retsToResolve = curNode match {
         case call: nodes.Call =>
-          if (methodsForCall(call).to(Traversal).internal.nonEmpty && semanticsForCall(call).isEmpty) {
+          if ((task.callDepth != context.config.maxCallDepth) && methodsForCall(call)
+                .to(Traversal)
+                .internal
+                .nonEmpty && semanticsForCall(call).isEmpty) {
             List(ReachableByResult(PathElement(path.head.node, resolved = false) +: path.tail, partial = true))
           } else {
             List()

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -298,7 +298,7 @@ private class ReachableByCallable(task: ReachableByTask, context: EngineContext)
       endStates ++ retsToResolve
     }
 
-    val res = resultsForParents ++ resultsForCurNode
+    val res = (resultsForParents ++ resultsForCurNode).distinct
     table.add(curNode, res)
     res
   }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -22,12 +22,11 @@ class ResultTable {
     * table, and if so, for each result, determine the path up to `first` and prepend it to
     * `path`, giving us new results via table lookup.
     */
-  def createFromTable(path: List[PathElement]): Option[List[ReachableByResult]] = {
-    val first = path.head
+  def createFromTable(first: PathElement, remainder: List[PathElement]): Option[List[ReachableByResult]] = {
     table.get(first.node).map { res =>
       res.map { r =>
         val pathToFirstNode = r.path.slice(0, r.path.map(_.node).indexOf(first.node))
-        val completePath =  pathToFirstNode ++ path
+        val completePath = pathToFirstNode ++ (first :: remainder)
         r.copy(path = completePath)
       }
     }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -22,11 +22,11 @@ class ResultTable {
     * table, and if so, for each result, determine the path up to `first` and prepend it to
     * `path`, giving us new results via table lookup.
     */
-  def createFromTable(first: PathElement, remainder: List[PathElement]): Option[List[ReachableByResult]] = {
+  def createFromTable(first: PathElement, remainder: Vector[PathElement]): Option[List[ReachableByResult]] = {
     table.get(first.node).map { res =>
       res.map { r =>
         val pathToFirstNode = r.path.slice(0, r.path.map(_.node).indexOf(first.node))
-        val completePath = pathToFirstNode ++ (first :: remainder)
+        val completePath = pathToFirstNode ++ (first +: remainder)
         r.copy(path = completePath)
       }
     }
@@ -50,10 +50,10 @@ class ResultTable {
   * @param partial indicate whether this result stands on its own or requires further analysis,
   *                e.g., by expanding output arguments backwards into method output parameters.
   * */
-case class ReachableByResult(path: List[PathElement], callDepth: Int = 0, partial: Boolean = false) {
+case class ReachableByResult(path: Vector[PathElement], callDepth: Int = 0, partial: Boolean = false) {
   def source: nodes.TrackingPoint = path.head.node
 
-  def unresolvedArgs: List[nodes.TrackingPoint] =
+  def unresolvedArgs: Vector[nodes.TrackingPoint] =
     path.collect {
       case elem if !elem.resolved =>
         elem.node

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -5,15 +5,15 @@ import scala.jdk.CollectionConverters._
 
 class ResultTable {
 
-  private val table = new java.util.concurrent.ConcurrentHashMap[nodes.StoredNode, List[ReachableByResult]].asScala
+  private val table = new java.util.concurrent.ConcurrentHashMap[nodes.StoredNode, Vector[ReachableByResult]].asScala
 
   /**
     * Add all results in `value` to table entry at `key`, appending to existing
     * results.
     */
-  def add(key: nodes.StoredNode, value: List[ReachableByResult]): Unit = {
+  def add(key: nodes.StoredNode, value: Vector[ReachableByResult]): Unit = {
     table.asJava.compute(key, { (_, existingValue) =>
-      Option(existingValue).toList.flatten ++ value
+      Option(existingValue).toVector.flatten ++ value
     })
   }
 
@@ -22,7 +22,7 @@ class ResultTable {
     * table, and if so, for each result, determine the path up to `first` and prepend it to
     * `path`, giving us new results via table lookup.
     */
-  def createFromTable(first: PathElement, remainder: Vector[PathElement]): Option[List[ReachableByResult]] = {
+  def createFromTable(first: PathElement, remainder: Vector[PathElement]): Option[Vector[ReachableByResult]] = {
     table.get(first.node).map { res =>
       res.map { r =>
         val pathToFirstNode = r.path.slice(0, r.path.map(_.node).indexOf(first.node))
@@ -36,7 +36,7 @@ class ResultTable {
     * Retrieve list of results for `node` or None if they are not
     * available in the table.
     */
-  def get(node: nodes.StoredNode): Option[List[ReachableByResult]] = {
+  def get(node: nodes.StoredNode): Option[Vector[ReachableByResult]] = {
     table.get(node)
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -26,7 +26,8 @@ class ResultTable {
     val first = path.head
     table.get(first.node).map { res =>
       res.map { r =>
-        val completePath = r.path.slice(0, r.path.map(_.node).indexOf(first.node)) ++ path
+        val pathToFirstNode = r.path.slice(0, r.path.map(_.node).indexOf(first.node))
+        val completePath =  pathToFirstNode ++ path
         r.copy(path = completePath)
       }
     }

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/language/CDataFlowTests.scala
@@ -464,19 +464,16 @@ class CDataFlowTests12 extends DataFlowCodeToCpgSuite {
     val sink = cpg.call.code("z\\+=a").argument(1)
     val flows = sink.reachableByFlows(source).l
 
-    flows.size shouldBe 2
+    flows.size shouldBe 1
 
     flows.map(flowToResultPairs).toSet shouldBe
-      Set(List[(String, Option[Integer])](
-            ("a = 0x37", 3),
-            ("b = a", 4),
-            ("z = b", 5),
-            ("z+=a", 6)
-          ),
-          List[(String, Option[Integer])](
-            ("a = 0x37", 3),
-            ("z+=a", 6)
-          ))
+      Set(
+        List[(String, Option[Integer])](
+          ("a = 0x37", 3),
+          ("b = a", 4),
+          ("z = b", 5),
+          ("z+=a", 6)
+        ))
   }
 }
 
@@ -497,7 +494,7 @@ class CDataFlowTests13 extends DataFlowCodeToCpgSuite {
     val sink = cpg.identifier.name("w")
     val flows = sink.reachableByFlows(source).l
 
-    flows.size shouldBe 2
+    flows.size shouldBe 1
 
     flows.map(flowToResultPairs).toSet shouldBe
       Set(
@@ -505,11 +502,6 @@ class CDataFlowTests13 extends DataFlowCodeToCpgSuite {
           ("a = 0x37", 3),
           ("b = a", 4),
           ("z = b", 5),
-          ("z+=a", 6),
-          ("w = z", 7)
-        ),
-        List[(String, Option[Integer])](
-          ("a = 0x37", 3),
           ("z+=a", 6),
           ("w = z", 7)
         )
@@ -566,21 +558,7 @@ class CDataFlowTests15 extends DataFlowCodeToCpgSuite {
     val source = cpg.method.parameter.name("y")
     val sink = cpg.identifier.name("z")
     val flows = sink.reachableByFlows(source).l
-
-    flows.map(flowToResultPairs).toSet shouldBe Set(
-      List[(String, Option[Integer])](
-        ("foo(bool x, void* y)", 2),
-        ("g(y)", 3),
-        ("x ? f(y) : g(y)", 3),
-        ("* z =  x ? f(y) : g(y)", 3)
-      ),
-      List[(String, Option[Integer])](
-        ("foo(bool x, void* y)", 2),
-        ("f(y)", 3),
-        ("x ? f(y) : g(y)", 3),
-        ("* z =  x ? f(y) : g(y)", 3)
-      )
-    )
+    flows.size shouldBe 1
   }
 }
 

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -21,8 +21,8 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1 = List(ReachableByResult(Vector(PathElement(node1))))
-      val res2 = List(ReachableByResult(Vector(PathElement(node2))))
+      val res1 = Vector(ReachableByResult(Vector(PathElement(node1))))
+      val res2 = Vector(ReachableByResult(Vector(PathElement(node2))))
       table.add(node1, res1)
       table.add(node1, res2)
       table.get(node1) match {
@@ -52,9 +52,9 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node4 = cpg.literal.code("moo").head
       val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table = new ResultTable
-      table.add(pivotNode, List(ReachableByResult(pathContainingPivot)))
+      table.add(pivotNode, Vector(ReachableByResult(pathContainingPivot)))
       table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
-        case Some(List(ReachableByResult(path, _, _))) =>
+        case Some(Vector(ReachableByResult(path, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case None => fail
       }

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -50,11 +50,10 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val pivotNode = cpg.literal.code("bar").head
       val node3 = cpg.literal.code("woo").head
       val node4 = cpg.literal.code("moo").head
-      val pathFromPivot = List(PathElement(pivotNode), PathElement(node1))
       val pathContainingPivot = List(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table = new ResultTable
       table.add(pivotNode, List(ReachableByResult(pathContainingPivot)))
-      table.createFromTable(pathFromPivot) match {
+      table.createFromTable(PathElement(pivotNode), List(PathElement(node1))) match {
         case Some(List(ReachableByResult(path, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case None => fail

--- a/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
+++ b/dataflowengineoss/src/test/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTableTests.scala
@@ -21,8 +21,8 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val node1 = cpg.literal.head
       val node2 = cpg.literal.last
       val table = new ResultTable
-      val res1 = List(ReachableByResult(List(PathElement(node1))))
-      val res2 = List(ReachableByResult(List(PathElement(node2))))
+      val res1 = List(ReachableByResult(Vector(PathElement(node1))))
+      val res2 = List(ReachableByResult(Vector(PathElement(node2))))
       table.add(node1, res1)
       table.add(node1, res2)
       table.get(node1) match {
@@ -50,10 +50,10 @@ class ResultTableTests extends AnyWordSpec with Matchers {
       val pivotNode = cpg.literal.code("bar").head
       val node3 = cpg.literal.code("woo").head
       val node4 = cpg.literal.code("moo").head
-      val pathContainingPivot = List(PathElement(node4), PathElement(pivotNode), PathElement(node3))
+      val pathContainingPivot = Vector(PathElement(node4), PathElement(pivotNode), PathElement(node3))
       val table = new ResultTable
       table.add(pivotNode, List(ReachableByResult(pathContainingPivot)))
-      table.createFromTable(PathElement(pivotNode), List(PathElement(node1))) match {
+      table.createFromTable(PathElement(pivotNode), Vector(PathElement(node1))) match {
         case Some(List(ReachableByResult(path, _, _))) =>
           path.map(_.node.id) shouldBe List(node4.id, pivotNode.id, node1.id)
         case None => fail


### PR DESCRIPTION
Prep work for upcoming article on data flow.

It is computationally prohibitive to enumerate all flows, however, determining whether a flow exists and returning a sample can be done efficiently. This PR modifies `reachableByFlows` to accomplish this, return the flow of maximum length. If multiple flows of maximum length exist, we sort by node-ids to ensure that we obtain reproducible.

* Return only sample flows in data flow calculation
* Use vectors as opposed to lists to store path elements and results
* Deduplicate results before writing them to the result table
* Do not store partial results if this is the last analysis stage
