### PR TITLE
Set graphviz direction explicitly

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -34,6 +34,7 @@ object DotSerializer {
       case _                    => ""
     }
     sb.append(s"digraph $name {  \n")
+    sb.append("  rankdir=LR\n")
   }
 
   private def stringRepr(vertex: nodes.StoredNode): String = {


### PR DESCRIPTION
Before:

![ast](https://user-images.githubusercontent.com/1175576/106384551-b8827380-63cb-11eb-8986-8df8b1caff37.png)

After:

![ast-lr](https://user-images.githubusercontent.com/1175576/106384556-be785480-63cb-11eb-891e-c60ccd5359d9.png)


@fabsx00 please let me know if there is a specific reason to not set the direction explicitly.