### PR TITLE
Add optional `HASH` field to files

### DIFF
--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -76,7 +76,7 @@
 
         {"id" : 38,
          "name": "FILE",
-         "keys": ["NAME", "ORDER"],
+         "keys": ["NAME", "ORDER", "HASH"],
          "comment": "Node representing a source file. Often also the AST root",
          "outEdges": [{"edgeName": "AST", "inNodes": [{"name": "NAMESPACE_BLOCK", "cardinality": "0-1:n"}]}],
          "is" : ["AST_NODE"]


### PR DESCRIPTION
This is the only light modification we need to support https://github.com/plume-oss. Brings in a field that allows storing of a non-mandatory file hash.