### PR TITLE
Make `writeCodeToFile` protected in `CodeToCpgFixture`

### DIFF
--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
@@ -30,7 +30,7 @@ class CodeToCpgFixture(val frontend: LanguageFrontend) extends AnyWordSpec with 
     passes(cpg)
   }
 
-  private def writeCodeToFile(sourceCode: String): File = {
+  protected def writeCodeToFile(sourceCode: String): File = {
     val tmpDir = Files.createTempDirectory("semanticcpgtest").toFile
     tmpDir.deleteOnExit()
     val codeFile = File.createTempFile("Test", frontend.fileSuffix, tmpDir)


### PR DESCRIPTION
In the PHP frontend, we could use the `CodeToCpgFixture` pretty much as-is, if it wasn't for the following:

* We need to set a timestamp in order to work around a bug in PHP
* Code needs to be enclosed in `<?php ...?>`

Making `writeCodeToFile` protected as opposed to private to allow us to override it.