### PR TITLE
make queryInit explicitly return a `Query` to avoid casts

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/console/Query.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/console/Query.scala
@@ -1,0 +1,20 @@
+package io.shiftleft.console
+
+import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.Cpg
+import overflowdb.traversal.Traversal
+
+case class Query(name: String,
+                 author: String,
+                 title: String,
+                 description: String,
+                 score: Double,
+                 // intended to be filled by com.lihaoyi.sourcecode.Line
+                 docStartLine: Int = 0,
+                 traversal: Cpg => Traversal[nodes.StoredNode],
+                 // intended to be filled by com.lihaoyi.sourcecode.Line
+                 docEndLine: Int = 0,
+                 // intended to be filled by com.lihaoyi.sourcecode.FileName
+                 docFileName: String = "",
+                 traversalAsString: String = "",
+                 tags: List[String] = List())

--- a/console/src/main/scala/io/shiftleft/console/QueryDatabase.scala
+++ b/console/src/main/scala/io/shiftleft/console/QueryDatabase.scala
@@ -1,12 +1,8 @@
 package io.shiftleft.console
 
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes
 import org.reflections8.Reflections
 import org.reflections8.util.{ClasspathHelper, ConfigurationBuilder}
 import org.slf4j.{Logger, LoggerFactory}
-import overflowdb.traversal.Traversal
-
 import scala.annotation.{StaticAnnotation, unused}
 import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
@@ -14,21 +10,6 @@ import scala.reflect.runtime.{universe => ru}
 
 trait QueryBundle
 class q() extends StaticAnnotation
-
-case class Query(name: String,
-                 author: String,
-                 title: String,
-                 description: String,
-                 score: Double,
-                 // intended to be filled by com.lihaoyi.sourcecode.Line
-                 docStartLine: Int = 0,
-                 traversal: Cpg => Traversal[nodes.StoredNode],
-                 // intended to be filled by com.lihaoyi.sourcecode.Line
-                 docEndLine: Int = 0,
-                 // intended to be filled by com.lihaoyi.sourcecode.FileName
-                 docFileName: String = "",
-                 traversalAsString: String = "",
-                 tags: List[String] = List())
 
 class QueryDatabase(defaultArgumentProvider: DefaultArgumentProvider = new DefaultArgumentProvider,
                     namespace: String = "io.joern.scanners") {

--- a/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
@@ -4,7 +4,6 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.codepropertygraph.Cpg
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.traversal.Traversal
 import io.shiftleft.macros.QueryMacros
 
 object TestBundle extends QueryBundle {
@@ -43,7 +42,9 @@ class QueryDatabaseTests extends AnyWordSpec with should.Matchers {
         "an-author",
         "a-title",
         "a-description",
-        2.0, { cpg: Cpg => cpg.method }).asInstanceOf[Query]
+        2.0,
+        { cpg: Cpg => cpg.method }
+      )
       query.title shouldBe "a-title"
       query.traversalAsString shouldBe "cpg: Cpg => cpg.method"
     }

--- a/macros/src/main/scala/io/shiftleft/macros/Macros.scala
+++ b/macros/src/main/scala/io/shiftleft/macros/Macros.scala
@@ -2,6 +2,7 @@ package io.shiftleft.macros
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.console.Query
 import overflowdb.traversal.Traversal
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
@@ -13,21 +14,21 @@ object QueryMacros {
                 title: String,
                 description: String,
                 score: Double,
-                traversal: Cpg => Traversal[nodes.StoredNode]): Any = macro queryInitImpl
+                traversal: Cpg => Traversal[nodes.StoredNode]): Query = macro queryInitImpl
 
   def queryInitImpl(c: whitebox.Context)(name: c.Tree,
                                          author: c.Tree,
                                          title: c.Tree,
                                          description: c.Tree,
                                          score: c.Tree,
-                                         traversal: c.Tree): c.Expr[Any] = {
+                                         traversal: c.Tree): c.Expr[Query] = {
     import c.universe._
     val fileContent = new String(traversal.pos.source.content)
     val start = traversal.pos.start
     val end = traversal.pos.end
     val traversalAsString: String = fileContent.slice(start, end)
 
-    c.Expr[Any](
+    c.Expr(
       q"""
         Query(
           name = $name,


### PR DESCRIPTION
note: in order to reference `Query` from the macro i needed to pull it
out to another common dependency - you probably want to move it
somewhere else