### PR TITLE
Bring back CodeDirToCpgFixture

### DIFF
--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeDirToCpgFixture.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeDirToCpgFixture.scala
@@ -1,0 +1,37 @@
+package io.shiftleft.semanticcpg.testfixtures
+
+import java.io.File
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
+import io.shiftleft.semanticcpg.testfixtures.LanguageFrontend.FuzzycFrontend
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CodeDirToCpgFixture extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  val dir: java.io.File = null
+  var cpg: Cpg = _
+  val frontend: LanguageFrontend = new FuzzycFrontend
+  def passes(cpg: Cpg): Unit = createEnhancements(cpg)
+
+  override def beforeAll(): Unit = {
+    buildCpgForDir(dir)
+  }
+
+  def createEnhancements(cpg: Cpg): Unit = {
+    val context = new LayerCreatorContext(cpg)
+    new Scpg().run(context)
+  }
+
+  private def buildCpgForDir[T](dir: File): Unit = {
+    cpg = frontend.execute(dir)
+    passes(cpg)
+  }
+
+  override def afterAll(): Unit = {
+    cpg.close()
+  }
+
+}


### PR DESCRIPTION
This is required to update the joern-sample-extension. Seems that we lost this class somewhere on the way.