### PR TITLE
Fix `ambiguous` method steps

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -14,12 +14,6 @@ import scala.collection.mutable
 class TrackingPoint(val traversal: Traversal[nodes.TrackingPoint]) extends AnyVal {
 
   /**
-    * The enclosing method of the tracking point
-    * */
-  def method: Traversal[nodes.Method] =
-    traversal.map(_.method)
-
-  /**
     * Convert to nearest CFG node
     * */
   def cfgNode: Traversal[nodes.CfgNode] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/Call.scala
@@ -22,12 +22,6 @@ class Call(val traversal: Traversal[nodes.Call]) extends AnyVal {
     traversal.dispatchType("DYNAMIC_DISPATCH")
 
   /**
-    The caller
-    */
-  def method: Traversal[nodes.Method] =
-    traversal.in(EdgeTypes.CONTAINS).hasLabel(NodeTypes.METHOD).cast[nodes.Method]
-
-  /**
     The receiver of a call if the call has a receiver associated.
     */
   def receiver: Traversal[nodes.Expression] =


### PR DESCRIPTION
There are multiple implicit conversion when calling `.method` on call nodes. This fixes this by removing some of them which are not required.