### PR TITLE
Run the schema extender only if necessary

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -146,7 +146,7 @@ trait BridgeBase {
           if (config.server) {
             startHttpServer(config)
           } else if (config.pluginToRun.isDefined) {
-            runBundle(config)
+            runPlugin(config)
           } else {
             startInteractiveShell(config, slProduct)
           }
@@ -180,7 +180,7 @@ trait BridgeBase {
     }
   }
 
-  private def runBundle(config: Config): Unit = {
+  private def runPlugin(config: Config): Unit = {
     if (config.src.isEmpty) {
       println("You must supply a source directory with the --src flag")
       return
@@ -196,6 +196,7 @@ trait BridgeBase {
         |   .filter(_.inputPath == "$src")
         |   .map(_.name).foreach(n => workspace.removeProject(n))
         |   importCode.$language("$src")
+        |   run.ossdataflow
         |   save
         | } else {
         |    println("Using existing CPG - Use `--overwrite` if this is not what you want")


### PR DESCRIPTION
If a plugin doesn't introduce schema modifications, then we don't have to run the schema extender and we shouldn't as it takes quite a while to extend the schema.

Also: call `run.ossdataflow` in scanner.