### PR TITLE
Tweaks and fixes for LayerCreator API

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Commit.scala
+++ b/console/src/main/scala/io/shiftleft/console/Commit.scala
@@ -18,7 +18,7 @@ class Commit(opts: CommitOptions) extends LayerCreator {
   override val description: String = Commit.description
 
   override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
-    val serializedCpg = initSerializedCpg(context.outputDir, "commit", 0)
+    val serializedCpg = initSerializedCpg(context.outputDir, "commit")
     new CpgPass(context.cpg) {
       override def run(): Iterator[DiffGraph] = Iterator(opts.diffGraphBuilder.build())
     }.createApplySerializeAndStore(serializedCpg, serializeInverse)

--- a/console/src/main/scala/io/shiftleft/console/Commit.scala
+++ b/console/src/main/scala/io/shiftleft/console/Commit.scala
@@ -17,11 +17,12 @@ class Commit(opts: CommitOptions) extends LayerCreator {
   override val overlayName: String = Commit.overlayName
   override val description: String = Commit.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
-    val serializedCpg = initSerializedCpg(context.outputDir, "commit")
-    new CpgPass(context.cpg) {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
+    val pass: CpgPass = new CpgPass(context.cpg) {
+      override val name = "commit"
       override def run(): Iterator[DiffGraph] = Iterator(opts.diffGraphBuilder.build())
-    }.createApplySerializeAndStore(serializedCpg, serializeInverse)
+    }
+    runPass(pass, context, storeUndoInfo)
     opts.diffGraphBuilder = DiffGraph.newBuilder
   }
 

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -568,7 +568,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
 
   protected def runCreator(creator: LayerCreator, overlayDirName: Option[String]): Unit = {
     val context = new LayerCreatorContext(cpg, overlayDirName)
-    creator.run(context, serializeInverse = true)
+    creator.run(context, storeUndoInfo = true)
   }
 
 }

--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -17,17 +17,16 @@ object Run {
         override val overlayName: String = "custom"
         override val description: String = "A custom pass"
 
-        override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
-          val serializedCpg = initSerializedCpg(context.outputDir, "custom")
-          val pass = new CpgPass(console.cpg) {
+        override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
+          val pass: CpgPass = new CpgPass(console.cpg) {
+            override val name = "custom"
             override def run(): Iterator[DiffGraph] = {
               implicit val diffGraph: DiffGraph.Builder = DiffGraph.newBuilder
               query.store
               Iterator(diffGraph.build())
             }
           }
-          pass.createApplySerializeAndStore(serializedCpg, inverse = true, "custom")
-          serializedCpg.close()
+          runPass(pass, context, storeUndoInfo)
         }
         override def probe(cpg: Cpg): Boolean = false
       }

--- a/console/src/main/scala/io/shiftleft/console/Run.scala
+++ b/console/src/main/scala/io/shiftleft/console/Run.scala
@@ -18,7 +18,7 @@ object Run {
         override val description: String = "A custom pass"
 
         override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
-          val serializedCpg = initSerializedCpg(context.outputDir, "custom", 0)
+          val serializedCpg = initSerializedCpg(context.outputDir, "custom")
           val pass = new CpgPass(console.cpg) {
             override def run(): Iterator[DiffGraph] = {
               implicit val diffGraph: DiffGraph.Builder = DiffGraph.newBuilder

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -253,7 +253,7 @@ class ConsoleTests extends AnyWordSpec with Matchers {
     override val overlayName: String = "fooname"
     override val description: String = "foodescr"
 
-    override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {}
+    override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {}
     override def probe(cpg: Cpg): Boolean = false
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14.scala
@@ -22,7 +22,7 @@ class DumpCpg14(options: Cpg14DumpOptions)(implicit semantics: Semantics) extend
   override val overlayName: String = DumpDdg.overlayName
   override val description: String = DumpDdg.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach {
       case (method, i) =>

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14.scala
@@ -21,6 +21,7 @@ object DumpCpg14 {
 class DumpCpg14(options: Cpg14DumpOptions)(implicit semantics: Semantics) extends LayerCreator {
   override val overlayName: String = DumpDdg.overlayName
   override val description: String = DumpDdg.description
+  override val modifiesCpg: Boolean = false
 
   override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdg.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdg.scala
@@ -21,6 +21,7 @@ object DumpDdg {
 class DumpDdg(options: DdgDumpOptions)(implicit semantics: Semantics) extends LayerCreator {
   override val overlayName: String = DumpDdg.overlayName
   override val description: String = DumpDdg.description
+  override val modifiesCpg: Boolean = false
 
   override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdg.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdg.scala
@@ -22,7 +22,7 @@ class DumpDdg(options: DdgDumpOptions)(implicit semantics: Semantics) extends La
   override val overlayName: String = DumpDdg.overlayName
   override val description: String = DumpDdg.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach {
       case (method, i) =>

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpPdg.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpPdg.scala
@@ -22,7 +22,7 @@ class DumpPdg(options: PdgDumpOptions)(implicit semantics: Semantics) extends La
   override val overlayName: String = DumpPdg.overlayName
   override val description: String = DumpPdg.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach {
       case (method, i) =>

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpPdg.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpPdg.scala
@@ -21,6 +21,7 @@ object DumpPdg {
 class DumpPdg(options: PdgDumpOptions)(implicit semantics: Semantics) extends LayerCreator {
   override val overlayName: String = DumpPdg.overlayName
   override val description: String = DumpPdg.description
+  override val modifiesCpg: Boolean = false
 
   override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -18,14 +18,12 @@ class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
     val enhancementExecList = Iterator(new ReachingDefPass(cpg))
     enhancementExecList.zipWithIndex.foreach {
       case (pass, index) =>
-        val serializedCpg = initSerializedCpg(context.outputDir, pass.name, index)
-        pass.createApplySerializeAndStore(serializedCpg)
-        serializedCpg.close()
+        runPass(pass, context, storeUndoInfo, index)
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpAst.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpAst.scala
@@ -17,6 +17,7 @@ object DumpAst {
 class DumpAst(options: AstDumpOptions) extends LayerCreator {
   override val overlayName: String = DumpAst.overlayName
   override val description: String = DumpAst.description
+  override val modifiesCpg: Boolean = false
 
   override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpAst.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpAst.scala
@@ -18,7 +18,7 @@ class DumpAst(options: AstDumpOptions) extends LayerCreator {
   override val overlayName: String = DumpAst.overlayName
   override val description: String = DumpAst.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach {
       case (method, i) =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCdg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCdg.scala
@@ -19,7 +19,7 @@ class DumpCdg(options: CdgDumpOptions) extends LayerCreator {
   override val overlayName: String = DumpCdg.overlayName
   override val description: String = DumpCdg.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach {
       case (method, i) =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCdg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCdg.scala
@@ -18,6 +18,7 @@ object DumpCdg {
 class DumpCdg(options: CdgDumpOptions) extends LayerCreator {
   override val overlayName: String = DumpCdg.overlayName
   override val description: String = DumpCdg.description
+  override val modifiesCpg: Boolean = false
 
   override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCfg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCfg.scala
@@ -18,6 +18,7 @@ object DumpCfg {
 class DumpCfg(options: CfgDumpOptions) extends LayerCreator {
   override val overlayName: String = DumpCfg.overlayName
   override val description: String = DumpCfg.description
+  override val modifiesCpg: Boolean = false
 
   override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCfg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/DumpCfg.scala
@@ -19,7 +19,7 @@ class DumpCfg(options: CfgDumpOptions) extends LayerCreator {
   override val overlayName: String = DumpCfg.overlayName
   override val description: String = DumpCfg.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
     cpg.method.zipWithIndex.foreach {
       case (method, i) =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
@@ -28,7 +28,7 @@ abstract class LayerCreator {
     }
   }
 
-  protected def initSerializedCpg(outputDir: Option[String], passName: String, index: Int): SerializedCpg = {
+  protected def initSerializedCpg(outputDir: Option[String], passName: String, index: Int = 0): SerializedCpg = {
     outputDir match {
       case Some(dir) => new SerializedCpg((File(dir) / s"${index}_$passName").path.toAbsolutePath.toString)
       case None      => new SerializedCpg()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
@@ -53,7 +53,7 @@ abstract class LayerCreator {
     * when `metaData.overlays` is not present due
     * to conversion from legacy CPG.
     * */
-  def probe(cpg: Cpg): Boolean
+  def probe(cpg: Cpg): Boolean = false
 
 }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -35,7 +35,7 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
   override val overlayName: String = Scpg.overlayName
   override val description: String = Scpg.description
 
-  override def create(context: LayerCreatorContext, serializeInverse: Boolean): Unit = {
+  override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
     val language = cpg.metaData.language.headOption
       .getOrElse(throw new Exception("Meta node missing."))
@@ -43,9 +43,7 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
     val enhancementExecList = createEnhancementExecList(cpg, language)
     enhancementExecList.zipWithIndex.foreach {
       case (pass, index) =>
-        val serializedCpg = initSerializedCpg(context.outputDir, pass.name, index)
-        pass.createApplySerializeAndStore(serializedCpg, serializeInverse)
-        serializedCpg.close()
+        runPass(pass, context, storeUndoInfo, index)
     }
   }
 


### PR DESCRIPTION
Changes are backward compatible, API is not broken.

* The name `serializeInverse` was technically correct but didn't communicate the intent: storing undo information. It has therefore been renamed.
* A utility method named `runPass` and executes the pass and creates undo information has been made available for all `LayerCreators`.
* We need to allow LayerCreators that do not modify the CPG, and for these, the meta data block of the CPG should not be modified. Otherwise, executing the same pass will require an `undo`. Introduced `modifiesCpg` flag to allow for the creation of such `LayerCreators`
* Provide default implementation for `probe` as this is a legacy method that we'll remove soon and I don't want it to spread to extensions.