### PR TITLE
Invoke fuzzyc via java as opposed to via shell script

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -4,7 +4,8 @@ enablePlugins(JavaAppPackaging)
 
 dependsOn(Projects.codepropertygraph,
           Projects.semanticcpg,
-          Projects.macros)
+          Projects.macros,
+          Projects.fuzzyc2cpg)
 
 scalacOptions ++= Seq(
   "-deprecation",                      // Emit warning and location for usages of deprecated APIs.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -3,6 +3,7 @@ package io.shiftleft.console.cpgcreation
 import java.nio.file.Path
 
 import io.shiftleft.console.FuzzyCFrontendConfig
+import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
 
 /**
   * Fuzzy C/C++ language frontend. Translates C/C++ source files
@@ -18,10 +19,11 @@ case class FuzzyCCpgGenerator(config: FuzzyCFrontendConfig, rootPath: Path) exte
   override def generate(inputPath: String,
                         outputPath: String = "cpg.bin.zip",
                         namespaces: List[String] = List()): Option[String] = {
-    val fuzzyc2cpgsh = rootPath.resolve("fuzzyc2cpg.sh").toString
-    val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
-    runShellCommand(fuzzyc2cpgsh, arguments).map(_ => outputPath)
+    val fuzzyc = new FuzzyC2Cpg()
+    val cpg = fuzzyc.runAndOutput(Set(inputPath), Set(".c"), Some(outputPath))
+    cpg.close()
+    Some(outputPath)
   }
 
-  override def isAvailable: Boolean = rootPath.resolve("fuzzyc2cpg.sh").toFile.exists
+  override def isAvailable: Boolean = true
 }

--- a/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
@@ -60,7 +60,6 @@ class TestCpgGeneratorFactory(config: ConsoleConfig) extends CpgGeneratorFactory
 
     override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
       val fuzzyc = new FuzzyC2Cpg()
-      File(inputPath).list.foreach(println(_))
       val cpg = fuzzyc.runAndOutput(Set(inputPath), Set(".c"), Some(outputPath))
       cpg.close()
       Some(outputPath)


### PR DESCRIPTION
People are reporting that in their installations, the shell script `fuzzyc2cpg.sh` can't be found. While I cannot reproduce this issue locally, calling fuzzyc via the command line seems like a bad idea anyway, so with this PR, we're calling it via Java instead.