### PR TITLE
Allow extensions from `io.shiftleft` and `io.joern` packages

### DIFF
--- a/console/src/main/scala/io/joern/Empty.scala
+++ b/console/src/main/scala/io/joern/Empty.scala
@@ -1,0 +1,3 @@
+package io.joern
+
+class Empty {}

--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -38,7 +38,7 @@ object Run {
     * @param exclude list of analyzers to exclude (by full class name)
     * */
   def codeForRunCommand(exclude: List[String] = List()): String = {
-    val r = new Reflections("io.shiftleft")
+    val r = new Reflections("io")
     val layerCreatorTypeNames = r
       .getSubTypesOf(classOf[LayerCreator])
       .asScala


### PR DESCRIPTION
We were previously looking for extensions only in the `io.shiftleft` package.
