### PR TITLE
Link calls with METHOD_REF receiver.

### DIFF
--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -258,7 +258,6 @@
              {"name": "METHOD_REF", "cardinality": "0-1:0-1"},
              {"name": "TYPE_REF"},
              {"name": "BLOCK", "cardinality": "0-1:0-1"},
-             {"name": "JUMP_TARGET"},
 	     {"name": "CONTROL_STRUCTURE"},
 	     {"name": "UNKNOWN"}
            ]},

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/calllinker/CallLinker.scala
@@ -54,7 +54,6 @@ class CallLinker(cpg: Cpg) extends CpgPass(cpg) {
         if (receiverIt.hasNext) {
           val receiver = receiverIt.next
           receiver match {
-            case methodRefReceiver: nodes.MethodRef => // nothing
             case _ =>
               val receiverTypeDecl = receiver
                 ._evalTypeOut()


### PR DESCRIPTION
No linking those calls was a leftover from when METHOD_REF node where no
proper expressions and had no type associated.

Also fixed error in CPG format spec. JUMP_TARGET cannot be the
destination of a RECEIVER edge originating from a CALL since JUMP_TARGET
is not an EXPRESSION.