### PR TITLE
Stable ordering for flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,4 +271,3 @@ A metadata block (type META_DATA) is included in CPG with two fields: a language
 
 [3] The ShiftLeft Tinkergraph
     https://github.com/ShiftLeftSecurity/tinkergraph-gremlin
-


### PR DESCRIPTION
Due to parallel computation, we were still seeing some instability in the order in which flows were reported. This PR addresses this.