### PR TITLE
More fixes for OSS data flow

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/ExpressionMethods.scala
@@ -22,7 +22,12 @@ class ExpressionMethods[NodeType <: nodes.Expression](val node: NodeType) extend
     * */
   def isDefined(implicit semantics: Semantics): Boolean = {
     val s = semanticsForCallByArg
-    s.isEmpty || s.exists(_.mappings.exists { case (_, dstIndex) => dstIndex == node.order })
+    s.isEmpty || s.exists { semantic =>
+      semantic.mappings.exists {
+        case (_, dstIndex) =>
+          dstIndex == node.order
+      }
+    }
   }
 
   /**

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -27,6 +27,7 @@ object ReachingDefProblem {
     val init = new ReachingDefInit(transfer.gen)
     def meet: (Set[Definition], Set[Definition]) => Set[Definition] =
       (x: Set[Definition], y: Set[Definition]) => { x.union(y) }
+
     new DataFlowProblem[Set[Definition]](flowGraph, transfer, meet, init, true, Set[Definition]())
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/UsageAnalyzer.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/UsageAnalyzer.scala
@@ -40,7 +40,6 @@ class UsageAnalyzer(in: Map[nodes.StoredNode, Set[Definition]]) {
 
   def uses(node: nodes.StoredNode): Set[nodes.StoredNode] = {
     val n = node match {
-      // case methodRet: nodes.MethodReturn => methodRet.start.method.cfgNode.toSet
       case ret: nodes.Return =>
         ret.astChildren.toSet
       case call: nodes.Call =>

--- a/dataflowengineoss/src/test/resources/default.semantics
+++ b/dataflowengineoss/src/test/resources/default.semantics
@@ -30,3 +30,4 @@
 "<operator>.addition" 1->-1 2->-1
 "<operator>.conditional" 2->-1 3->-1
 "woo" 1->-1
+"free" 1->1

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotDdgGeneratorTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotDdgGeneratorTests.scala
@@ -19,11 +19,11 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       |""".stripMargin
 
   "A DdgDotGenerator" should {
-    "create a dot graph with 30 edges" in {
+    "create a dot graph with 31 edges" in {
       implicit val s = semantics
       val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
       lines.head.startsWith("digraph foo") shouldBe true
-      lines.count(x => x.contains("->")) shouldBe 30
+      lines.count(x => x.contains("->")) shouldBe 31
       lines.last.startsWith("}") shouldBe true
     }
   }
@@ -42,7 +42,7 @@ class DotDdgGeneratorTests2 extends DataFlowCodeToCpgSuite {
   "create correct dot graph" in {
     implicit val s = semantics
     val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
-    lines.count(x => x.contains("->") && x.contains("\"x\"")) shouldBe 2
+    lines.count(x => x.contains("->") && x.contains("\"x\"")) shouldBe 3
   }
 
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/DataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/DataFlowTests.scala
@@ -50,7 +50,7 @@ class DataFlowTests extends DataFlowCodeToCpgSuite {
   "should find flows from identifiers to return values of `flow`" in {
     val source = cpg.identifier
     val sink = cpg.method.name("flow").methodReturn
-    sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 7
+    sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.size shouldBe 8
   }
 
   "find flows from z to method returns of flow" in {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/FreeListDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/FreeListDataFlowTests.scala
@@ -50,7 +50,7 @@ class FreeListDataFlowTests extends DataFlowCodeToCpgSuite {
   "should find flows from identifiers to return values of `flow`" in {
     val source = cpg.identifier
     val sink = cpg.method.name("flow").methodReturn
-    sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 7
+    sink.reachableByFlows(source).l.map(flowToResultPairs).distinct.toSet.size shouldBe 8
   }
 
   "find flows from z to method returns of flow" in {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/TrackingPointMethods.scala
@@ -115,13 +115,14 @@ object TrackingPointMethodsBase {
       case node: nodes.ImplicitCall       => (TrackedReturnValue(node), Nil)
       case node: nodes.PostExecutionCall =>
         toTrackedBaseAndAccessPathInternal(node._refOut().next.asInstanceOf[nodes.TrackingPoint])
-      case node: nodes.Identifier => (TrackedNamedVariable(node.name), Nil)
-      case node: nodes.Literal    => (TrackedLiteral(node), Nil)
-      case node: nodes.MethodRef  => (TrackedMethodOrTypeRef(node), Nil)
-      case node: nodes.TypeRef    => (TrackedMethodOrTypeRef(node), Nil)
-      case _: nodes.Return        => (TrackedFormalReturn, Nil)
-      case _: nodes.MethodReturn  => (TrackedFormalReturn, Nil)
-      case _: nodes.Unknown       => (TrackedUnknown, Nil)
+      case node: nodes.Identifier    => (TrackedNamedVariable(node.name), Nil)
+      case node: nodes.Literal       => (TrackedLiteral(node), Nil)
+      case node: nodes.MethodRef     => (TrackedMethodOrTypeRef(node), Nil)
+      case node: nodes.TypeRef       => (TrackedMethodOrTypeRef(node), Nil)
+      case _: nodes.Return           => (TrackedFormalReturn, Nil)
+      case _: nodes.MethodReturn     => (TrackedFormalReturn, Nil)
+      case _: nodes.Unknown          => (TrackedUnknown, Nil)
+      case _: nodes.ControlStructure => (TrackedUnknown, Nil)
       // FieldIdentifiers are only fake arguments, hence should not be tracked
       case _: nodes.FieldIdentifier => (TrackedUnknown, Nil)
       case block: nodes.Block =>


### PR DESCRIPTION
My attempt to correctly connect edges to the method exit node yesterday was a bit too naive: we can't just connect any nodes that do not have outgoing edges, we need to connect all "incoming definitions" to the exit node, of course. There was furthermore a problem with application of semantics: for annotated methods, we still always assumed that the return value is tainted, independent of the contents of the semantics. Both issues are fixed with this PR. The remainder of the changes are cosmetic.