### PR TITLE
Fix resource leak in OSS data flow engine

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/TrackingPoint.scala
@@ -73,7 +73,10 @@ class TrackingPoint(val traversal: Traversal[nodes.TrackingPoint]) extends AnyVa
         .toList
 
     val sinks = traversal.dedup.toList.sortBy(_.id)
-    new Engine(context).backwards(sinks, sources)
+    val engine = new Engine(context)
+    val result = engine.backwards(sinks, sources)
+    engine.shutdown()
+    result
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -26,15 +26,11 @@ class Engine(context: EngineContext) {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
   private var numberOfTasksRunning: Int = 0
-  private val completionService = initializeWorkerPool()
+  private val executorService: ExecutorService = Executors.newWorkStealingPool()
+  private val completionService = new ExecutorCompletionService[Vector[ReachableByResult]](executorService)
 
-  /**
-    * Initialize a pool of workers and return a "completion service" that
-    * we can query (in a blocking manner) for completed tasks.
-    * */
-  private def initializeWorkerPool(): ExecutorCompletionService[Vector[ReachableByResult]] = {
-    val executorService: ExecutorService = Executors.newWorkStealingPool()
-    new ExecutorCompletionService[Vector[ReachableByResult]](executorService)
+  def shutdown(): Unit = {
+    executorService.shutdown()
   }
 
   /**


### PR DESCRIPTION
When running multiple `reachableBy` queries, each query creates its own executor pool and fails to shut it down. This PR fixes that.