### PR TITLE
Cleanup `File` node creation and add test

### DIFF
--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/FileNodeTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/FileNodeTests.scala
@@ -1,0 +1,36 @@
+package io.shiftleft.fuzzyc2cpg.querying
+
+import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.structure.File
+
+class FileNodeTests extends FuzzyCCodeToCpgSuite {
+
+  override val code: String =
+    """
+      |
+      |""".stripMargin
+
+  "should contain two file nodes in total, both with order=0" in {
+    cpg.file.order.l shouldBe List(0, 0)
+    cpg.file.name(File.UNKNOWN).size shouldBe 1
+    cpg.file.nameNot(File.UNKNOWN).size shouldBe 1
+  }
+
+  "should contain exactly one placeholder file node with `name=\"<unknown>\"/order=0`" in {
+    cpg.file(File.UNKNOWN).l match {
+      case List(x) =>
+        x.order shouldBe 0
+      case _ => fail
+    }
+  }
+
+  "should contain exactly one non-placeholder file with absolute path in `name`" in {
+    cpg.file.nameNot(File.UNKNOWN).l match {
+      case List(x) =>
+        x.name should startWith("/")
+      case _ => fail
+    }
+  }
+
+}

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/AstCreationPass.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/AstCreationPass.scala
@@ -23,7 +23,7 @@ class AstCreationPass(filenames: List[String], cpg: Cpg, keyPool: IntervalKeyPoo
 
     val diffGraph = DiffGraph.newBuilder
     val absolutePath = new java.io.File(filename).toPath.toAbsolutePath.normalize().toString
-    val fileNode = nodes.NewFile(name = absolutePath)
+    val fileNode = nodes.NewFile(name = absolutePath, order = 0)
     diffGraph.addNode(fileNode)
     val namespaceBlock = nodes.NewNamespaceBlock(
       name = Defines.globalNamespaceName,

--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -77,7 +77,7 @@
         {"id" : 38,
          "name": "FILE",
          "keys": ["NAME", "ORDER", "HASH"],
-         "comment": "Node representing a source file. Often also the AST root",
+         "comment": "Node representing a source file - the root of the AST",
          "outEdges": [{"edgeName": "AST", "inNodes": [{"name": "NAMESPACE_BLOCK", "cardinality": "0-1:n"}]}],
          "is" : ["AST_NODE"]
         },

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/File.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/File.scala
@@ -24,3 +24,9 @@ class File(val traversal: Traversal[nodes.File]) extends AnyVal {
     traversal.out(EdgeTypes.AST).hasLabel(NodeTypes.COMMENT).cast[nodes.Comment]
 
 }
+
+object File {
+
+  val UNKNOWN = "<unknown>"
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/filecompat/FileLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/filecompat/FileLinker.scala
@@ -4,6 +4,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.structure.File
 import io.shiftleft.semanticcpg.passes.linking.linker.Linker
 
 import scala.collection.mutable
@@ -22,17 +23,14 @@ class FileLinker(cpg: Cpg) extends CpgPass(cpg) {
     val originalFileNameToNode = mutable.Map.empty[String, nodes.StoredNode]
     val newFileNameToNode = mutable.Map.empty[String, nodes.NewFile]
 
-    var maxFileOrder = -1
-
     cpg.file.foreach { node =>
       originalFileNameToNode += node.name -> node
-      maxFileOrder = Math.max(maxFileOrder, node.order)
     }
 
-    def createFileIfDoesNotExist(srcNode: nodes.StoredNode, dstFullName: String): Unit = {
+    def createFileIfDoesNotExist(srcNode: nodes.StoredNode, destFullName: String): Unit = {
+      val dstFullName = if (destFullName == "") { File.UNKNOWN } else { destFullName }
       val newFile = newFileNameToNode.getOrElseUpdate(dstFullName, {
-        maxFileOrder += 1
-        val file = nodes.NewFile(name = dstFullName, order = maxFileOrder)
+        val file = nodes.NewFile(name = dstFullName, order = 0)
         dstGraph.addNode(file)
         file
       })


### PR DESCRIPTION
I am currently providing a test battery for new language frontends, and while doing so, I'm taking a deeper look at each of the nodes and edges in the base schema. Here are my notes in `File` nodes along with minor fixes for fuzzyc so that it meets this spec:

```
### `File(name: String, [hash: String])` is an `AstNode`

Code property graphs are created from sets of files. Information about these 
files is stored in the graph to enable queries to map nodes of the graph 
back to the files that contain the code they represent.

For each file, the graph must contain exactly one `File` node with the 
following fields:

* `name`: the absolute path of the file at CPG construction time in Unix style.
  No two file nodes of the CPG may have the same `name` field.
* `hash` (optional): A hash value calculated over the file contents.

As file nodes are root nodes of abstract syntax tress, they are `AstNodes` 
and their `order` field is set to `0`.

Each code property graph must contain a special file node with 
`name` set to `"<unknown>"`. This node is a placeholder used in cases 
where a file cannot be determined at compile time. As an example, consider 
the case where an external type is introduced only at link time.

```