### PR TITLE
remove ambiguous implicits

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/package.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/package.scala
@@ -23,15 +23,12 @@ package object language {
   implicit def trackingPointToAstNodeMethods(node: nodes.TrackingPoint) =
     new AstNodeMethods(trackingPointToAstNode(node))
 
-  private def trackingPointToAstNode(node: nodes.TrackingPoint): nodes.AstNode = node match {
-    case n: nodes.AstNode               => n
-    case n: nodes.DetachedTrackingPoint => n.cfgNode
-    case _                              => ??? //TODO markus/fabs?
-  }
-
-  implicit def trackingPointToAstBase[A](a: A)(
-      implicit f: A => Traversal[nodes.TrackingPoint]): AstNode[nodes.AstNode] =
-    new AstNode(f(a).map(trackingPointToAstNode))
+  implicit def trackingPointToAstNode(node: nodes.TrackingPoint): nodes.AstNode =
+    node match {
+      case n: nodes.AstNode               => n
+      case n: nodes.DetachedTrackingPoint => n.cfgNode
+      case _                              => ??? //TODO markus/fabs?
+    }
 
   implicit def toDdgNodeDot[A](a: A)(implicit f: A => Traversal[nodes.Method]): DdgNodeDot =
     new DdgNodeDot(f(a))


### PR DESCRIPTION
prior to this we had two conversion paths from `nodes.TrackingPoint`
to `AstNode[nodes.AstNode]`, which would lead to ambiguous implicits
that don't resolve, e.g. for `cpg.call.where(_.argument.order(1).isIdentifier)`

re https://github.com/ShiftLeftSecurity/joern/issues/382