### PR TITLE
bump Odb and codegen versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.23"
+val overflowdbVersion = "1.27"
 
 inThisBuild(
   List(

--- a/project/meta-build.sbt
+++ b/project/meta-build.sbt
@@ -1,6 +1,6 @@
 libraryDependencies ++= Seq(
   "com.github.pathikrit" %% "better-files" % "3.8.0",
-  "io.shiftleft" %% "overflowdb-codegen" % "1.35",
+  "io.shiftleft" %% "overflowdb-codegen" % "1.37",
 )
 
 resolvers += Resolver.bintrayRepo("shiftleft", "maven")


### PR DESCRIPTION
bump Odb and codegen versions, in order to reap benefits from accelerated traversals