### PR TITLE
More incremental work on CPG spec cleanup

### DIFF
--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
@@ -20,17 +20,17 @@ class FileTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should contain exactly one placeholder file node with `name=\"<unknown>\"/order=0`" in {
-    cpg.file(File.UNKNOWN).l match {
-      case List(x) =>
-        x.order shouldBe 0
-      case _ => fail()
-    }
+    cpg.file(File.UNKNOWN).order.l shouldBe List(0)
+    cpg.file(File.UNKNOWN).hash.l shouldBe List()
   }
 
   "should contain exactly one non-placeholder file with absolute path in `name`" in {
     cpg.file.nameNot(File.UNKNOWN).l match {
       case List(x) =>
         x.name should startWith("/")
+        // C-frontend currently does not set hash but should do so
+        // in the future
+        x.hash shouldBe None
       case _ => fail()
     }
   }
@@ -39,11 +39,11 @@ class FileTests extends FuzzyCCodeToCpgSuite {
     cpg.file.nameNot(File.UNKNOWN).namespaceBlock.name.toSet shouldBe Set("<global>")
   }
 
-  "should allow traversing from file to its methods" in {
+  "should allow traversing from file to its methods via namespace block" in {
     cpg.file.nameNot(File.UNKNOWN).method.name.toSet shouldBe Set("foo", "bar")
   }
 
-  "should allow traversing from file to its type declarations" in {
+  "should allow traversing from file to its type declarations via namespace block" in {
     cpg.file.nameNot(File.UNKNOWN).typeDecl.name.toSet shouldBe Set("my_struct")
   }
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
@@ -25,14 +25,11 @@ class FileTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should contain exactly one non-placeholder file with absolute path in `name`" in {
-    cpg.file.nameNot(File.UNKNOWN).l match {
-      case List(x) =>
-        x.name should startWith("/")
-        // C-frontend currently does not set hash but should do so
-        // in the future
-        x.hash shouldBe None
-      case _ => fail()
-    }
+    val List(x) = cpg.file.nameNot(File.UNKNOWN).l
+    x.name should startWith("/")
+    // C-frontend currently does not set hash but should do so
+    // in the future
+    x.hash shouldBe None
   }
 
   "should allow traversing from file to its namespace blocks" in {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
@@ -8,7 +8,9 @@ class FileTests extends FuzzyCCodeToCpgSuite {
 
   override val code: String =
     """
-      |
+      | int foo() {}
+      | int bar() {}
+      | struct my_struct { int x; };
       |""".stripMargin
 
   "should contain two file nodes in total, both with order=0" in {
@@ -31,6 +33,18 @@ class FileTests extends FuzzyCCodeToCpgSuite {
         x.name should startWith("/")
       case _ => fail()
     }
+  }
+
+  "should allow traversing from file to its namespace blocks" in {
+    cpg.file.nameNot(File.UNKNOWN).namespaceBlock.name.toSet shouldBe Set("<global>")
+  }
+
+  "should allow traversing from file to its methods" in {
+    cpg.file.nameNot(File.UNKNOWN).method.name.toSet shouldBe Set("foo", "bar")
+  }
+
+  "should allow traversing from file to its type declarations" in {
+    cpg.file.nameNot(File.UNKNOWN).typeDecl.name.toSet shouldBe Set("my_struct")
   }
 
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MetaDataTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MetaDataTests.scala
@@ -11,16 +11,13 @@ class MetaDataTests extends FuzzyCCodeToCpgSuite {
       |""".stripMargin
 
   "should contain exactly one node with all mandatory fields set" in {
-    cpg.metaData.l match {
-      case List(x) =>
-        x.language shouldBe "C"
-        x.version shouldBe "0.1"
-        x.overlays shouldBe List("semanticcpg")
-        // C-frontend does not set hash for entire CPG.
-        // Change this assertion if it is supposed to.
-        x.hash shouldBe None
-      case _ => fail()
-    }
+    val List(x) = cpg.metaData.l
+    x.language shouldBe "C"
+    x.version shouldBe "0.1"
+    x.overlays shouldBe List("semanticcpg")
+    // C-frontend does not set hash for entire CPG.
+    // Change this assertion if it is supposed to.
+    x.hash shouldBe None
   }
 
   "should not have any incoming or outgoing edges" in {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MetaDataTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MetaDataTests.scala
@@ -16,8 +16,17 @@ class MetaDataTests extends FuzzyCCodeToCpgSuite {
         x.language shouldBe "C"
         x.version shouldBe "0.1"
         x.overlays shouldBe List("semanticcpg")
+        // C-frontend does not set hash for entire CPG.
+        // Change this assertion if it is supposed to.
+        x.hash shouldBe None
       case _ => fail()
     }
+  }
+
+  "should not have any incoming or outgoing edges" in {
+    cpg.metaData.size shouldBe 1
+    cpg.metaData.in.l shouldBe List()
+    cpg.metaData.out.l shouldBe List()
   }
 
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodParameterTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodParameterTests.scala
@@ -1,0 +1,35 @@
+package io.shiftleft.fuzzyc2cpg.standard
+
+import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
+import io.shiftleft.semanticcpg.language._
+
+class MethodParameterTests extends FuzzyCCodeToCpgSuite {
+
+  override val code =
+    """
+      |  int main(int argc, char **argv) {
+      | }""".stripMargin
+
+  "should return exactly two parameters with correct fields" in {
+    cpg.parameter.name.toSet shouldBe Set("argc", "argv")
+
+    val List(x) = cpg.parameter.name("argc").l
+    x.code shouldBe "int argc"
+    x.typeFullName shouldBe "int"
+    x.lineNumber shouldBe Some(2)
+    x.columnNumber shouldBe Some(11)
+    x.order shouldBe 1
+
+    val List(y) = cpg.parameter.name("argv").l
+    y.code shouldBe "char **argv"
+    y.typeFullName shouldBe "char * *"
+    y.lineNumber shouldBe Some(2)
+    y.columnNumber shouldBe Some(21)
+    y.order shouldBe 2
+  }
+
+  "should allow traversing from parameter to method" in {
+    cpg.parameter.name("argc").method.name.l shouldBe List("main")
+  }
+
+}

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
@@ -11,18 +11,15 @@ class MethodReturnTests extends FuzzyCCodeToCpgSuite {
       |""".stripMargin
 
   "should have METHOD_RETURN node with correct fields" in {
-    cpg.methodReturn.l match {
-      case List(x) =>
-        x.code shouldBe "int *"
-        x.typeFullName shouldBe "int *"
-        x.lineNumber shouldBe Some(2)
-        x.columnNumber shouldBe Some(1)
-        // we expect the METHOD_RETURN node to be the right-most
-        // child so that when traversing the AST from left to
-        // right in CFG construction, we visit it last.
-        x.order shouldBe 2
-      case _ => fail()
-    }
+    val List(x) = cpg.methodReturn.l
+    x.code shouldBe "int *"
+    x.typeFullName shouldBe "int *"
+    x.lineNumber shouldBe Some(2)
+    x.columnNumber shouldBe Some(1)
+    // we expect the METHOD_RETURN node to be the right-most
+    // child so that when traversing the AST from left to
+    // right in CFG construction, we visit it last.
+    x.order shouldBe 2
   }
 
   "should allow traversing to method" in {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodTests.scala
@@ -7,8 +7,8 @@ class MethodTests extends FuzzyCCodeToCpgSuite {
 
   override val code =
     """
-      |int main(int argc, char **argv) {
-      |}""".stripMargin
+      |  int main(int argc, char **argv) {
+      | }""".stripMargin
 
   "should contain exactly one method node with correct fields" in {
     cpg.method.l match {
@@ -17,54 +17,34 @@ class MethodTests extends FuzzyCCodeToCpgSuite {
         x.fullName shouldBe "main"
         x.code shouldBe "int main (int argc,char **argv)"
         x.signature shouldBe "int main (int,char * *)"
+        x.isExternal shouldBe false
+        x.order shouldBe 1
+        x.filename.startsWith("/") shouldBe true
+        x.filename.endsWith(".c") shouldBe true
+        x.lineNumber shouldBe Some(2)
+        x.lineNumberEnd shouldBe Some(3)
+        x.columnNumber shouldBe Some(2)
+        x.columnNumberEnd shouldBe Some(1)
       case _ => fail()
     }
-  }
-
-  "should return correct function/method name" in {
-    cpg.method.name.toSet shouldBe Set("main")
-  }
-
-  "should return correct line number" in {
-    cpg.method.lineNumber.l shouldBe List(2)
-  }
-
-  "should return correct end line number" in {
-    cpg.method.lineNumberEnd.l shouldBe List(3)
   }
 
   "should return correct number of lines" in {
     cpg.method.numberOfLines.l shouldBe List(2)
   }
 
-  "should have correct method signature" in {
-    cpg.method.signature.toSet shouldBe Set("int main (int,char * *)")
-  }
-
-  "should return correct number of parameters" in {
-    cpg.parameter.name.toSet shouldBe Set("argc", "argv")
+  "should allow traversing to parameters" in {
     cpg.method.name("main").parameter.name.toSet shouldBe Set("argc", "argv")
   }
 
-  "should return correct parameter types" in {
-    cpg.parameter.name("argc").typeFullName.l shouldBe List("int")
-    cpg.parameter.name("argv").typeFullName.l shouldBe List("char * *")
-  }
-
-  "should return correct return type" in {
-    cpg.methodReturn.typeFullName.l shouldBe List("int")
+  "should allow traversing to methodReturn" in {
     cpg.method.name("main").methodReturn.typeFullName.l shouldBe List("int")
-    cpg.parameter.name("argc").method.methodReturn.typeFullName.l shouldBe List("int")
   }
 
-  "should return a filename for method 'main'" in {
+  "should allow traversing to file" in {
     cpg.method.name("main").file.name.l should not be empty
   }
 
-  "should allow filtering by number of parameters" in {
-    cpg.method.filter(_.parameter.size == 2).name.l shouldBe List("main")
-    cpg.method.filter(_.parameter.size == 1).name.l shouldBe List()
-  }
 }
 
 class CMethodTests2 extends FuzzyCCodeToCpgSuite {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodTests.scala
@@ -3,15 +3,23 @@ package io.shiftleft.fuzzyc2cpg.standard
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 
-/**
-  * Language primitives for navigating method stubs
-  * */
 class MethodTests extends FuzzyCCodeToCpgSuite {
 
   override val code =
     """
       |int main(int argc, char **argv) {
       |}""".stripMargin
+
+  "should contain exactly one method node with correct fields" in {
+    cpg.method.l match {
+      case List(x) =>
+        x.name shouldBe "main"
+        x.fullName shouldBe "main"
+        x.code shouldBe "int main (int argc,char **argv)"
+        x.signature shouldBe "int main (int,char * *)"
+      case _ => fail()
+    }
+  }
 
   "should return correct function/method name" in {
     cpg.method.name.toSet shouldBe Set("main")
@@ -39,14 +47,14 @@ class MethodTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should return correct parameter types" in {
-    cpg.parameter.name("argc").evalType.l shouldBe List("int")
-    cpg.parameter.name("argv").evalType.l shouldBe List("char * *")
+    cpg.parameter.name("argc").typeFullName.l shouldBe List("int")
+    cpg.parameter.name("argv").typeFullName.l shouldBe List("char * *")
   }
 
   "should return correct return type" in {
-    cpg.methodReturn.evalType.l shouldBe List("int")
-    cpg.method.name("main").methodReturn.evalType.l shouldBe List("int")
-    cpg.parameter.name("argc").method.methodReturn.evalType.l shouldBe List("int")
+    cpg.methodReturn.typeFullName.l shouldBe List("int")
+    cpg.method.name("main").methodReturn.typeFullName.l shouldBe List("int")
+    cpg.parameter.name("argc").method.methodReturn.typeFullName.l shouldBe List("int")
   }
 
   "should return a filename for method 'main'" in {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodTests.scala
@@ -11,22 +11,19 @@ class MethodTests extends FuzzyCCodeToCpgSuite {
       | }""".stripMargin
 
   "should contain exactly one method node with correct fields" in {
-    cpg.method.l match {
-      case List(x) =>
-        x.name shouldBe "main"
-        x.fullName shouldBe "main"
-        x.code shouldBe "int main (int argc,char **argv)"
-        x.signature shouldBe "int main (int,char * *)"
-        x.isExternal shouldBe false
-        x.order shouldBe 1
-        x.filename.startsWith("/") shouldBe true
-        x.filename.endsWith(".c") shouldBe true
-        x.lineNumber shouldBe Some(2)
-        x.lineNumberEnd shouldBe Some(3)
-        x.columnNumber shouldBe Some(2)
-        x.columnNumberEnd shouldBe Some(1)
-      case _ => fail()
-    }
+    val List(x) = cpg.method.l
+    x.name shouldBe "main"
+    x.fullName shouldBe "main"
+    x.code shouldBe "int main (int argc,char **argv)"
+    x.signature shouldBe "int main (int,char * *)"
+    x.isExternal shouldBe false
+    x.order shouldBe 1
+    x.filename.startsWith("/") shouldBe true
+    x.filename.endsWith(".c") shouldBe true
+    x.lineNumber shouldBe Some(2)
+    x.lineNumberEnd shouldBe Some(3)
+    x.columnNumber shouldBe Some(2)
+    x.columnNumberEnd shouldBe Some(1)
   }
 
   "should return correct number of lines" in {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
@@ -34,6 +34,7 @@ class NamespaceBlockTests extends FuzzyCCodeToCpgSuite {
     cpg.namespaceBlock.filenameNot(File.UNKNOWN).l match {
       case List(x) =>
         x.name shouldBe Namespace.globalNamespaceName
+        x.filename should not be ""
         x.fullName shouldBe s"${x.filename}:${Namespace.globalNamespaceName}"
         x.order shouldBe 0
       case _ => fail()

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
@@ -12,6 +12,8 @@ class NamespaceBlockTests extends FuzzyCCodeToCpgSuite {
 
   override val code: String =
     """
+      |int foo() {}
+      |struct my_struct{};
       |""".stripMargin
 
   "should contain two namespace blocks in total" in {
@@ -36,6 +38,18 @@ class NamespaceBlockTests extends FuzzyCCodeToCpgSuite {
         x.order shouldBe 0
       case _ => fail()
     }
+  }
+
+  "should allow traversing from namespace block to method" in {
+    cpg.namespaceBlock.filenameNot(File.UNKNOWN).method.name.l shouldBe List("foo")
+  }
+
+  "should allow traversing from namespace block to type declaration" in {
+    cpg.namespaceBlock.filenameNot(File.UNKNOWN).typeDecl.name.l shouldBe List("my_struct")
+  }
+
+  "should allow traversing from namespace block to namespace" in {
+    cpg.namespaceBlock.filenameNot(File.UNKNOWN).namespace.name.l shouldBe List(Namespace.globalNamespaceName)
   }
 
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
@@ -21,24 +21,18 @@ class NamespaceBlockTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should contain a correct global namespace block for the `<unknown>` file" in {
-    cpg.namespaceBlock.filename(File.UNKNOWN).l match {
-      case List(x) =>
-        x.name shouldBe Namespace.globalNamespaceName
-        x.fullName shouldBe Namespace.globalNamespaceName
-        x.order shouldBe 0
-      case _ => fail()
-    }
+    val List(x) = cpg.namespaceBlock.filename(File.UNKNOWN).l
+    x.name shouldBe Namespace.globalNamespaceName
+    x.fullName shouldBe Namespace.globalNamespaceName
+    x.order shouldBe 0
   }
 
   "should contain correct namespace block for known file" in {
-    cpg.namespaceBlock.filenameNot(File.UNKNOWN).l match {
-      case List(x) =>
-        x.name shouldBe Namespace.globalNamespaceName
-        x.filename should not be ""
-        x.fullName shouldBe s"${x.filename}:${Namespace.globalNamespaceName}"
-        x.order shouldBe 0
-      case _ => fail()
-    }
+    val List(x) = cpg.namespaceBlock.filenameNot(File.UNKNOWN).l
+    x.name shouldBe Namespace.globalNamespaceName
+    x.filename should not be ""
+    x.fullName shouldBe s"${x.filename}:${Namespace.globalNamespaceName}"
+    x.order shouldBe 0
   }
 
   "should allow traversing from namespace block to method" in {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/ParameterTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/ParameterTests.scala
@@ -1,3 +1,0 @@
-package io.shiftleft.fuzzyc2cpg.standard
-
-class ParameterTests {}

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AntlrParserDriver.java
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AntlrParserDriver.java
@@ -2,9 +2,7 @@ package io.shiftleft.fuzzyc2cpg.passes.astcreation;
 
 import static org.antlr.v4.runtime.Token.EOF;
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes;
 import io.shiftleft.codepropertygraph.generated.nodes.NewComment;
-import io.shiftleft.codepropertygraph.generated.nodes.NewFile;
 import io.shiftleft.fuzzyc2cpg.ast.AstNode;
 import io.shiftleft.fuzzyc2cpg.ast.AstNodeBuilder;
 import io.shiftleft.fuzzyc2cpg.ast.logical.statements.CompoundStatement;
@@ -34,7 +32,6 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import scala.Some;
-import scala.collection.immutable.List$;
 
 abstract public class AntlrParserDriver {
     // TODO: This class does two things:

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
@@ -117,7 +117,8 @@ private[astcreation] class AstCreator(diffGraph: DiffGraph.Builder,
       lineNumberEnd = location.endLine,
       columnNumberEnd = location.endPos,
       signature = signature,
-      filename = namespaceBlock.filename
+      filename = namespaceBlock.filename,
+      order = context.childNum
     )
 
     addAndConnectAsAstChild(method)

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
@@ -104,11 +104,12 @@ private[astcreation] class AstCreator(diffGraph: DiffGraph.Builder,
     }
 
     val signature = returnType + " " + astFunction.getFunctionSignature(false)
+    val code = returnType + " " + astFunction.getFunctionSignature(true)
 
     val location = astFunction.getLocation
     val method = nodes.NewMethod(
       name = astFunction.getName,
-      code = astFunction.getEscapedCodeStr,
+      code = code,
       isExternal = false,
       fullName = astFunction.getName,
       lineNumber = location.startLine,

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/MethodHeaderTests.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/MethodHeaderTests.scala
@@ -21,7 +21,7 @@ class MethodHeaderTests extends AnyWordSpec with Matchers {
       method.property(NodeKeys.COLUMN_NUMBER) shouldBe 0
       method.property(NodeKeys.LINE_NUMBER_END) shouldBe 3
       method.property(NodeKeys.COLUMN_NUMBER_END) shouldBe 0
-      method.property(NodeKeys.CODE) shouldBe "foo (int x,int y)"
+      method.property(NodeKeys.CODE) shouldBe "int foo (int x,int y)"
     }
 
     "have correct METHOD_PARAMETER_IN nodes for method foo" in {

--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -4,19 +4,21 @@
 
     // Keys for node properties
 
-    "nodeKeys" : [
+  "nodeKeys" : [
+
+        // Properties of the MetaData block
 
         { "id": 19, "name" : "LANGUAGE", "comment" : "The programming language this graph originates from", "valueType" : "string", "cardinality" : "one"},
         { "id" : 13, "name": "VERSION", "comment" : "A version, given as a string", "valueType" : "string", "cardinality" : "one"},
-	{ "id" : 118, "name" : "OVERLAYS", "comment" : "Names of overlays applied to this graph, in order of application", "valueType" : "string", "cardinality" : "list"},
-	{ "id" : 120, "name" : "HASH", "comment" : "Hash value of the artifact that this CPG is built from.", "valueType": "string", "cardinality" : "zeroOrOne"},
+	      { "id" : 118, "name" : "OVERLAYS", "comment" : "Names of overlays applied to this graph, in order of application", "valueType" : "string", "cardinality" : "list"},
+	      { "id" : 120, "name" : "HASH", "comment" : "Hash value of the artifact that this CPG is built from.", "valueType": "string", "cardinality" : "zeroOrOne"},
 
         // Properties that indicate where the code can be found
 
         {"id" : 2, "name": "LINE_NUMBER", "comment": "Line where the code starts", "valueType" : "int", "cardinality" : "zeroOrOne"},
         {"id" : 11, "name": "COLUMN_NUMBER", "comment" : "Column where the code starts", "valueType" : "int", "cardinality" : "zeroOrOne" },
-	{"id" : 12, "name": "LINE_NUMBER_END", "comment" : "Line where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne"},
-	{"id" : 16, "name": "COLUMN_NUMBER_END", "comment" : "Column where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne"},
+      	{"id" : 12, "name": "LINE_NUMBER_END", "comment" : "Line where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne"},
+	      {"id" : 16, "name": "COLUMN_NUMBER_END", "comment" : "Column where the code ends", "valueType" : "int", "cardinality" : "zeroOrOne"},
 
         {"id" : 3, "name": "PARSER_TYPE_NAME", "comment": "Type name emitted by parser, only present for logical type UNKNOWN", "valueType" : "string", "cardinality" : "one"},
         {"id" : 4, "name": "ORDER", "comment": "General ordering property, such that the children of each AST-node are typically numbered from 1, ..., N (this is not enforced). The ordering has no technical meaning, but is used for pretty printing and OUGHT TO reflect order in the source code", "valueType" : "int", "cardinality" : "one"},
@@ -32,14 +34,14 @@
         {"id": 21, "name": "CODE", "comment": "The code snippet the node represents", "valueType" : "string", "cardinality" : "one"},
         {"id": 22, "name": "SIGNATURE", "comment": "Method signature. The format is defined by the language front-end, and the backend simply compares strings to resolve function overloading, i.e. match call-sites to METHODs. In theory, consecutive integers would be valid, but in practice this should be human readable", "valueType" : "string", "cardinality" : "one"},
         {"id": 26, "name" : "MODIFIER_TYPE", "comment" : "Indicates the modifier which is represented by a MODIFIER node. See modifierTypes", "valueType" : "string", "cardinality" : "one"},
+
         // Properties used to link nodes in the backend
+
         {"id": 51, "name" : "TYPE_FULL_NAME", "comment" : "The static type of an entity. E.g. expressions, local, parameters etc. This property is matched against the FULL_NAME of TYPE nodes and thus it is required to have at least one TYPE node for each TYPE_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
         {"id": 52, "name" : "TYPE_DECL_FULL_NAME", "comment" : "The static type decl of a TYPE. This property is matched against the FULL_NAME of TYPE_DECL nodes. It is required to have exactly one TYPE_DECL for each different TYPE_DECL_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
         {"id": 53, "name" : "INHERITS_FROM_TYPE_FULL_NAME", "comment" : "The static types a TYPE_DECL inherits from. This property is matched against the FULL_NAME of TYPE nodes and thus it is required to have at least one TYPE node for each TYPE_FULL_NAME", "valueType" : "string", "cardinality" : "list"},
         {"id": 54, "name" : "METHOD_FULL_NAME", "comment" : "The FULL_NAME of a method. Used to link CALL and METHOD nodes. It is required to have exactly one METHOD node for each METHOD_FULL_NAME", "valueType" : "string", "cardinality" : "one"},
         {"id": 55, "name" : "METHOD_INST_FULL_NAME", "comment" : "Deprecated", "valueType" : "string", "cardinality" : "zeroOrOne"},
-        {"id": 56, "name" : "AST_PARENT_TYPE", "comment" : "The type of the AST parent. Since this is only used in some parts of the graph the list does not include all possible parents by intention. Possible parents: METHOD, TYPE_DECL, NAMESPACE_BLOCK", "valueType" : "string", "cardinality" : "one"},
-        {"id": 57, "name" : "AST_PARENT_FULL_NAME", "comment" : "The FULL_NAME of a the AST parent of an entity", "valueType" : "string", "cardinality" : "one"},
         {"id": 158, "name" : "ALIAS_TYPE_FULL_NAME", "comment" : "Type full name of which a TYPE_DECL is an alias of", "valueType" : "string", "cardinality" : "zeroOrOne"},
         {"id" : 106, "name" : "FILENAME", "comment" : "Full path of canonical file that contained this node; will be linked into corresponding FILE nodes. Possible for METHOD, TYPE_DECL and NAMESPACE_BLOCK", "valueType" : "string", "cardinality" : "one"},
         
@@ -64,7 +66,8 @@
             "comment" : "Node to save meta data about the graph on its properties. Exactly one node of this type per graph",
             "outEdges" : []
         },
-        // Nodes describing program structure
+
+      // Nodes describing program structure
 
         {"id" : 38,
          "name": "FILE",
@@ -77,7 +80,7 @@
         // Nodes of method declarations
 
         {"id" : 1, "name" : "METHOD",
-         "keys": ["CODE", "NAME", "FULL_NAME", "IS_EXTERNAL", "SIGNATURE", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME",
+         "keys": ["CODE", "NAME", "FULL_NAME", "IS_EXTERNAL", "SIGNATURE",
 		  "LINE_NUMBER", "COLUMN_NUMBER", "LINE_NUMBER_END", "COLUMN_NUMBER_END", "ORDER", "FILENAME"],
          "comment" : "A method/function/procedure",
          "is": ["DECLARATION", "CFG_NODE", "AST_NODE"],
@@ -138,7 +141,7 @@
          ]
         },
         {"id" : 46, "name" : "TYPE_DECL",
-         "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME", "AST_PARENT_TYPE", "AST_PARENT_FULL_NAME", "ALIAS_TYPE_FULL_NAME", "ORDER", "FILENAME"],
+         "keys" : ["NAME", "FULL_NAME", "IS_EXTERNAL", "INHERITS_FROM_TYPE_FULL_NAME", "ALIAS_TYPE_FULL_NAME", "ORDER", "FILENAME"],
          "comment" : "A type declaration",
          "outEdges" : [
            {"edgeName": "AST", "inNodes": [
@@ -375,6 +378,7 @@
          ]
         },
         // METHOD_INST is deprecated.
+
        {"id":32, "name":"METHOD_INST",
          "keys":["NAME", "SIGNATURE", "FULL_NAME", "METHOD_FULL_NAME", "ORDER"],
          "comment":"A method instance which always has to reference a method and may have type argument children if the referred to method is a template",
@@ -383,6 +387,7 @@
          ],
 	 "is" : ["AST_NODE"]
         },
+
         {"id" : 14, "name" : "ARRAY_INITIALIZER",
          "keys":[],
          "outEdges": [],

--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -124,6 +124,7 @@
          "comment" : "A formal method return",
          "is": ["CFG_NODE", "TRACKING_POINT"]
         },
+
         {"id" : 300, "name" : "MODIFIER",
          "keys" : ["MODIFIER_TYPE", "ORDER"],
          "comment" : "A modifier, e.g., static, public, private",

--- a/schema/src/main/resources/schemas/enhancements.json
+++ b/schema/src/main/resources/schemas/enhancements.json
@@ -8,7 +8,9 @@
       { "id" : 119, "name" : "POLICY_DIRECTORIES", "comment": "Sub directories of the policy directory that should be loaded when processing the CPG", "valueType" : "string", "cardinality" : "list"},
       {"id": 15, "name" : "EVALUATION_STRATEGY", "comment" : "Evaluation strategy for function parameters and return values. One of the values in \"evaluationStrategies\"", "valueType" : "string", "cardinality" : "one"},
       {"id": 25, "name": "DISPATCH_TYPE", "comment": "The dispatch type of a call, which is either static or dynamic. See dispatchTypes", "valueType" : "string", "cardinality" : "one"},
-      {"id": 1591, "name" : "DYNAMIC_TYPE_HINT_FULL_NAME", "comment" : "Type hint for the dynamic type", "valueType" : "string", "cardinality" : "list"}
+      {"id": 1591, "name" : "DYNAMIC_TYPE_HINT_FULL_NAME", "comment" : "Type hint for the dynamic type", "valueType" : "string", "cardinality" : "list"},
+      {"id": 56, "name" : "AST_PARENT_TYPE", "comment" : "The type of the AST parent. Since this is only used in some parts of the graph the list does not include all possible parents by intention. Possible parents: METHOD, TYPE_DECL, NAMESPACE_BLOCK", "valueType" : "string", "cardinality" : "one"},
+      {"id": 57, "name" : "AST_PARENT_FULL_NAME", "comment" : "The FULL_NAME of a the AST parent of an entity", "valueType" : "string", "cardinality" : "one"}
     ],
     
     "edgeKeys" : [
@@ -70,6 +72,7 @@
 	  "keys" : ["DISPATCH_TYPE", "DYNAMIC_TYPE_HINT_FULL_NAME"]
 	},
         { "name": "METHOD",
+          "keys" : ["AST_PARENT_TYPE", "AST_PARENT_FULL_NAME"],
           "outEdges" : [
              {"edgeName": "AST", "inNodes": [
               {"name": "TYPE_DECL", "cardinality": "0-1:n"},
@@ -171,6 +174,7 @@
           ]
         },
         { "name": "TYPE_DECL",
+          "keys" : ["AST_PARENT_TYPE", "AST_PARENT_FULL_NAME"],
           "outEdges" : [
              {"edgeName": "AST", "inNodes": [
               {"name": "TYPE_DECL", "cardinality": "0-1:n"},

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -310,9 +310,9 @@ class StepsTest extends AnyWordSpec with Matchers {
     method.dotCfg.head.startsWith("digraph add {")
     method.head.dotCfg.head.startsWith("digraph add {")
 
-    // evalType
-    local.evalType.head shouldBe "java.lang.Integer"
-    local.head.evalType.head shouldBe "java.lang.Integer"
+    // typeFullName
+    local.typeFullName.head shouldBe "java.lang.Integer"
+    local.head.typeFullName shouldBe "java.lang.Integer"
 
     // modifierAccessors
     method.modifier.modifierType.toSet shouldBe Set("STATIC", "VIRTUAL")

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
@@ -22,7 +22,6 @@ class MethodDecoratorPassTests extends AnyWordSpec with Matchers {
         NodeKeys.LINE_NUMBER -> 10
       )
       .asInstanceOf[nodes.MethodParameterIn]
-    val evalType = graph + NodeTypes.TYPE
 
     method --- EdgeTypes.AST --> parameterIn
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
@@ -8,7 +8,7 @@ class NamespaceBlock(val traversal: Traversal[nodes.NamespaceBlock]) extends Any
   /**
     * Namespaces for namespace blocks.
     * */
-  def namespaces: Traversal[nodes.Namespace] =
+  def namespace: Traversal[nodes.Namespace] =
     traversal.out(EdgeTypes.REF).cast[nodes.Namespace]
 
   /**
@@ -20,4 +20,9 @@ class NamespaceBlock(val traversal: Traversal[nodes.NamespaceBlock]) extends Any
       .hasLabel(NodeTypes.TYPE_DECL)
       .cast[nodes.TypeDecl]
 
+  def method : Traversal[nodes.Method] =
+    traversal
+      .out(EdgeTypes.AST)
+      .hasLabel(NodeTypes.METHOD)
+      .cast[nodes.Method]
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlock.scala
@@ -20,7 +20,7 @@ class NamespaceBlock(val traversal: Traversal[nodes.NamespaceBlock]) extends Any
       .hasLabel(NodeTypes.TYPE_DECL)
       .cast[nodes.TypeDecl]
 
-  def method : Traversal[nodes.Method] =
+  def method: Traversal[nodes.Method] =
     traversal
       .out(EdgeTypes.AST)
       .hasLabel(NodeTypes.METHOD)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
@@ -4,6 +4,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.types.structure.Namespace
 
 /**
   * This pass has no other pass as prerequisite.
@@ -37,9 +38,8 @@ class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
       fullName = fullName,
       isExternal = true,
       inheritsFromTypeFullName = Nil,
-      // TODO: don't set these two at all and assume them as default
       astParentType = NodeTypes.NAMESPACE_BLOCK,
-      astParentFullName = "<global>"
+      astParentFullName = Namespace.globalNamespaceName
     )
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
@@ -33,12 +33,13 @@ class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
   private def createTypeDeclStub(name: String, fullName: String): nodes.NewTypeDecl = {
     nodes.NewTypeDecl(
-      name,
-      fullName,
+      name = name,
+      fullName = fullName,
       isExternal = true,
       inheritsFromTypeFullName = Nil,
-      NodeTypes.NAMESPACE_BLOCK,
-      "<global>"
+      // TODO: don't set these two at all and assume them as default
+      astParentType = NodeTypes.NAMESPACE_BLOCK,
+      astParentFullName = "<global>"
     )
   }
 


### PR DESCRIPTION
* Cleanup and extend File, MetaData, Method and NamespaceBlock tests
* Use `typeFullName` in place of `evalType` where immediately possible
* Move `AST_PARENT_TYPE` and `AST_PARENT_FULL_NAME` into enhancements