### PR TITLE
properly handle duplicate entries in zip archives for bin.zip

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.scala
@@ -27,7 +27,7 @@ object ProtoCpgLoader {
         val edgeLists: ArrayBuffer[JCollection[Edge]] = ArrayBuffer.empty
         val zip = use(new java.util.zip.ZipFile(fileName))
         val names = mutable.Set[String]()
-        for (zipEntry <- zip.entries().asScala) {
+        for (zipEntry <- zip.entries().asScala if !zipEntry.isDirectory) {
           if (!names.add(zipEntry.getName)) {
             logger.warn(
               s"""Zip file contains multiple entries with name "${zipEntry.getName}" -- is this really intended?""")

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -28,7 +28,7 @@ class CpgLoaderTests extends AnyWordSpec with Matchers {
     }
 
     "throw an appropriate exception if the provided filename that refers to a non-existing file" in {
-      an[FileSystemNotFoundException] should be thrownBy CpgLoader.load("invalid/path/cpg.bin.zip")
+      an[java.io.FileNotFoundException] should be thrownBy CpgLoader.load("invalid/path/cpg.bin.zip")
     }
 
     /**

--- a/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.{Inside}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.console.scripting.ScriptManager.{ScriptCollections, ScriptDescription, ScriptDescriptions}
 
-import java.nio.file.{FileSystemNotFoundException, NoSuchFileException, Path}
+import java.nio.file.{NoSuchFileException, Path}
 
 import scala.io.Source
 import scala.util.Try
@@ -87,7 +87,7 @@ class ScriptManagerTest extends AnyWordSpec with Matchers with Inside {
     }
 
     "throw an exception if the specified CPG can not be found" in withScriptManager { scriptManager =>
-      intercept[FileSystemNotFoundException] {
+      intercept[java.io.FileNotFoundException] {
         scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
       }
     }


### PR DESCRIPTION
Valid zip files are permitted to contain multiple files with identical names. This of course breaks abstractions that imagine a zip file as a filesystem (as well as naive attempts to unzip them). As it appears, `java.nio.FileSystems`, in its infinite wisdom, silently ignores duplicate files and only sees one of them (obviously what the user expected, right?).

Luckily, `java.util.zip.ZipFile` is less broken (not that https://docs.oracle.com/javase/8/docs/api/java/util/zip/ZipFile.html advertises this fact, but let's just hope that newer jdks don't regress on that). 

This is not hypothetical, cf https://github.com/ShiftLeftSecurity/product/issues/6073

I'm not sure what to do about the overlay-loading code, so I didn't touch that for now. Archives with duplicate entries are probably corner-casy enough to warrant a logged warning, though.