### PR TITLE
Reduce default max call depth from 4 to 2 in OSS dflow

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -256,7 +256,7 @@ object Engine {
 }
 
 case class EngineContext(semantics: Semantics, config: EngineConfig = EngineConfig())
-case class EngineConfig(var maxCallDepth: Int = 4)
+case class EngineConfig(var maxCallDepth: Int = 2)
 
 /**
   * Callable for solving a ReachableByTask


### PR DESCRIPTION
... to be in line with what `joern-scan` does.