### PR TITLE
Cleanup bundle/extension/plugin terminology

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -64,19 +64,19 @@ trait BridgeBase {
         .action((x, c) => c.copy(command = Some(x)))
         .text("select one of multiple @main methods")
 
-      note("Bundle execution")
+      note("Extension execution")
 
-      opt[Unit]("bundles")
-        .action((_, c) => c.copy(listBundles = true))
-        .text("List available bundles")
+      opt[Unit]("extensions")
+        .action((_, c) => c.copy(extensions = true))
+        .text("List available extensions")
 
       opt[String]("run")
-        .action((x, c) => c.copy(bundleToRun = Some(x)))
-        .text("Run bundle. Get a list via --bundles")
+        .action((x, c) => c.copy(extensionsToRun = Some(x)))
+        .text("Run extension. Get a list via --extensions")
 
       opt[String]("src")
         .action((x, c) => c.copy(src = Some(x)))
-        .text("Source code directory to run bundle on")
+        .text("Source code directory to run extension on")
 
       opt[String]("language")
         .action((x, c) => c.copy(language = Some(x)))
@@ -88,7 +88,7 @@ trait BridgeBase {
 
       opt[Unit]("store")
         .action((_, c) => c.copy(store = true))
-        .text("Store graph changes made by bundle")
+        .text("Store graph changes made by extension")
 
       note("REST server mode")
 

--- a/console/src/main/scala/io/shiftleft/console/BundleManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/BundleManager.scala
@@ -7,13 +7,13 @@ import java.nio.file.Path
 import scala.util.{Failure, Success, Try}
 
 /**
-  * Plugin management component
+  * Query bundle management component
   * @param installDir the Joern/Ocular installation dir
   * */
-class PluginManager(installDir: File) {
+class BundleManager(installDir: File) {
 
-  def listPlugins(): List[String] = {
-    val installedPluginNames = pluginDir.toList
+  def list(): List[String] = {
+    val installedPluginNames = libDir.toList
       .flatMap { dir =>
         File(dir).list.toList.flatMap { f =>
           "^joernext-(.*?)-.*$".r.findAllIn(f.name).matchData.map { m =>
@@ -27,7 +27,7 @@ class PluginManager(installDir: File) {
   }
 
   def add(filename: String): Unit = {
-    if (pluginDir.isEmpty) {
+    if (libDir.isEmpty) {
       println("Plugin directory does not exist")
       return
     }
@@ -47,7 +47,7 @@ class PluginManager(installDir: File) {
 
   private def addExistingUnzipped(file: File, pluginName: String): Unit = {
     file.listRecursively.filter(_.name.endsWith(".jar")).foreach { jar =>
-      pluginDir.foreach { pDir =>
+      libDir.foreach { pDir =>
         if (!(pDir / jar.name).exists) {
           val dstFileName = s"joernext-$pluginName-${jar.name}"
           val dstFile = pDir / dstFileName
@@ -68,11 +68,11 @@ class PluginManager(installDir: File) {
   }
 
   def rm(name: String): List[String] = {
-    if (!listPlugins().contains(name)) {
+    if (!list().contains(name)) {
       println(s"Plugin $name is not installed")
       List()
     } else {
-      val filesToRemove = pluginDir.toList.flatMap { dir =>
+      val filesToRemove = libDir.toList.flatMap { dir =>
         dir.list.filter { f =>
           f.name.startsWith(s"joernext-$name")
         }
@@ -82,7 +82,7 @@ class PluginManager(installDir: File) {
     }
   }
 
-  def pluginDir: Option[Path] = {
+  def libDir: Option[Path] = {
     val pathToPluginDir = installDir.path.resolve("lib")
     if (pathToPluginDir.toFile.exists()) {
       Some(pathToPluginDir)

--- a/console/src/test/scala/io/shiftleft/console/BundleManagerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/BundleManagerTests.scala
@@ -5,9 +5,9 @@ import better.files._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-class PluginManagerTests extends AnyWordSpec with Matchers {
+class BundleManagerTests extends AnyWordSpec with Matchers {
 
-  "PluginManager::add" should {
+  "add" should {
     "not crash if file does not exist" in Fixture() { manager =>
       val testZipFileName = "console/src/test/resources/doesnotexist.zip"
       manager.add(testZipFileName)
@@ -21,7 +21,7 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
     "copy jar files in zip to plugin dir" in Fixture() { manager =>
       val testZipFileName = "console/src/test/resources/test.zip"
       manager.add(testZipFileName)
-      manager.pluginDir match {
+      manager.libDir match {
         case Some(dir) =>
           dir.toFile.list().toList shouldBe List("joernext-test-foo.jar")
         case None => fail
@@ -29,7 +29,7 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
     }
   }
 
-  "PluginManager::rm" should {
+  "rm" should {
 
     "not crash if name of to-be-removed plugin is incorrect" in Fixture() { manager =>
       manager.rm("somename")
@@ -39,24 +39,24 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
       val testZipFileName = "console/src/test/resources/test.zip"
       manager.add(testZipFileName)
       manager.rm("test") shouldBe List("joernext-test-foo.jar")
-      manager.listPlugins() shouldBe List()
+      manager.list() shouldBe List()
       manager.add(testZipFileName)
       manager.rm("test") shouldBe List("joernext-test-foo.jar")
-      manager.listPlugins() shouldBe List()
+      manager.list() shouldBe List()
     }
 
   }
 
-  "PluginManager::listPlugins" should {
+  "list" should {
 
     "display empty plugin list if no plugins exist" in Fixture() { manager =>
-      manager.listPlugins() shouldBe List()
+      manager.list() shouldBe List()
     }
 
     "display plugin after adding it" in Fixture() { manager =>
       val testZipFileName = "console/src/test/resources/test.zip"
       manager.add(testZipFileName)
-      manager.listPlugins() shouldBe List("test")
+      manager.list() shouldBe List("test")
     }
   }
 
@@ -64,10 +64,10 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
 
 object Fixture {
 
-  def apply[T]()(f: PluginManager => T): T = {
+  def apply[T]()(f: BundleManager => T): T = {
     val dir = File.newTemporaryDirectory("pluginmantests")
     mkdir(dir / "lib")
-    val result = f(new PluginManager(dir))
+    val result = f(new BundleManager(dir))
     dir.delete()
     result
   }


### PR DESCRIPTION
The effort to bring in bundles of queries into ocular/joern has lead to confusing terminology that I'm cleaning up before anyone starts depending on it or trying to explain/document it. The terminology is as follows now:

* Users can install "extensions". An extension extends ocular/joern's capabilities, e.g., by providing support for new file types, an extension of the query language and/or an extension of the CPG schema. The scanner is an extension, as is the docker extension.
* Users can install "query bundles" or "bundles" for short. These are collections of queries exclusively, following the same format as `query-database`.

From a technical perspective, both are just jars that we add to the class path.
