### PR TITLE
Integrate with scalafix for OrderingImports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,16 @@ inThisBuild(
       Resolver.mavenLocal,
       Resolver.bintrayRepo("shiftleft", "maven"),
       Resolver.bintrayRepo("mpollmeier", "maven"),
-      "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"),
+      "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"
+    ),
     packageDoc / publishArtifact := true,
     packageSrc / publishArtifact := true,
-    scmInfo := Some(ScmInfo(url("https://github.com/ShiftLeftSecurity/codepropertygraph"),
-                            "scm:git@github.com:ShiftLeftSecurity/codepropertygraph.git")),
+    scmInfo := Some(
+      ScmInfo(
+        url("https://github.com/ShiftLeftSecurity/codepropertygraph"),
+        "scm:git@github.com:ShiftLeftSecurity/codepropertygraph.git"
+      )
+    ),
     homepage := Some(url("https://github.com/ShiftLeftSecurity/codepropertygraph/")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
@@ -42,15 +47,20 @@ inThisBuild(
   )
 )
 
-ThisBuild/publishTo := sonatypePublishToBundle.value
+ThisBuild / publishTo := sonatypePublishToBundle.value
 ThisBuild / Test / fork := true
 ThisBuild / Test / javaOptions += s"-Dlog4j2.configurationFile=file:${baseDirectory.in(ThisBuild).value}/resources/log4j2-test.xml"
 // If we fork we immediately stumble upon https://github.com/sbt/sbt/issues/3892 and https://github.com/sbt/sbt/issues/3892
 ThisBuild / Test / javaOptions += s"-Duser.dir=${baseDirectory.in(ThisBuild).value}"
 
-ThisBuild/libraryDependencies ++= Seq(
-  "org.apache.logging.log4j" %  "log4j-slf4j-impl" % "2.11.2" % Test
+ThisBuild / libraryDependencies ++= Seq(
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.11.2" % Test
 )
+
+// Scalafix / imports check setup
+ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.5.0-alpha.1"
+ThisBuild / semanticdbEnabled := true // enable SemanticDB
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision // use Scalafix compatible version
 
 name := "codepropertygraph"
 publish / skip := true
@@ -68,18 +78,23 @@ lazy val console = Projects.console
 lazy val fuzzyc2cpg = Projects.fuzzyc2cpg
 lazy val fuzzyc2cpgtests = Projects.fuzzyc2cpgtests
 
-ThisBuild/scalacOptions ++= Seq(
+// Once sbt-scalafmt is at version > 2.x, use scalafmtAll
+addCommandAlias("format", ";scalafixAll OrganizeImports;scalafmt;test:scalafmt")
+
+ThisBuild / scalacOptions ++= Seq(
   "-deprecation",
   "-feature",
+  "-Ywarn-unused", // required by scalafix
   // "-Xfatal-warnings", // TODO MP reenable
   "-language:implicitConversions",
   "-Ycache-macro-class-loader:last-modified",
-  "-Ybackend-parallelism", "4")
-ThisBuild/compile/javacOptions ++= Seq("-g") //debug symbols
+  "-Ybackend-parallelism",
+  "4"
+)
+ThisBuild / compile / javacOptions ++= Seq("-g") //debug symbols
 
-Global/onChangedBuildSource := ReloadOnSourceChanges
+Global / onChangedBuildSource := ReloadOnSourceChanges
 onLoad in Global := {
   assert(GitLFSUtils.isGitLFSEnabled(), "You need to install git-lfs and run 'git lfs pull'")
   (onLoad in Global).value
 }
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,10 @@
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
+// TODO: switch to addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+// This version is ancient and not supported
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "2.0.13")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"   % "1.3.5")
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.25")


### PR DESCRIPTION
Initial integration solely for the purpose of solving the unordered
imports problem. scalafix can introduce a lot of other linting, but for
now I'm only invoking a single rule.

Provides `format` alias to correctly first invoke scalafix and then
scalafmt (the former can break formatting). Having a single command
simplifies stuff when we have failures in CI.

Not used TaskKey definition as sbt-scalafix does some "clever" caching
preventing me from invoking it correctly. Alias works just fine.

Note:
This change does not introduce PR/master checks for scalafixCheck.
This change does not include the result of `sbt format`.

Both will be added in a follow up PR, as they do a lot of automatic
formatting.