### PR TITLE
Incremental work on spec cleanup

### DIFF
--- a/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
@@ -13,7 +13,9 @@ object TestBundle extends QueryBundle {
     title = "a-title",
     description = s"a-description $n",
     score = 2.0,
-    traversal = { cpg => cpg.method }
+    traversal = { cpg =>
+      cpg.method
+    }
   )
 }
 
@@ -42,8 +44,9 @@ class QueryDatabaseTests extends AnyWordSpec with should.Matchers {
         "an-author",
         "a-title",
         "a-description",
-        2.0,
-        { cpg: Cpg => cpg.method }
+        2.0, { cpg: Cpg =>
+          cpg.method
+        }
       )
       query.title shouldBe "a-title"
       query.traversalAsString shouldBe "cpg: Cpg => cpg.method"

--- a/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
@@ -49,7 +49,7 @@ class QueryDatabaseTests extends AnyWordSpec with should.Matchers {
         }
       )
       query.title shouldBe "a-title"
-      query.traversalAsString shouldBe "cpg: Cpg => cpg.method"
+      query.traversalAsString.endsWith("cpg.method") shouldBe true
     }
   }
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CDataFlowTests.scala
@@ -603,7 +603,7 @@ class CDataFlowTests17 extends DataFlowCodeToCpgSuite {
     sink.reachableByFlows(source).l.map(flowToResultPairs).toSet shouldBe Set(
       List(("source()", Some(4)),
            ("return source();", Some(4)),
-           ("RET", Some(3)),
+           ("int", Some(3)),
            ("bar()", Some(8)),
            ("y = bar()", Some(8)),
            ("sink(y)", Some(9)))
@@ -616,7 +616,7 @@ class CDataFlowTests17 extends DataFlowCodeToCpgSuite {
     sink.reachableByFlows(source).l.map(flowToResultPairs).toSet shouldBe Set(
       List(("source()", Some(4)),
            ("return source();", Some(4)),
-           ("RET", Some(3)),
+           ("int", Some(3)),
            ("bar()", Some(8)),
            ("y = bar()", Some(8)),
            ("sink(y)", Some(9)),
@@ -657,7 +657,7 @@ class CDataFlowTests18 extends DataFlowCodeToCpgSuite {
     val flows = sink.reachableByFlows(source).l
     flows.size shouldBe 1
     flows.map(flowToResultPairs).toSet shouldBe Set(
-      List(("RET", Some(7)),
+      List(("double", Some(7)),
            ("source(2)", Some(16)),
            ("k = source(2)", Some(16)),
            ("point.x = k", Some(18)),
@@ -698,7 +698,7 @@ class CDataFlowTests19 extends DataFlowCodeToCpgSuite {
 
     flows.size shouldBe 1
     flows.map(flowToResultPairs).toSet shouldBe Set(
-      List(("RET", Some(7)),
+      List(("struct Point", Some(7)),
            ("source(2)", Some(17)),
            ("point = source(2)", Some(17)),
            ("sink(point.x)", Some(18)),
@@ -879,8 +879,8 @@ class CDataFlowTests27 extends DataFlowCodeToCpgSuite {
     val flows = sink.reachableByFlows(source).l
 
     flows.map(flowToResultPairs).toSet shouldBe Set(
-      List(("free(x)", Some(4)), ("RET", Some(2))),
-      List(("free(y)", Some(3)), ("RET", Some(2)))
+      List(("free(x)", Some(4)), ("int", Some(2))),
+      List(("free(y)", Some(3)), ("int", Some(2)))
     )
   }
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NewCDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NewCDataFlowTests.scala
@@ -58,7 +58,7 @@ class NewCDataFlowTests3 extends DataFlowCodeToCpgSuite {
     val flows = sink.reachableByFlows(source).l
     flows.size shouldBe 1
     flows.map(flowToResultPairs).toSet shouldBe Set(
-      List(("woo(x)", Some(3)), ("RET", Some(2)))
+      List(("woo(x)", Some(3)), ("void", Some(2)))
     )
   }
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
@@ -1,10 +1,10 @@
-package io.shiftleft.fuzzyc2cpg.querying
+package io.shiftleft.fuzzyc2cpg.standard
 
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.File
 
-class FileNodeTests extends FuzzyCCodeToCpgSuite {
+class FileTests extends FuzzyCCodeToCpgSuite {
 
   override val code: String =
     """

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MetaDataTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MetaDataTests.scala
@@ -1,9 +1,9 @@
-package io.shiftleft.fuzzyc2cpg.querying
+package io.shiftleft.fuzzyc2cpg.standard
 
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 
-class MetaDataNodeTests extends FuzzyCCodeToCpgSuite {
+class MetaDataTests extends FuzzyCCodeToCpgSuite {
 
   override val code: String =
     """

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
@@ -2,7 +2,6 @@ package io.shiftleft.fuzzyc2cpg.standard
 
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
-import io.shiftleft.proto.cpg.Cpg.EvaluationStrategies
 
 class MethodReturnTests extends FuzzyCCodeToCpgSuite {
 
@@ -14,7 +13,6 @@ class MethodReturnTests extends FuzzyCCodeToCpgSuite {
   "should" in {
     cpg.methodReturn.l match {
       case List(x) =>
-        x.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE.toString
         x.code shouldBe "RET"
         x.typeFullName shouldBe "int *"
       case _ => fail()

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
@@ -25,4 +25,8 @@ class MethodReturnTests extends FuzzyCCodeToCpgSuite {
     }
   }
 
+  "should allow traversing to method" in {
+    cpg.methodReturn.method.name.l shouldBe List("foo")
+  }
+
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
@@ -1,0 +1,24 @@
+package io.shiftleft.fuzzyc2cpg.standard
+
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
+import io.shiftleft.proto.cpg.Cpg.EvaluationStrategies
+
+class MethodReturnTests extends FuzzyCCodeToCpgSuite {
+
+  override val code =
+    """
+      |int *foo() { return x; }
+      |""".stripMargin
+
+  "should" in {
+    cpg.methodReturn.l match {
+      case List(x) =>
+        x.evaluationStrategy shouldBe EvaluationStrategies.BY_VALUE.toString
+        x.code shouldBe "RET"
+        x.typeFullName shouldBe "int *"
+      case _ => fail()
+    }
+  }
+
+}

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
@@ -7,14 +7,20 @@ class MethodReturnTests extends FuzzyCCodeToCpgSuite {
 
   override val code =
     """
-      |int *foo() { return x; }
+      | int *foo() { return x; }
       |""".stripMargin
 
-  "should" in {
+  "should have METHOD_RETURN node with correct fields" in {
     cpg.methodReturn.l match {
       case List(x) =>
-        x.code shouldBe "RET"
+        x.code shouldBe "int *"
         x.typeFullName shouldBe "int *"
+        x.lineNumber shouldBe Some(2)
+        x.columnNumber shouldBe Some(1)
+        // we expect the METHOD_RETURN node to be the right-most
+        // child so that when traversing the AST from left to
+        // right in CFG construction, we visit it last.
+        x.order shouldBe 2
       case _ => fail()
     }
   }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodTests.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.fuzzyc2cpg.querying
+package io.shiftleft.fuzzyc2cpg.standard
 
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
@@ -6,7 +6,7 @@ import io.shiftleft.semanticcpg.language._
 /**
   * Language primitives for navigating method stubs
   * */
-class CMethodTests extends FuzzyCCodeToCpgSuite {
+class MethodTests extends FuzzyCCodeToCpgSuite {
 
   override val code =
     """

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.fuzzyc2cpg.querying
+package io.shiftleft.fuzzyc2cpg.standard
 
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/ParameterTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/ParameterTests.scala
@@ -1,0 +1,3 @@
+package io.shiftleft.fuzzyc2cpg.standard
+
+class ParameterTests {}

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/TypeDeclTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/TypeDeclTests.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.fuzzyc2cpg.querying
+package io.shiftleft.fuzzyc2cpg.standard
 
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
@@ -144,8 +144,12 @@ private[astcreation] class AstCreator(diffGraph: DiffGraph.Builder,
 
     astFunction.getContent.accept(this)
 
+    val retCode = Option(astFunction.getReturnType)
+      .map(_.getEscapedCodeStr)
+      .getOrElse("RET")
+
     val methodReturn = nodes.NewMethodReturn(
-      code = "RET",
+      code = retCode,
       evaluationStrategy = EvaluationStrategies.BY_VALUE.name(),
       typeFullName = registerType(returnType),
       lineNumber = methodReturnLocation.startLine,

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/MethodHeaderTests.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/MethodHeaderTests.scala
@@ -60,7 +60,7 @@ class MethodHeaderTests extends AnyWordSpec with Matchers {
         .l
 
       methodReturn.size shouldBe 1
-      methodReturn.head.property(NodeKeys.CODE) shouldBe "RET"
+      methodReturn.head.property(NodeKeys.CODE) shouldBe "int"
       methodReturn.head.property(NodeKeys.EVALUATION_STRATEGY) shouldBe EvaluationStrategies.BY_VALUE
       methodReturn.head.property(NodeKeys.LINE_NUMBER) shouldBe 1
       methodReturn.head.property(NodeKeys.COLUMN_NUMBER) shouldBe 0

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPassTests.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPassTests.scala
@@ -463,7 +463,7 @@ class CfgFixture(file1Code: String) {
 
   File.usingTemporaryDirectory("fuzzyctest") { dir =>
     val file1 = dir / "file1.c"
-    file1.write(s"int func() { $file1Code }")
+    file1.write(s"RET func() { $file1Code }")
     val keyPoolFile1 = new IntervalKeyPool(1001, 2000)
     val cfgKeyPool = new IntervalKeyPool(2001, 3000)
     val filenames = List(file1.path.toAbsolutePath.toString)

--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -32,11 +32,6 @@
         {"id": 21, "name": "CODE", "comment": "The code snippet the node represents", "valueType" : "string", "cardinality" : "one"},
         {"id": 22, "name": "SIGNATURE", "comment": "Method signature. The format is defined by the language front-end, and the backend simply compares strings to resolve function overloading, i.e. match call-sites to METHODs. In theory, consecutive integers would be valid, but in practice this should be human readable", "valueType" : "string", "cardinality" : "one"},
         {"id": 26, "name" : "MODIFIER_TYPE", "comment" : "Indicates the modifier which is represented by a MODIFIER node. See modifierTypes", "valueType" : "string", "cardinality" : "one"},
-
-        // Properties to characterize call-sites
-
-        {"id": 25, "name": "DISPATCH_TYPE", "comment": "The dispatch type of a call, which is either static or dynamic. See dispatchTypes", "valueType" : "string", "cardinality" : "one"},
-
         // Properties used to link nodes in the backend
         {"id": 51, "name" : "TYPE_FULL_NAME", "comment" : "The static type of an entity. E.g. expressions, local, parameters etc. This property is matched against the FULL_NAME of TYPE nodes and thus it is required to have at least one TYPE node for each TYPE_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
         {"id": 52, "name" : "TYPE_DECL_FULL_NAME", "comment" : "The static type decl of a TYPE. This property is matched against the FULL_NAME of TYPE_DECL nodes. It is required to have exactly one TYPE_DECL for each different TYPE_DECL_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
@@ -211,7 +206,7 @@
          ]
         },
         {"id": 15, "name" : "CALL",
-         "keys": ["CODE", "NAME", "ORDER", "METHOD_INST_FULL_NAME", "METHOD_FULL_NAME", "ARGUMENT_INDEX", "DISPATCH_TYPE", "SIGNATURE", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": ["CODE", "NAME", "ORDER", "METHOD_INST_FULL_NAME", "METHOD_FULL_NAME", "ARGUMENT_INDEX", "SIGNATURE", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A (method)-call",
          "is": ["EXPRESSION", "CALL_REPR"],
          "outEdges" : [
@@ -623,11 +618,6 @@
     ],
 
     // Enums
-
-    "dispatchTypes" : [
-        {"id" : 1, "name" : "STATIC_DISPATCH", "comment": "For statically dispatched calls the call target is known before program execution"},
-        {"id" : 2, "name" : "DYNAMIC_DISPATCH", "comment": "For dynamically dispatched calls the target is determined during runtime"}
-    ],
 
     // TODO rename to "frontends"
     "languages" : [

--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -36,7 +36,6 @@
         // Properties to characterize call-sites
 
         {"id": 25, "name": "DISPATCH_TYPE", "comment": "The dispatch type of a call, which is either static or dynamic. See dispatchTypes", "valueType" : "string", "cardinality" : "one"},
-        {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\"", "valueType" : "string", "cardinality" : "one"},
 
         // Properties used to link nodes in the backend
         {"id": 51, "name" : "TYPE_FULL_NAME", "comment" : "The static type of an entity. E.g. expressions, local, parameters etc. This property is matched against the FULL_NAME of TYPE nodes and thus it is required to have at least one TYPE node for each TYPE_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
@@ -118,13 +117,13 @@
         },
 
         {"id" : 34, "name" : "METHOD_PARAMETER_IN",
-         "keys": ["CODE", "ORDER", "NAME", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": ["CODE", "ORDER", "NAME", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "This node represents a formal parameter going towards the callee side",
          "is": ["DECLARATION", "LOCAL_LIKE", "TRACKING_POINT", "AST_NODE"]
         },
 
         {"id" : 3, "name" : "METHOD_RETURN",
-         "keys": ["CODE", "EVALUATION_STRATEGY", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
+         "keys": ["CODE", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
          "comment" : "A formal method return",
          "is": ["CFG_NODE", "TRACKING_POINT"]
         },
@@ -624,12 +623,6 @@
     ],
 
     // Enums
-
-    "evaluationStrategies" : [
-        {"id" : 1, "name" : "BY_REFERENCE", "comment" : "A parameter or return of a function is passed by reference which means an address is used behind the scenes"},
-        {"id" : 2, "name" : "BY_SHARING", "comment" : "Only applicable to object parameter or return values. The pointer to the object is passed by value but the object itself is not copied and changes to it are thus propagated out of the method context"},
-        {"id" : 3, "name" : "BY_VALUE", "comment" : "A parameter or return of a function passed by value which means a flat copy is used"}
-    ],
 
     "dispatchTypes" : [
         {"id" : 1, "name" : "STATIC_DISPATCH", "comment": "For statically dispatched calls the call target is known before program execution"},

--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -153,19 +153,9 @@
              {"name": "MEMBER", "cardinality": "1:n"},
              {"name": "MODIFIER", "cardinality": "1:n"}
            ]},
-           {"edgeName": "BINDS", "inNodes": [{"name":"BINDING", "cardinality": "1:n"}]},
            {"edgeName": "VTABLE", "inNodes": [{"name":"METHOD"}]}
          ],
          "is" : ["AST_NODE"]
-        },
-        {"id" : 146, "name" : "BINDING",
-         "keys" : ["NAME", "SIGNATURE"],
-         "comment" : "A binding of a METHOD into a TYPE_DECL",
-         "outEdges" : [
-           {"edgeName": "REF", "inNodes": [
-            {"name":"METHOD", "cardinality": "n:1"}
-           ]}
-         ]
         },
         {"id" : 47, "name" : "TYPE_PARAMETER",
          "keys" : ["NAME", "ORDER"],
@@ -627,8 +617,7 @@
         // VTABLE edge is deprecated.
         {"id" : 30, "name": "VTABLE", "comment" : "Indicates that a method is part of the vtable of a certain type declaration", "keys": []},
         {"id" : 55, "name": "RECEIVER", "comment" : "The receiver of a method call which is either an object or a pointer", "keys": []},
-        {"id" : 56, "name": "CONDITION", "comment" : "Edge from control structure node to the expression that holds the condition", "keys" : []},
-        {"id" : 155, "name": "BINDS", "comment" : "Relation between TYPE_DECL and BINDING node", "keys": []},
+        {"id" : 56, "name": "CONDITION", "comment" : "Edge from control structure node to the expression that holds the condition", "keys" : []},        
         {"id" : 156, "name": "ARGUMENT", "comment" : "Relation between a CALL and its arguments and RETURN and the returned expression", "keys": []},
         {"id" : 157, "name" : "SOURCE_FILE", "comment" : "Source file of a node, in which its LINE_NUMBER and COLUMN_NUMBER are valid", "keys" : []}
 

--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -41,7 +41,6 @@
         {"id": 56, "name" : "AST_PARENT_TYPE", "comment" : "The type of the AST parent. Since this is only used in some parts of the graph the list does not include all possible parents by intention. Possible parents: METHOD, TYPE_DECL, NAMESPACE_BLOCK", "valueType" : "string", "cardinality" : "one"},
         {"id": 57, "name" : "AST_PARENT_FULL_NAME", "comment" : "The FULL_NAME of a the AST parent of an entity", "valueType" : "string", "cardinality" : "one"},
         {"id": 158, "name" : "ALIAS_TYPE_FULL_NAME", "comment" : "Type full name of which a TYPE_DECL is an alias of", "valueType" : "string", "cardinality" : "zeroOrOne"},
-        {"id": 1591, "name" : "DYNAMIC_TYPE_HINT_FULL_NAME", "comment" : "Type hint for the dynamic type", "valueType" : "string", "cardinality" : "list"},
         {"id" : 106, "name" : "FILENAME", "comment" : "Full path of canonical file that contained this node; will be linked into corresponding FILE nodes. Possible for METHOD, TYPE_DECL and NAMESPACE_BLOCK", "valueType" : "string", "cardinality" : "one"},
         
         // special properties
@@ -112,13 +111,13 @@
         },
 
         {"id" : 34, "name" : "METHOD_PARAMETER_IN",
-         "keys": ["CODE", "ORDER", "NAME", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": ["CODE", "ORDER", "NAME", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "This node represents a formal parameter going towards the callee side",
          "is": ["DECLARATION", "LOCAL_LIKE", "TRACKING_POINT", "AST_NODE"]
         },
 
         {"id" : 3, "name" : "METHOD_RETURN",
-         "keys": ["CODE", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
+         "keys": ["CODE", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
          "comment" : "A formal method return",
          "is": ["CFG_NODE", "TRACKING_POINT"]
         },
@@ -168,7 +167,7 @@
         },
 
         {"id" : 9, "name" : "MEMBER",
-         "keys" : [ "CODE", "NAME", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "ORDER"],
+         "keys" : [ "CODE", "NAME", "TYPE_FULL_NAME", "ORDER"],
          "comment" : "Member of a class struct or union",
          "is": ["DECLARATION", "AST_NODE"]
         },
@@ -184,7 +183,7 @@
         // Nodes that describe method content
 
         {"id" : 8, "name" : "LITERAL",
-         "keys" : ["CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys" : ["CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "Literal/Constant",
          "is": ["EXPRESSION"],
          "outEdges" : [
@@ -206,7 +205,7 @@
          ]
         },
         {"id": 15, "name" : "CALL",
-         "keys": ["CODE", "NAME", "ORDER", "METHOD_INST_FULL_NAME", "METHOD_FULL_NAME", "ARGUMENT_INDEX", "SIGNATURE", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": ["CODE", "NAME", "ORDER", "METHOD_INST_FULL_NAME", "METHOD_FULL_NAME", "ARGUMENT_INDEX", "SIGNATURE", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A (method)-call",
          "is": ["EXPRESSION", "CALL_REPR"],
          "outEdges" : [
@@ -259,12 +258,12 @@
          ]
         },
         {"id":23, "name" : "LOCAL",
-         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
+         "keys": ["CODE", "NAME", "CLOSURE_BINDING_ID", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
          "comment": "A local variable",
          "is": ["DECLARATION", "LOCAL_LIKE", "AST_NODE"]
         },
         {"id":27, "name": "IDENTIFIER",
-         "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": ["CODE", "NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "An arbitrary identifier/reference",
          "is": ["EXPRESSION", "LOCAL_LIKE"],
          "outEdges" : [
@@ -343,7 +342,7 @@
          ]
         },
         {"id":31, "name": "BLOCK",
-         "keys": [ "CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": [ "CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A structuring block in the AST",
          "is": [ "EXPRESSION"],
          "outEdges" : [
@@ -392,7 +391,7 @@
         },
 
         {"id":333, "name":"METHOD_REF",
-          "keys": ["CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "METHOD_INST_FULL_NAME", "METHOD_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+          "keys": ["CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "METHOD_INST_FULL_NAME", "METHOD_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
           "comment":"Reference to a method instance",
          "is": ["EXPRESSION"],
           "outEdges": [
@@ -413,7 +412,7 @@
           ]
         },
       {"id":335, "name":"TYPE_REF",
-        "keys": ["CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+        "keys": ["CODE", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
         "comment":"Reference to a type/class",
         "is": ["EXPRESSION"],
         "outEdges": [
@@ -548,7 +547,7 @@
         // This is the "catch-all-others" node type.
 
         {"id" : 44, "name": "UNKNOWN",
-         "keys" : ["CODE", "PARSER_TYPE_NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "DYNAMIC_TYPE_HINT_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys" : ["CODE", "PARSER_TYPE_NAME", "ORDER", "ARGUMENT_INDEX", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A language-specific node",
          "is": ["EXPRESSION"],
          "outEdges" : [

--- a/schema/src/main/resources/schemas/enhancements.json
+++ b/schema/src/main/resources/schemas/enhancements.json
@@ -6,7 +6,8 @@
       {"id" : 8, "name": "VALUE", "comment" : "Tag value", "valueType" : "string", "cardinality" : "one"},
       {"id" : 1002, "name": "IS_METHOD_NEVER_OVERRIDDEN", "comment" : "True if the referenced method is never overridden by the subclasses and false otherwise", "valueType" : "boolean", "cardinality" : "zeroOrOne"},
       { "id" : 119, "name" : "POLICY_DIRECTORIES", "comment": "Sub directories of the policy directory that should be loaded when processing the CPG", "valueType" : "string", "cardinality" : "list"},
-      {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\"", "valueType" : "string", "cardinality" : "one"}
+      {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\"", "valueType" : "string", "cardinality" : "one"},
+      {"id": 25, "name": "DISPATCH_TYPE", "comment": "The dispatch type of a call, which is either static or dynamic. See dispatchTypes", "valueType" : "string", "cardinality" : "one"}
     ],
 
     "edgeKeys" : [
@@ -64,6 +65,9 @@
 	     {"edgeName": "TAGGED_BY", "inNodes": [{"name": "TAG"}]}
             ]
         },
+	{ "name": "CALL",
+	  "keys" : ["DISPATCH_TYPE"]
+	},
         { "name": "METHOD",
           "outEdges" : [
              {"edgeName": "AST", "inNodes": [
@@ -279,6 +283,11 @@
     ],
 
     // Enums
+
+    "dispatchTypes" : [
+        {"id" : 1, "name" : "STATIC_DISPATCH", "comment": "For statically dispatched calls the call target is known before program execution"},
+        {"id" : 2, "name" : "DYNAMIC_DISPATCH", "comment": "For dynamically dispatched calls the target is determined during runtime"}
+    ],
 
     "evaluationStrategies" : [
         {"id" : 1, "name" : "BY_REFERENCE", "comment" : "A parameter or return of a function is passed by reference which means an address is used behind the scenes"},

--- a/schema/src/main/resources/schemas/enhancements.json
+++ b/schema/src/main/resources/schemas/enhancements.json
@@ -7,9 +7,10 @@
       {"id" : 1002, "name": "IS_METHOD_NEVER_OVERRIDDEN", "comment" : "True if the referenced method is never overridden by the subclasses and false otherwise", "valueType" : "boolean", "cardinality" : "zeroOrOne"},
       { "id" : 119, "name" : "POLICY_DIRECTORIES", "comment": "Sub directories of the policy directory that should be loaded when processing the CPG", "valueType" : "string", "cardinality" : "list"},
       {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\"", "valueType" : "string", "cardinality" : "one"},
-      {"id": 25, "name": "DISPATCH_TYPE", "comment": "The dispatch type of a call, which is either static or dynamic. See dispatchTypes", "valueType" : "string", "cardinality" : "one"}
+      {"id": 25, "name": "DISPATCH_TYPE", "comment": "The dispatch type of a call, which is either static or dynamic. See dispatchTypes", "valueType" : "string", "cardinality" : "one"},
+      {"id": 1591, "name" : "DYNAMIC_TYPE_HINT_FULL_NAME", "comment" : "Type hint for the dynamic type", "valueType" : "string", "cardinality" : "list"}
     ],
-
+    
     "edgeKeys" : [
       {"id": 1, "name" : "ALIAS", "comment" : "Defines whether a PROPAGATE edge creates an alias", "valueType"     : "boolean", "cardinality" : "one" },
       {"id" : 11, "name" : "VARIABLE", "comment" : "A variable propagated by a reaching-def edge", "valueType" : "string", "cardinality" : "one"}
@@ -66,7 +67,7 @@
             ]
         },
 	{ "name": "CALL",
-	  "keys" : ["DISPATCH_TYPE"]
+	  "keys" : ["DISPATCH_TYPE", "DYNAMIC_TYPE_HINT_FULL_NAME"]
 	},
         { "name": "METHOD",
           "outEdges" : [
@@ -109,7 +110,7 @@
           ]
         },
         { "name": "METHOD_PARAMETER_IN",
-	  "keys": ["EVALUATION_STRATEGY"],
+	  "keys": ["EVALUATION_STRATEGY", "DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "PROPAGATE", "inNodes": [
               {"name": "METHOD_PARAMETER_OUT"},
@@ -135,7 +136,7 @@
          ]
         },
         { "name": "METHOD_RETURN",
-	  "keys": ["EVALUATION_STRATEGY"],
+	  "keys": ["EVALUATION_STRATEGY", "DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
@@ -152,12 +153,14 @@
             ]
         },
         { "name": "METHOD_REF",
+	  "keys" : ["DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "REF", "inNodes": [{"name": "METHOD", "cardinality": "n:1"}]},
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         },
       { "name": "TYPE_REF",
+        "keys" : ["DYNAMIC_TYPE_HINT_FULL_NAME"],
         "outEdges" : [
           {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
         ]
@@ -182,11 +185,13 @@
           ]
         },
         { "name": "MEMBER",
+	  "keys" : ["DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
         },
         {"name" : "LITERAL",
+	  "keys" : ["DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
 	    {"edgeName": "REACHING_DEF", "inNodes": [
@@ -211,12 +216,14 @@
           ]
         },
         { "name": "LOCAL",
+	  "keys" : ["DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
             {"edgeName": "CAPTURED_BY", "inNodes": [{"name": "CLOSURE_BINDING"}]}
           ]
         },
         {"name" : "IDENTIFIER",
+	  "keys" : ["DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
 	    {"edgeName": "REACHING_DEF", "inNodes": [
@@ -228,6 +235,7 @@
           ]
         },
         {"name" : "BLOCK",
+	  "keys" : ["DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]},
 	    {"edgeName": "REACHING_DEF", "inNodes": [
@@ -251,6 +259,7 @@
           ]
         },
         {"name" : "UNKNOWN",
+	 "keys" : ["DYNAMIC_TYPE_HINT_FULL_NAME"],
           "outEdges" : [
             {"edgeName": "REACHING_DEF", "inNodes": [
               {"name": "CALL"},

--- a/schema/src/main/resources/schemas/enhancements.json
+++ b/schema/src/main/resources/schemas/enhancements.json
@@ -14,6 +14,16 @@
     ],
 
     "nodeTypes" : [
+    
+      {"id" : 146, "name" : "BINDING",
+       	 "keys" : ["NAME", "SIGNATURE"],
+         "comment" : "A binding of a METHOD into a TYPE_DECL",
+         "outEdges" : [
+           {"edgeName": "REF", "inNodes": [
+            {"name":"METHOD", "cardinality": "n:1"}
+           ]}
+         ]
+      },
       {
         "id":307,"name" : "IMPLICIT_CALL",
           "keys" : ["CODE", "NAME", "SIGNATURE", "LINE_NUMBER", "COLUMN_NUMBER", "ORDER"],
@@ -160,7 +170,8 @@
              {"edgeName": "ALIAS_OF", "inNodes": [{"name": "TYPE"}]},
              {"edgeName": "CONTAINS", "inNodes": [{"name": "METHOD"}]},
              {"edgeName": "SOURCE_FILE", "inNodes": [{"name": "FILE"}]},
-             {"edgeName": "TYPE_DECL_ALIAS", "inNodes": [{"name": "TYPE_DECL"}]}
+             {"edgeName": "TYPE_DECL_ALIAS", "inNodes": [{"name": "TYPE_DECL"}]},
+	     {"edgeName": "BINDS", "inNodes": [{"name":"BINDING", "cardinality": "1:n"}]}
           ]
         },
         { "name": "MEMBER",
@@ -260,7 +271,8 @@
         {"id" : 1, "name" : "PROPAGATE", "keys" : ["ALIAS"], "comment" : "Encodes propagation of data from on node to another. The ALIAS property is deprecated."},
         {"id" : 137, "name": "REACHING_DEF", "comment" : "Reaching definition edge", "keys" : ["VARIABLE"]},
         {"id" : 138, "name" : "ALIAS_OF", "comment" : "Alias relation between types", "keys" : [] },
-        {"id" : 139, "name" : "TYPE_DECL_ALIAS", "comment" : "Alias relation between two TYPE_DECL", "keys" : [] }
+        {"id" : 139, "name" : "TYPE_DECL_ALIAS", "comment" : "Alias relation between two TYPE_DECL", "keys" : [] },
+	{"id" : 155, "name": "BINDS", "comment" : "Relation between TYPE_DECL and BINDING node", "keys": []}
     ]
 
 }

--- a/schema/src/main/resources/schemas/enhancements.json
+++ b/schema/src/main/resources/schemas/enhancements.json
@@ -5,7 +5,8 @@
     "nodeKeys" : [
       {"id" : 8, "name": "VALUE", "comment" : "Tag value", "valueType" : "string", "cardinality" : "one"},
       {"id" : 1002, "name": "IS_METHOD_NEVER_OVERRIDDEN", "comment" : "True if the referenced method is never overridden by the subclasses and false otherwise", "valueType" : "boolean", "cardinality" : "zeroOrOne"},
-      { "id" : 119, "name" : "POLICY_DIRECTORIES", "comment": "Sub directories of the policy directory that should be loaded when processing the CPG", "valueType" : "string", "cardinality" : "list"}
+      { "id" : 119, "name" : "POLICY_DIRECTORIES", "comment": "Sub directories of the policy directory that should be loaded when processing the CPG", "valueType" : "string", "cardinality" : "list"},
+      {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\"", "valueType" : "string", "cardinality" : "one"}
     ],
 
     "edgeKeys" : [
@@ -104,6 +105,7 @@
           ]
         },
         { "name": "METHOD_PARAMETER_IN",
+	  "keys": ["EVALUATION_STRATEGY"],
           "outEdges" : [
             {"edgeName": "PROPAGATE", "inNodes": [
               {"name": "METHOD_PARAMETER_OUT"},
@@ -129,6 +131,7 @@
          ]
         },
         { "name": "METHOD_RETURN",
+	  "keys": ["EVALUATION_STRATEGY"],
           "outEdges" : [
             {"edgeName": "EVAL_TYPE", "inNodes": [{"name": "TYPE"}]}
           ]
@@ -273,6 +276,14 @@
         {"id" : 138, "name" : "ALIAS_OF", "comment" : "Alias relation between types", "keys" : [] },
         {"id" : 139, "name" : "TYPE_DECL_ALIAS", "comment" : "Alias relation between two TYPE_DECL", "keys" : [] },
 	{"id" : 155, "name": "BINDS", "comment" : "Relation between TYPE_DECL and BINDING node", "keys": []}
+    ],
+
+    // Enums
+
+    "evaluationStrategies" : [
+        {"id" : 1, "name" : "BY_REFERENCE", "comment" : "A parameter or return of a function is passed by reference which means an address is used behind the scenes"},
+        {"id" : 2, "name" : "BY_SHARING", "comment" : "Only applicable to object parameter or return values. The pointer to the object is passed by value but the object itself is not copied and changes to it are thus propagated out of the method context"},
+        {"id" : 3, "name" : "BY_VALUE", "comment" : "A parameter or return of a function passed by value which means a flat copy is used"}
     ]
 
 }


### PR DESCRIPTION
* Run `sbt test:scalafmt` and fix QueryDatabase test accordingly
* Move BINDING nodes, BINDS edges, EVALUATION_STRATEGY and DYNAMIC_TYPE_HINT_FULL_NAME away from `base.json` as they are not used in the OSS world and are confusing for frontend developers
* Store code in `$MethodReturn.code` instead of just "RET"
* Add tests for method return nodes
* Move tests that will serve as a baseline for the standard into a separate package