### PR TITLE
Minor fixes for DataFlowCodeToCpgSuite

### DIFF
--- a/dataflowengineoss-tests/src/test/scala/io/shiftleft/dataflowengineoss/language/DataFlowCodeToCpgSuite.scala
+++ b/dataflowengineoss-tests/src/test/scala/io/shiftleft/dataflowengineoss/language/DataFlowCodeToCpgSuite.scala
@@ -16,9 +16,15 @@ import scala.util.Try
 
 class DataFlowCodeToCpgSuite extends CodeToCpgSuite {
 
-  val semanticsFilename = "dataflowengineoss/src/test/resources/default.semantics"
-  val semantics: Semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
-  implicit val context = EngineContext(semantics)
+  var semanticsFilename = "dataflowengineoss/src/test/resources/default.semantics"
+  var semantics: Semantics = _
+  implicit var context: EngineContext = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    semantics = Semantics.fromList(new Parser().parseFile(semanticsFilename))
+    context = EngineContext(semantics)
+  }
 
   implicit val viewer: ImageViewer = (pathStr: String) =>
     Try {

--- a/dataflowengineoss-tests/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
+++ b/dataflowengineoss-tests/src/test/scala/io/shiftleft/dataflowengineoss/language/TrackingPointTests.scala
@@ -6,7 +6,12 @@ import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 class TrackingPointTests extends DataFlowCodeToCpgSuite {
 
   implicit val resolver: NoResolve.type = NoResolve
-  implicit val s: Semantics = semantics
+  implicit var s: Semantics = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    s = semantics
+  }
 
   override val code =
     """


### PR DESCRIPTION
It wasn't possible previously to override the semantics filename in a suite inheriting from `DataFlowCodeToCpgSuite`. This PR fixes this.