### PR TITLE
better workaround for the scala reflect bug (#1100)

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -50,7 +50,7 @@ val BetterFilesVersion = "3.8.0"
 val CaskVersion = "0.7.8"
 val CatsVersion = "2.3.1"
 val CirceVersion = "0.12.2"
-val AmmoniteVersion = "2.3.8-32-64308dc3"
+val AmmoniteVersion = "2.3.8-4-88785969"
 val ZeroturnaroundVersion = "1.13"
 
 dependsOn(Projects.fuzzyc2cpg % Test)

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -48,9 +48,9 @@ scalacOptions -= "-Xfatal-warnings"
 val ScoptVersion = "3.7.1"
 val BetterFilesVersion = "3.8.0"
 val CaskVersion = "0.7.8"
-val CatsVersion = "2.0.0"
+val CatsVersion = "2.3.1"
 val CirceVersion = "0.12.2"
-val AmmoniteVersion = "2.3.8-4-88785969"
+val AmmoniteVersion = "2.3.8-32-64308dc3"
 val ZeroturnaroundVersion = "1.13"
 
 dependsOn(Projects.fuzzyc2cpg % Test)

--- a/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
@@ -17,6 +17,8 @@ import java.nio.file.{Files, Path}
   * All scripts are compiled in-memory and no caching is performed.
   */
 trait AmmoniteExecutor {
+  ScalaReflectWorkaround.workaroundScalaReflectBugByTriggeringReflection()
+
   protected def predef: String
 
   protected lazy val ammoniteMain: Main = ammonite.Main(predefCode = predef,

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
@@ -7,8 +7,8 @@ import com.google.protobuf.DescriptorProtos.FileDescriptorProto
   * idea: invoke this at the very start to trigger the bug. future invocations should be fine
   * i asked to move the retry logic into scala reflect as a better way to handle this
   * https://github.com/scala/bug/issues/12038#issuecomment-760629585
-  * 
-  * to reproduce the issue, comment out this workaround, publish cpg locally and run the following in the codescience repo: 
+  *
+  * to reproduce the issue, comment out this workaround, publish cpg locally and run the following in the codescience repo:
   * `cpg2sp/testOnly *PolicyAmmoniteExecutorTest`
   * if the above is green without this workaround, we don't need it any more
   */

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
@@ -1,0 +1,28 @@
+package io.shiftleft.console.scripting
+
+import scala.reflect.runtime.currentMirror
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+
+/** a workaround for a scala reflect bug, where the first invocation of scala reflect fails
+  * idea: invoke this at the very start to trigger the bug. future invocations should be fine
+  * i asked to move the retry logic into scala reflect as a better way to handle this
+  * https://github.com/scala/bug/issues/12038#issuecomment-760629585
+  */
+object ScalaReflectWorkaround {
+  var applied = false
+
+  def fromJava(t: FileDescriptorProto): Unit = ()
+
+  def workaroundScalaReflectBugByTriggeringReflection() = {
+    if (!applied) {
+      try {
+        currentMirror
+          .reflectModule(currentMirror.staticModule("io.shiftleft.console.scripting.ScalaReflectWorkaround$"))
+          .instance
+      } catch {
+        case t: Throwable => // that's what we want to trigger - it happens the first time, then works - all good
+      }
+      applied = true
+    }
+  }
+}

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
@@ -11,7 +11,11 @@ import com.google.protobuf.DescriptorProtos.FileDescriptorProto
 object ScalaReflectWorkaround {
   var applied = false
 
-  def fromJava(t: FileDescriptorProto): Unit = ()
+  def fromJava(t: FileDescriptorProto): Unit = {
+    println(t)
+    // this is just here to suppress a warnings - it is never invoked by anything afaik,
+    // but for whatever reason essential to trigger the scala reflection bug...
+  }
 
   def workaroundScalaReflectBugByTriggeringReflection() = {
     if (!applied) {
@@ -20,7 +24,7 @@ object ScalaReflectWorkaround {
           .reflectModule(currentMirror.staticModule("io.shiftleft.console.scripting.ScalaReflectWorkaround$"))
           .instance
       } catch {
-        case t: Throwable => // that's what we want to trigger - it happens the first time, then works - all good
+        case _: Throwable => // that's what we want to trigger - it happens the first time, then works - all good
       }
       applied = true
     }

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
@@ -7,6 +7,10 @@ import com.google.protobuf.DescriptorProtos.FileDescriptorProto
   * idea: invoke this at the very start to trigger the bug. future invocations should be fine
   * i asked to move the retry logic into scala reflect as a better way to handle this
   * https://github.com/scala/bug/issues/12038#issuecomment-760629585
+  * 
+  * to reproduce the issue, comment out this workaround, publish cpg locally and run the following in the codescience repo: 
+  * `cpg2sp/testOnly *PolicyAmmoniteExecutorTest`
+  * if the above is green without this workaround, we don't need it any more
   */
 object ScalaReflectWorkaround {
   var applied = false


### PR DESCRIPTION
workaround for https://github.com/scala/bug/issues/12038

* upgrade ammonite and cats

* doesn't seem to fix anything but doesn't harm either

* better workaround for the scala reflect bug
 it only seems to happen with ammonite scrits, so now we trigger scala reflect once, which is a workaround for the bug - it only happens the first time...

* fmt