### PR TITLE
Fixes for issues encountered during work on installer

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -211,7 +211,7 @@ trait BridgeBase {
         | $storeCode
         |""".stripMargin
 
-    val logFileName = "run-log.txt"
+    val logFileName = "/tmp/joern-scan-log.txt"
     println(s"Detailed logs at: $logFileName")
     val file = new java.io.File(logFileName);
     val fos = new FileOutputStream(file);

--- a/console/src/main/scala/io/shiftleft/console/PluginManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/PluginManager.scala
@@ -23,7 +23,6 @@ class PluginManager(installDir: File) {
       }
       .distinct
       .sorted
-    installedPluginNames.foreach(println)
     installedPluginNames
   }
 


### PR DESCRIPTION
* It's a better idea to write the run-log to `/tmp/joern-run-log.txt` rather than `run-log.txt` because the directory in which `joern-scan` is located may not be writable for the user.
* There was a stale debug println invoked when calling `joern --remove-plugin`