### PR TITLE
Allow loading of CPGs produced by js2cpg into joern

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -110,6 +110,22 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
           new CfgDominatorPass(cpg),
           new CdgPass(cpg),
         )
+      case Languages.JAVASCRIPT =>
+        Iterator(
+          new ArgumentCompat(cpg),
+          new MethodInstCompat(cpg),
+          new MethodStubCreator(cpg),
+          new MethodDecoratorPass(cpg),
+          new CapturingLinker(cpg),
+          new Linker(cpg),
+          new FileNameCompat(cpg),
+          new FileLinker(cpg),
+          new ContainsEdgePass(cpg),
+          new MethodExternalDecoratorPass(cpg),
+          new CfgDominatorPass(cpg),
+          new CdgPass(cpg),
+          new NamespaceCreator(cpg),
+        )
       case _ => Iterator()
     }
   }


### PR DESCRIPTION
As for Java and LLVM-based CPGs, if we do find that someone gives us a Javascript CPG, let's execute at least some of the enhancements. We're missing policy-related enhancements and some passes we use specifically for the commercial data flow engine, but the resulting CPG is at least more useful than the base CPG provided by js2cpg alone.