### PR TITLE
Add documentation members to Query

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/QueryDatabase.scala
+++ b/console/src/main/scala/io/shiftleft/console/QueryDatabase.scala
@@ -20,7 +20,13 @@ case class Query(name: String,
                  title: String,
                  description: String,
                  score: Double,
+                 // intended to be filled by com.lihaoyi.sourcecode.Line
+                 docStartLine: Int = 0,
                  traversal: Cpg => Traversal[nodes.StoredNode],
+                 // intended to be filled by com.lihaoyi.sourcecode.Line
+                 docEndLine: Int = 0,
+                 // intended to be filled by com.lihaoyi.sourcecode.FileName
+                 docFileName: String = "",
                  tags: List[String] = List())
 
 class QueryDatabase(defaultArgumentProvider: DefaultArgumentProvider = new DefaultArgumentProvider,

--- a/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
@@ -10,7 +10,7 @@ object TestBundle extends QueryBundle {
     author = "an-author",
     title = "a-title",
     description = s"a-description $n",
-    score = 2.0, { cpg =>
+    score = 2.0, traversal = { cpg =>
       cpg.method
     }
   )


### PR DESCRIPTION
Example usage in the `query-database`:

```
object CopyLoops extends QueryBundle {

  @q
  def isCopyLoop(): Query = Query(
    name = "copy-loop",
    author = Crew.fabs,
    title = "Copy loop detected",
    description =
      """
        |For (buf, indices) pairs, determine those inside control structures (for, while, if ...)
        |where any of the calls made outside of the body (block) are Inc operations. Determine
        |the first argument of that Inc operation and check if they are used as indices for
        |the write operation into the buffer.
        |""".stripMargin,
    score = 2,
    startLine = sourcecode.Line(),
    traversal = { cpg =>
      cpg.assignment.target.isArrayAccess
        .map { access =>
          (access.array, access.subscripts.code.toSet)
        }
        .filter {
          case (buf, subscripts) =>
            val incIdentifiers = buf.inAst.isControlStructure.astChildren
              .filterNot(_.isBlock)
              .assignments
              .target
              .code
              .toSet
            (incIdentifiers & subscripts).nonEmpty
        }
        .map(_._1)
    },
    endLine = sourcecode.Line(),
    fileName = sourcecode.FileName()
  )

}
```