### PR TITLE
call.argument with no args

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -1,24 +1,24 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.semanticcpg.language._
-import scala.jdk.CollectionConverters._
 import overflowdb.traversal._
 
 class CallMethods(val node: nodes.Call) extends AnyVal {
   def arguments(index: Int): Traversal[nodes.Expression] =
-    node._argumentOut.asScala
+    node._argumentOut
       .collect {
         case expr: nodes.Expression if expr.argumentIndex == index => expr
       }
       .to(Traversal)
 
+  def argument: Traversal[nodes.Expression] =
+    node._argumentOut.collectAll[nodes.Expression]
+
   def argument(index: Int): nodes.Expression =
     arguments(index).head
 
   def argumentOption(index: Int): Option[nodes.Expression] =
-    node._argumentOut.asScala
-      .collectFirst {
-        case expr: nodes.Expression if expr.argumentIndex == index => expr
-      }
+    node._argumentOut.collectFirst {
+      case expr: nodes.Expression if expr.argumentIndex == index => expr
+    }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -37,13 +37,13 @@ class Call(val traversal: Traversal[nodes.Call]) extends AnyVal {
     Arguments of the call
     */
   def argument: Traversal[nodes.Expression] =
-    traversal.out(EdgeTypes.ARGUMENT).cast[nodes.Expression]
+    traversal.flatMap(_.argument)
 
   /**
     `i'th` arguments of the call
     */
   def argument(i: Integer): Traversal[nodes.Expression] =
-    argument.argumentIndex(i)
+    traversal.flatMap(_.argument(i))
 
   /**
     To formal method return parameter


### PR DESCRIPTION
prior to this:
```
semanticcpg/console

import io.shiftleft.codepropertygraph.Cpg
import io.shiftleft.semanticcpg.language._

def cpg: Cpg = ???
def a = cpg.call.argument

def b = cpg.call.head.argument
cmd1.sc:1: missing argument list for method argument in class CallMethods
Unapplied methods are only converted to functions when a function type is expected.
```