### PR TITLE
better workaround for the scala reflect bug

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -48,9 +48,9 @@ scalacOptions -= "-Xfatal-warnings"
 val ScoptVersion = "3.7.1"
 val BetterFilesVersion = "3.8.0"
 val CaskVersion = "0.7.8"
-val CatsVersion = "2.0.0"
+val CatsVersion = "2.3.1"
 val CirceVersion = "0.12.2"
-val AmmoniteVersion = "2.3.8-4-88785969"
+val AmmoniteVersion = "2.3.8-32-64308dc3"
 val ZeroturnaroundVersion = "1.13"
 
 dependsOn(Projects.fuzzyc2cpg % Test)

--- a/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
@@ -17,6 +17,8 @@ import java.nio.file.{Files, Path}
   * All scripts are compiled in-memory and no caching is performed.
   */
 trait AmmoniteExecutor {
+  ScalaReflectWorkaround.workaroundScalaReflectBugByTriggeringReflection()
+
   protected def predef: String
 
   protected lazy val ammoniteMain: Main = ammonite.Main(predefCode = predef,

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
@@ -3,7 +3,6 @@ package io.shiftleft.console.scripting
 import scala.reflect.runtime.currentMirror
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto
 
-
 /** a workaround for a scala reflect bug, where the first invocation of scala reflect fails
   * idea: invoke this at the very start to trigger the bug. future invocations should be fine
   * i asked to move the retry logic into scala reflect as a better way to handle this
@@ -17,7 +16,9 @@ object ScalaReflectWorkaround {
   def workaroundScalaReflectBugByTriggeringReflection() = {
     if (!applied) {
       try {
-        currentMirror.reflectModule(currentMirror.staticModule("io.shiftleft.console.scripting.ScalaReflectWorkaround$")).instance
+        currentMirror
+          .reflectModule(currentMirror.staticModule("io.shiftleft.console.scripting.ScalaReflectWorkaround$"))
+          .instance
       } catch {
         case t: Throwable => // that's what we want to trigger - it happens the first time, then works - all good
       }

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
@@ -1,0 +1,27 @@
+package io.shiftleft.console.scripting
+
+import scala.reflect.runtime.currentMirror
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+
+
+/** a workaround for a scala reflect bug, where the first invocation of scala reflect fails
+  * idea: invoke this at the very start to trigger the bug. future invocations should be fine
+  * i asked to move the retry logic into scala reflect as a better way to handle this
+  * https://github.com/scala/bug/issues/12038#issuecomment-760629585
+  */
+object ScalaReflectWorkaround {
+  var applied = false
+
+  def fromJava(t: FileDescriptorProto): Unit = ()
+
+  def workaroundScalaReflectBugByTriggeringReflection() = {
+    if (!applied) {
+      try {
+        currentMirror.reflectModule(currentMirror.staticModule("io.shiftleft.console.scripting.ScalaReflectWorkaround$")).instance
+      } catch {
+        case t: Throwable => // that's what we want to trigger - it happens the first time, then works - all good
+      }
+      applied = true
+    }
+  }
+}

--- a/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
@@ -13,7 +13,9 @@ object TestBundle extends QueryBundle {
     title = "a-title",
     description = s"a-description $n",
     score = 2.0,
-    traversal = { cpg => cpg.method }
+    traversal = { cpg =>
+      cpg.method
+    }
   )
 }
 
@@ -42,8 +44,9 @@ class QueryDatabaseTests extends AnyWordSpec with should.Matchers {
         "an-author",
         "a-title",
         "a-description",
-        2.0,
-        { cpg: Cpg => cpg.method }
+        2.0, { cpg: Cpg =>
+          cpg.method
+        }
       )
       query.title shouldBe "a-title"
       query.traversalAsString shouldBe "cpg: Cpg => cpg.method"


### PR DESCRIPTION
it only seems to happen with ammonite scrits, so now we trigger scala 
reflect once, which is a workaround for the bug - it only happens the first
time...

ammonite and cats upgrades are not essential, but they don't harm either