### PR TITLE
Plume branch for OSS Scpg

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -123,6 +123,12 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
           new CdgPass(cpg),
           new NamespaceCreator(cpg),
         )
+      case "Plume" =>
+        Iterator(
+          new FileCreationPass(cpg),
+          new Linker(cpg),
+          new NamespaceCreator(cpg),
+        )
       case _ => Iterator()
     }
   }


### PR DESCRIPTION
In SCPG creation on the OSS-side, we run passes depending on the language frontend. On the long run, for plume, the plan is to run them directly in the frontend instead, however, I'm not 100% sure how to achieve that at the moment. To unblock work on the initial plume/joern integration, I'm making OSS Scpg Plume aware. This only affects SCPG as generated in joern, not SCPG in Ocular.