### PR TITLE
Remove use of deprecated exception class

### DIFF
--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AntlrParserDriver.java
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AntlrParserDriver.java
@@ -10,6 +10,7 @@ import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
 import io.shiftleft.fuzzyc2cpg.parser.AntlrParserDriverObserver;
 import io.shiftleft.fuzzyc2cpg.parser.CommonParserContext;
+import io.shiftleft.fuzzyc2cpg.parser.ParserException;
 import io.shiftleft.fuzzyc2cpg.parser.TokenSubStream;
 import io.shiftleft.passes.DiffGraph;
 import java.io.IOException;
@@ -17,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 import java.util.function.Consumer;
-import jdk.nashorn.internal.runtime.ParserException;
 import org.antlr.v4.runtime.BailErrorStrategy;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -129,7 +129,7 @@ abstract public class AntlrParserDriver {
             throws ParserException {
         ParseTree returnTree = parseTokenStreamImpl(tokens);
         if (returnTree == null) {
-            throw new ParserException("");
+            throw new ParserException();
         }
         return returnTree;
     }


### PR DESCRIPTION
The `nashorn` ParserException is triggering compiler errors under certain
JDK-IntelliJ configurations. This change fixes the errors. The old
exception class is not caught anywhere explicitly and has been
deprecated in JDK11. Found together with @ml86.