### PR TITLE
don't throw exception in traversals without matching argument index

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -43,7 +43,7 @@ class Call(val traversal: Traversal[nodes.Call]) extends AnyVal {
     `i'th` arguments of the call
     */
   def argument(i: Integer): Traversal[nodes.Expression] =
-    traversal.flatMap(_.argument(i))
+    traversal.flatMap(_.arguments(i))
 
   /**
     To formal method return parameter


### PR DESCRIPTION
This broke in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1022. It causes failures in codescience.