### PR TITLE
omit `()` for dsl methods

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -27,7 +27,7 @@ class Steps[A](val traversal: Traversal[A]) extends AnyVal {
   /**
     Shorthand for `toBuffer`
     */
-  def b(): mutable.Buffer[A] = toBuffer()
+  def b: mutable.Buffer[A] = toBuffer()
 
   /**
     Alias for `toList`
@@ -43,13 +43,13 @@ class Steps[A](val traversal: Traversal[A]) extends AnyVal {
   /**
     Alias for `toStream`
     */
-  def s(): LazyList[A] = toStream()
+  def s: LazyList[A] = toStream()
 
   /**
     Execute the traversal and convert it into a Java list (as opposed
     to the Scala list obtained via `toList`)
     */
-  def jl(): JList[A] = b().asJava
+  def jl: JList[A] = b.asJava
 
   /**
     * Print help/documentation based on the current elementType `A`.


### PR DESCRIPTION
violation of the general rule 'use parens if it has side effects' is
overriden by 'beautify your dsl' rule