### PR TITLE
Added checks for code formatting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,8 +22,12 @@ jobs:
       run: sudo apt-get install -y --allow-downgrades sbt=1.3.12
     - name: Print sbt version
       run: sbt --version
-    - name: Run tests
-      run: sbt scalafmtCheck test
+    - name: Compile and run tests
+      run: sbt compile test
+    - name: Check formatting
+      run: sbt scalafmtCheck test:scalafmtCheck "scalafixAll --check OrganizeImports"
+    - run: echo "Code is not formatted. Run `sbt format`"
+      if: ${{ failure() }}
 
   test-fuzzypp-linux:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,7 @@ jobs:
       run: sbt compile test
     - name: Check formatting
       run: sbt scalafmtCheck test:scalafmtCheck "scalafixAll --check OrganizeImports"
-    - run: echo "Code is not formatted. Run `sbt format`"
+    - run: echo "Previous step failed because code is not formatted. Run `sbt format`"
       if: ${{ failure() }}
 
   test-fuzzypp-linux:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,7 +27,7 @@ jobs:
       run: sbt compile test
     - name: Check formatting
       run: sbt scalafmtCheck test:scalafmtCheck "scalafixAll --check OrganizeImports"
-    - run: echo "Code is not formatted. Run `sbt format`"
+    - run: echo "Previous step failed because code is not formatted. Run `sbt format`"
       if: ${{ failure() }}
 
   test-fuzzypp-linux:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,8 +23,12 @@ jobs:
       run: sudo apt-get install -y --allow-downgrades sbt=1.3.12
     - name: Print sbt version
       run: sbt --version
-    - name: Run tests
-      run: sbt scalafmtCheck test
+    - name: Compile and run tests
+      run: sbt compile test
+    - name: Check formatting
+      run: sbt scalafmtCheck test:scalafmtCheck "scalafixAll --check OrganizeImports"
+    - run: echo "Code is not formatted. Run `sbt format`"
+      if: ${{ failure() }}
 
   test-fuzzypp-linux:
     runs-on: ubuntu-18.04

--- a/README.md
+++ b/README.md
@@ -35,14 +35,10 @@ The build process has been verified on Linux and it should be possible
 to build on OS X and BSD systems as well. The build process requires
 the following prerequisites:
 
-* Java runtime 8
-  - Link: http://openjdk.java.net/install/
-* Scala build tool (sbt)
-  - Link: https://www.scala-sbt.org/
-* Git-lfs
-  - Link: https://git-lfs.github.com/
-* Protoc
-  - Link: https://github.com/protocolbuffers/protobuf/releases
+* [Java runtime 8](http://openjdk.java.net/install/)
+* [Scala build tool (SBT)](https://www.scala-sbt.org/)
+* [Git-lfs](https://git-lfs.github.com/)
+* [Protocol Buffer](https://github.com/protocolbuffers/protobuf/releases)
 
 Some binary files required for testing are managed through `git-lfs`. If you haven't cloned this repository yet, simply run `git lfs install`.
 If you have cloned it already, additionally run `git lfs pull` (from within the repository).
@@ -56,6 +52,15 @@ This command will install the following artifacts:
 * _codepropertygraph-VERSION.jar_: Java and Scala classes to be used in combination with the ShiftLeft Tinkergraph [3].
 
 * _codepropertygraph-protos-VERSION.jar_: Java bindings for Google's Protocol Buffer definitions
+
+# Code style
+
+Code style is automatically verified by external tools:
+
+* [scalafmt](https://github.com/scalameta/scalafmt)
+* [scalafix](https://github.com/scalacenter/scalafix)
+
+If your PR build fails code formatting check, simply run `sbt format` and submit the change along with the rest of the code. The commands runs necessary formatting in the right order.
 
 # Creating Protocol Buffer bindings for different languages
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/Implicits.scala
@@ -1,7 +1,6 @@
 package io.shiftleft
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 object Implicits {
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/SerializedCpg.scala
@@ -1,11 +1,11 @@
 package io.shiftleft
 
+import com.google.protobuf.GeneratedMessageV3
+
 import java.io.{File, IOException}
 import java.net.{URI, URISyntaxException}
 import java.nio.file.{FileSystem, FileSystems, Files}
 import java.util
-
-import com.google.protobuf.GeneratedMessageV3
 
 class SerializedCpg extends AutoCloseable {
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/Cpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/Cpg.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.codepropertygraph
 
 import io.shiftleft.codepropertygraph.generated.{edges, nodes}
-import overflowdb.Graph
-import overflowdb.Config
 import overflowdb.traversal.help.TraversalHelp
+import overflowdb.{Config, Graph}
 
 object Cpg {
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoader.scala
@@ -3,8 +3,7 @@ package io.shiftleft.codepropertygraph.cpgloading
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeKeys
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.Graph
 
 import scala.util.Try

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgOverlayLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/CpgOverlayLoader.scala
@@ -1,7 +1,5 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
-import java.io.IOException
-
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.passes.DiffGraph
@@ -10,6 +8,7 @@ import io.shiftleft.utils.StringInterner
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb._
 
+import java.io.IOException
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/NodeFilter.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/NodeFilter.scala
@@ -3,8 +3,8 @@ package io.shiftleft.codepropertygraph.cpgloading
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node
 import io.shiftleft.proto.cpg.Cpg.NodePropertyName
 
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 /**
   * Removes duplicate nodes to avoid uniqueness restriction for parallel frontends.

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoCpgLoader.scala
@@ -1,18 +1,15 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
 import com.google.protobuf.GeneratedMessageV3
-
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.proto.cpg.Cpg.{CpgOverlay, CpgStruct, DiffGraph}
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.Edge
-import java.util.{Collection => JCollection, List => JList}
-import java.io.InputStream
-import java.nio.file.{Files, Path}
-
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import io.shiftleft.proto.cpg.Cpg.{CpgOverlay, CpgStruct, DiffGraph}
+import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.Config
 
+import java.io.InputStream
+import java.nio.file.{Files, Path}
+import java.util.{Collection => JCollection, List => JList}
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try, Using}

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ProtoToCpg.scala
@@ -1,17 +1,14 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
-import java.util.{NoSuchElementException, Collection => JCollection}
-
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.proto.cpg.Cpg.CpgStruct.{Edge, Node}
 import io.shiftleft.proto.cpg.Cpg.PropertyValue
 import io.shiftleft.proto.cpg.Cpg.PropertyValue.ValueCase._
 import io.shiftleft.utils.StringInterner
-
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 import overflowdb._
 
+import java.util.{Collection => JCollection, NoSuchElementException}
 import scala.jdk.CollectionConverters._
 
 object ProtoToCpg {

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
@@ -4,7 +4,6 @@ import java.io.Closeable
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileSystem, FileSystems, FileVisitResult, Files, Path, Paths, SimpleFileVisitor}
 import java.util.{Collection => JCollection}
-
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/console/Query.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/console/Query.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.console
 
-import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes
 import overflowdb.traversal.Traversal
 
 case class Query(name: String,

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -1,17 +1,12 @@
 package io.shiftleft.passes
 
 import com.google.protobuf.GeneratedMessageV3
+import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
-import io.shiftleft.SerializedCpg
-import java.util
-import java.lang.{Long => JLong}
+import org.slf4j.{Logger, LoggerFactory}
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import overflowdb.Node
-import gnu.trove.map.hash.THashMap
-import scala.collection.mutable
+import java.lang.{Long => JLong}
 import scala.concurrent.duration.DurationLong
 
 /**

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -1,13 +1,12 @@
 package io.shiftleft.passes
 
-import java.security.MessageDigest
-
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{CpgNode, NewNode, StoredNode}
 import io.shiftleft.proto.cpg.Cpg.{DiffGraph => DiffGraphProto}
 import overflowdb._
 import overflowdb.traversal._
 
+import java.security.MessageDigest
 import scala.collection.mutable
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.jdk.CollectionConverters._

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraphProtoSerializer.scala
@@ -1,12 +1,10 @@
 package io.shiftleft.passes
 
-import io.shiftleft.proto.cpg.Cpg.CpgStruct.Edge.EdgeType
-import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node.NodeType
-import java.lang.{Long => JLong}
-
 import com.google.protobuf.ByteString
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.codepropertygraph.generated.nodes.{CpgNode, NewNode, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
+import io.shiftleft.proto.cpg.Cpg.CpgStruct.Edge.EdgeType
+import io.shiftleft.proto.cpg.Cpg.CpgStruct.Node.NodeType
 import io.shiftleft.proto.cpg.Cpg.{
   AdditionalEdgeProperty,
   AdditionalNodeProperty,
@@ -14,6 +12,7 @@ import io.shiftleft.proto.cpg.Cpg.{
   ContainedRefs,
   CpgOverlay,
   CpgStruct,
+  DiffGraph => DiffGraphProto,
   DoubleList,
   EdgePropertyName,
   FloatList,
@@ -21,10 +20,11 @@ import io.shiftleft.proto.cpg.Cpg.{
   LongList,
   NodePropertyName,
   PropertyValue,
-  StringList,
-  DiffGraph => DiffGraphProto
+  StringList
 }
 import overflowdb._
+
+import java.lang.{Long => JLong}
 
 object DiffGraphProtoSerializer {
   val nodePropertyNames: Set[String] = NodePropertyName.values().map { _.name() }.toSet

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.passes
-import java.util.concurrent.LinkedBlockingQueue
-
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.util.concurrent.LinkedBlockingQueue
 
 abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "", keyPools: Option[Iterator[KeyPool]] = None)
     extends CpgPassBase {

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
-import java.nio.file.FileSystemNotFoundException
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.Config
+
+import java.nio.file.FileSystemNotFoundException
 
 /**
   * Specification of the CPGLoader. The loader allows CPGs to be loaded

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/DiffGraphTest.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
 import io.shiftleft.OverflowDbTestInstance
-import overflowdb._
-import overflowdb.traversal._
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, StoredNode}
 import io.shiftleft.passes.{DiffGraph, IntervalKeyPool}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
+import overflowdb.traversal._
 
 class DiffGraphTest extends AnyWordSpec with Matchers {
   "should be able to build an inverse DiffGraph" in {

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgOverlayIntegrationTest.scala
@@ -1,7 +1,5 @@
 package io.shiftleft.passes
 
-import java.util.Optional
-
 import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated._
@@ -9,6 +7,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb._
 import overflowdb.traversal._
+
+import java.util.Optional
 
 class CpgOverlayIntegrationTest extends AnyWordSpec with Matchers {
   val InitialNodeCode = "initialNode"

--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgPassTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/CpgPassTests.scala
@@ -4,10 +4,10 @@ import better.files.File
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-
-import scala.jdk.CollectionConverters._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters._
 
 class CpgPassTests extends AnyWordSpec with Matchers {
 

--- a/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/x2cpg/X2CpgTests.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.x2cpg
 
+import better.files.File
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import better.files.File
 
 class X2CpgTests extends AnyWordSpec with Matchers {
 

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -1,11 +1,10 @@
 package io.shiftleft.console
 
-import ammonite.ops.pwd
-import ammonite.ops.Path
+import ammonite.ops.{Path, pwd}
 import ammonite.util.{Colors, Res}
 import better.files._
-import io.shiftleft.console.embammonite.EmbeddedAmmonite
 import io.shiftleft.console.cpgqlserver.CPGQLServer
+import io.shiftleft.console.embammonite.EmbeddedAmmonite
 
 import java.io.{FileOutputStream, PrintStream}
 

--- a/console/src/main/scala/io/shiftleft/console/Help.scala
+++ b/console/src/main/scala/io/shiftleft/console/Help.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.console
 
-import overflowdb.traversal.help.{Doc, Table}
 import org.apache.commons.lang.WordUtils
+import overflowdb.traversal.help.{Doc, Table}
 
 import scala.reflect.runtime.universe.{TypeTag, typeOf}
 

--- a/console/src/main/scala/io/shiftleft/console/PluginManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/PluginManager.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.console
-import better.files.File
 import better.files.Dsl._
+import better.files.File
 import better.files.File.apply
 
 import java.nio.file.Path

--- a/console/src/main/scala/io/shiftleft/console/QueryDatabase.scala
+++ b/console/src/main/scala/io/shiftleft/console/QueryDatabase.scala
@@ -3,6 +3,7 @@ package io.shiftleft.console
 import org.reflections8.Reflections
 import org.reflections8.util.{ClasspathHelper, ConfigurationBuilder}
 import org.slf4j.{Logger, LoggerFactory}
+
 import scala.annotation.{StaticAnnotation, unused}
 import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CSharpCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CSharpCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import io.shiftleft.console.CSharpFrontendConfig
+
+import java.nio.file.Path
 
 /**
   * C# language frontend. Translates C# project files into code property graphs.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
@@ -1,7 +1,5 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import better.files.Dsl._
 import better.files.File
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
@@ -9,6 +7,7 @@ import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.console.ConsoleConfig
 import overflowdb.Config
 
+import java.nio.file.Path
 import scala.util.Try
 
 class CpgGeneratorFactory(config: ConsoleConfig) {

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import io.shiftleft.console.FuzzyCFrontendConfig
 import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
+
+import java.nio.file.Path
 
 /**
   * Fuzzy C/C++ language frontend. Translates C/C++ source files

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/GoCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/GoCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import io.shiftleft.console.GoFrontendConfig
+
+import java.nio.file.Path
 
 /**
   * Language frontend for Go code.  Translates Go source code into Code Property Graphs.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
@@ -5,6 +5,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.console.workspacehandling.Project
 import overflowdb.traversal.help.Table
+
 import scala.util.Try
 
 class ImportCode[T <: Project](console: io.shiftleft.console.Console[T]) {

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/JavaCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/JavaCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import io.shiftleft.console.JavaFrontendConfig
+
+import java.nio.file.Path
 
 /**
   * Language frontend for Java archives (JAR files). Translates Java archives into code property graphs.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/JsCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import io.shiftleft.console.JsFrontendConfig
+
+import java.nio.file.Path
 
 case class JsCpgGenerator(config: JsFrontendConfig, rootPath: Path) extends CpgGenerator {
 

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/LlvmCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/LlvmCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import io.shiftleft.console.LlvmFrontendConfig
+
+import java.nio.file.Path
 
 /**
   * Language frontend for LLVM.  Translates LLVM bitcode into Code Property Graphs.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/PhpCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/PhpCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import io.shiftleft.console.PhpFrontendConfig
+
+import java.nio.file.Path
 
 case class PhpCpgGenerator(config: PhpFrontendConfig, rootPath: Path) extends CpgGenerator {
 

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/PythonCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/PythonCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.console.cpgcreation
 
-import java.nio.file.Path
-
 import io.shiftleft.console.PythonFrontendConfig
+
+import java.nio.file.Path
 
 case class PythonCpgGenerator(config: PythonFrontendConfig, rootPath: Path) extends CpgGenerator {
 

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.console
 
+import io.shiftleft.codepropertygraph.generated.Languages
+
 import java.io.File
 import java.nio.file.Path
-
-import io.shiftleft.codepropertygraph.generated.Languages
 
 package object cpgcreation {
 

--- a/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
@@ -1,12 +1,10 @@
 package io.shiftleft.console.cpgqlserver
 
-import java.util.Base64
-import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
-
 import cask.model.{Request, Response}
-
 import io.shiftleft.console.embammonite.{EmbeddedAmmonite, QueryResult}
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.{Base64, UUID}
 
 class CPGQLServer(ammonite: EmbeddedAmmonite,
                   serverHost: String,

--- a/console/src/main/scala/io/shiftleft/console/embammonite/EmbeddedAmmonite.scala
+++ b/console/src/main/scala/io/shiftleft/console/embammonite/EmbeddedAmmonite.scala
@@ -1,12 +1,11 @@
 package io.shiftleft.console.embammonite
 
 import ammonite.util.Colors
+import org.slf4j.{Logger, LoggerFactory}
+
 import java.io.{BufferedReader, InputStreamReader, PipedInputStream, PipedOutputStream, PrintWriter}
 import java.util.UUID
 import java.util.concurrent.{BlockingQueue, LinkedBlockingQueue, Semaphore}
-
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 /**
   * Result of executing a query, containing in particular

--- a/console/src/main/scala/io/shiftleft/console/embammonite/UserRunnable.scala
+++ b/console/src/main/scala/io/shiftleft/console/embammonite/UserRunnable.scala
@@ -1,12 +1,10 @@
 package io.shiftleft.console.embammonite
 
+import org.slf4j.{Logger, LoggerFactory}
+
 import java.io.{BufferedReader, PrintWriter}
 import java.util.UUID
 import java.util.concurrent.BlockingQueue
-
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-
 import scala.util.Try
 
 class UserRunnable(queue: BlockingQueue[Job], writer: PrintWriter, reader: BufferedReader, errReader: BufferedReader)

--- a/console/src/main/scala/io/shiftleft/console/scan/package.scala
+++ b/console/src/main/scala/io/shiftleft/console/scan/package.scala
@@ -2,8 +2,8 @@ package io.shiftleft.console
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
-import overflowdb.traversal._
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal._
 
 package object scan {
 

--- a/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/AmmoniteExecutor.scala
@@ -7,6 +7,7 @@ import cats.effect.IO
 import cats.instances.list._
 import cats.syntax.traverse._
 import io.shiftleft.codepropertygraph.Cpg
+
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScalaReflectWorkaround.scala
@@ -1,7 +1,8 @@
 package io.shiftleft.console.scripting
 
-import scala.reflect.runtime.currentMirror
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+
+import scala.reflect.runtime.currentMirror
 
 /** a workaround for a scala reflect bug, where the first invocation of scala reflect fails
   * idea: invoke this at the very start to trigger the bug. future invocations should be fine

--- a/console/src/main/scala/io/shiftleft/console/scripting/ScriptManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/scripting/ScriptManager.scala
@@ -4,11 +4,11 @@ import better.files._
 import cats.effect.IO
 import io.circe.generic.auto._
 import io.circe.parser._
-import org.zeroturnaround.zip.{NameMapper, ZipUtil}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.CpgLoader
-import java.nio.file.{Files, NoSuchFileException}
+import org.zeroturnaround.zip.{NameMapper, ZipUtil}
 
+import java.nio.file.{Files, NoSuchFileException}
 import scala.util.Try
 
 object ScriptManager {

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
@@ -1,11 +1,11 @@
 package io.shiftleft.console.workspacehandling
 
-import java.nio.file.Path
-
-import better.files.File
 import better.files.Dsl._
+import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.Overlays
+
+import java.nio.file.Path
 
 object Project {
   val workCpgFileName = "cpg.bin.tmp"

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/WorkspaceLoader.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/WorkspaceLoader.scala
@@ -1,12 +1,11 @@
 package io.shiftleft.console.workspacehandling
 
-import java.nio.file.Path
-
 import better.files.Dsl.mkdirs
 import better.files.File
 import org.json4s.DefaultFormats
 import org.json4s.native.Serialization.{read => jsonRead}
 
+import java.nio.file.Path
 import scala.collection.mutable.ListBuffer
 import scala.util.{Failure, Success, Try}
 

--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/WorkspaceManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/WorkspaceManager.scala
@@ -1,16 +1,15 @@
 package io.shiftleft.console.workspacehandling
 
-import java.net.URLEncoder
-import java.nio.file.Path
-
 import better.files.Dsl._
 import better.files._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
-import overflowdb.Config
 import org.json4s.DefaultFormats
 import org.json4s.native.Serialization.{write => jsonWrite}
+import overflowdb.Config
 
+import java.net.URLEncoder
+import java.nio.file.Path
 import scala.collection.mutable.ListBuffer
 import scala.reflect.io.Directory
 import scala.util.{Failure, Success, Try}

--- a/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleTests.scala
@@ -1,18 +1,16 @@
 package io.shiftleft.console
 
-import java.io.FileOutputStream
-import java.util.zip.ZipOutputStream
-
 import better.files.Dsl._
 import better.files._
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.console.testing._
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, Scpg}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.console.testing._
-import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, Scpg}
-
+import java.io.FileOutputStream
+import java.util.zip.ZipOutputStream
 import scala.util.Try
 
 class ConsoleTests extends AnyWordSpec with Matchers {

--- a/console/src/test/scala/io/shiftleft/console/HelpTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/HelpTests.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.console
 
 import io.shiftleft.console.workspacehandling.Project
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/QueryDatabaseTests.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.console
 
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.macros.QueryMacros
+import io.shiftleft.semanticcpg.language._
 import org.scalatest.matchers.should
 import org.scalatest.wordspec.AnyWordSpec
-import io.shiftleft.macros.QueryMacros
 
 object TestBundle extends QueryBundle {
   @q def foo(n: Int = 4): Query = Query(

--- a/console/src/test/scala/io/shiftleft/console/UnixUtilsTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/UnixUtilsTest.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.console
 
 import better.files._
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
@@ -3,14 +3,15 @@ package io.shiftleft.console.cpgqlserver
 import cask.util.Logger.Console._
 import castor.Context.Simple.global
 import io.shiftleft.console.embammonite.EmbeddedAmmonite
-import java.net.URLEncoder
-import java.util.UUID
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import requests.RequestFailedException
+import ujson.Value.Value
+
+import java.net.URLEncoder
+import java.util.UUID
 import scala.concurrent._
 import scala.concurrent.duration._
-import ujson.Value.Value
 
 class CPGQLServerTests extends AnyWordSpec with Matchers {
   val validBasicAuthHeaderVal = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="

--- a/console/src/test/scala/io/shiftleft/console/embammonite/EmbeddedAmmoniteTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/embammonite/EmbeddedAmmoniteTests.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.console.embammonite
 
-import java.util.concurrent.Semaphore
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.concurrent.Semaphore
 
 class EmbeddedAmmoniteTests extends AnyWordSpec with Matchers {
 

--- a/console/src/test/scala/io/shiftleft/console/scripting/AmmoniteExecutorTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/AmmoniteExecutorTest.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.console.scripting
 
+import io.shiftleft.codepropertygraph.Cpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
-import io.shiftleft.codepropertygraph.Cpg
 
 import java.nio.file.{Path, Paths}
 

--- a/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
@@ -2,17 +2,15 @@ package io.shiftleft.console.scripting
 
 import better.files.File
 import cats.effect.IO
-import org.scalatest.{Inside}
-
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.console.scripting.ScriptManager.{ScriptCollections, ScriptDescription, ScriptDescriptions}
-
-import java.nio.file.{FileSystemNotFoundException, NoSuchFileException, Path}
-
-import scala.io.Source
-import scala.util.Try
+import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{FileSystemNotFoundException, NoSuchFileException, Path}
+import scala.io.Source
+import scala.util.Try
 
 class ScriptManagerTest extends AnyWordSpec with Matchers with Inside {
 

--- a/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.console.testing
 
-import java.nio.file.Path
-
 import better.files.Dsl.mkdir
 import better.files.File
-import io.shiftleft.console.cpgcreation.{CpgGeneratorFactory, ImportCode, CpgGenerator}
-import io.shiftleft.console.{Console, ConsoleConfig, DefaultAmmoniteExecutor, InstallConfig}
+import io.shiftleft.console.cpgcreation.{CpgGenerator, CpgGeneratorFactory, ImportCode}
 import io.shiftleft.console.workspacehandling.{Project, ProjectFile, WorkspaceLoader}
+import io.shiftleft.console.{Console, ConsoleConfig, DefaultAmmoniteExecutor, InstallConfig}
 import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
+
+import java.nio.file.Path
 
 object ConsoleFixture {
   def apply[T <: Console[Project]](constructor: String => T = { x =>

--- a/console/src/test/scala/io/shiftleft/console/testing/package.scala
+++ b/console/src/test/scala/io/shiftleft/console/testing/package.scala
@@ -2,6 +2,7 @@ package io.shiftleft.console
 import better.files.Dsl._
 import better.files._
 import io.shiftleft.console.workspacehandling.Project
+
 import scala.util.{Failure, Success, Try}
 
 package object testing {

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/CpgValidatorMain.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.cpgvalidator
 
-import java.io.File
-
 import io.shiftleft.codepropertygraph.cpgloading.{CpgLoader, CpgLoaderConfig}
 import io.shiftleft.cpgvalidator.validators.CpgValidator
+
+import java.io.File
 
 object CpgValidatorMain extends App {
   case class Config(cpgPath: String, isOldProtoCpg: Boolean = false)

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/ValidationErrorRegistry.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/ValidationErrorRegistry.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.cpgvalidator
 
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.mutable
 

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/FactsImporter.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/FactsImporter.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.cpgvalidator.facts
 
-import java.io.FileInputStream
-
 import play.api.libs.json.{JsValue, Json}
+
+import java.io.FileInputStream
 
 abstract class FactsImporter {
 

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/KeysFactsImporter.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/KeysFactsImporter.scala
@@ -1,8 +1,7 @@
 package io.shiftleft.cpgvalidator.facts
 
-import play.api.libs.json.{Json, Reads}
-
 import play.api.libs.json.Reads._
+import play.api.libs.json.{Json, Reads}
 
 class KeysFactsImporter extends FactsImporter {
 

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/OutFactsImporter.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/OutFactsImporter.scala
@@ -2,6 +2,7 @@ package io.shiftleft.cpgvalidator.facts
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.cpgvalidator.SuperTypes
+
 import FactConstructionClasses._
 
 class OutFactsImporter extends FactsImporter {

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/InFactsValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/InFactsValidator.scala
@@ -2,10 +2,10 @@ package io.shiftleft.cpgvalidator.validators
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeTypes
-import io.shiftleft.cpgvalidator.facts.FactConstructionClasses.InFact
 import io.shiftleft.cpgvalidator._
+import io.shiftleft.cpgvalidator.facts.FactConstructionClasses.InFact
 import io.shiftleft.cpgvalidator.facts.InFactsImporter
-import overflowdb.{Direction, Node, Edge}
+import overflowdb.{Direction, Edge, Node}
 
 import scala.jdk.CollectionConverters._
 

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/OutFactsValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/OutFactsValidator.scala
@@ -2,10 +2,10 @@ package io.shiftleft.cpgvalidator.validators
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.NodeTypes
-import io.shiftleft.cpgvalidator.facts.FactConstructionClasses.OutFact
 import io.shiftleft.cpgvalidator._
+import io.shiftleft.cpgvalidator.facts.FactConstructionClasses.OutFact
 import io.shiftleft.cpgvalidator.facts.OutFactsImporter
-import overflowdb.{Direction, Node, Edge}
+import overflowdb.{Direction, Edge, Node}
 
 import scala.jdk.CollectionConverters._
 

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/Validator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/Validator.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.cpgvalidator.validators
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.cpgvalidator.ValidationErrorRegistry
 
 abstract class Validator() {
   def validate(notEnhancedCpg: Cpg): Boolean

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/cfg/NoLongJumpValidator.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/validators/cfg/NoLongJumpValidator.scala
@@ -2,8 +2,8 @@ package io.shiftleft.cpgvalidator.validators.cfg
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import io.shiftleft.cpgvalidator.{CfgEdgeError, ValidationErrorRegistry}
 import io.shiftleft.cpgvalidator.validators.Validator
+import io.shiftleft.cpgvalidator.{CfgEdgeError, ValidationErrorRegistry}
 import overflowdb.Node
 
 import scala.collection.mutable

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/CpgValidatorTest.scala
@@ -1,12 +1,12 @@
 package io.shiftleft.cpgvalidator
 
-import io.shiftleft.codepropertygraph.generated.NodeTypes
-import io.shiftleft.cpgvalidator.validators.CpgValidator
-import overflowdb._
 import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.cpgvalidator.validators.CpgValidator
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
 
 class CpgValidatorTest extends AnyWordSpec with Matchers {
   private def withNewBaseCpg[T](fun: Cpg => T): T = {

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/KeysValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/KeysValidatorTest.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.cpgvalidator
 
-import overflowdb._
-import io.shiftleft.codepropertygraph.generated.{nodes, NodeKeys, NodeTypes}
-import io.shiftleft.cpgvalidator.validators.KeysValidator
 import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.{NodeKeys, NodeTypes, nodes}
 import io.shiftleft.cpgvalidator.facts.FactConstructionClasses.Cardinality
+import io.shiftleft.cpgvalidator.validators.KeysValidator
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
 
 class KeysValidatorTest extends AnyWordSpec with Matchers {
 

--- a/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/NoLongJumpValidatorTest.scala
+++ b/cpgvalidator/src/test/scala/io.shiftleft.cpgvalidator/NoLongJumpValidatorTest.scala
@@ -1,12 +1,12 @@
 package io.shiftleft.cpgvalidator
 
-import overflowdb._
 import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes}
 import io.shiftleft.cpgvalidator.validators.cfg.NoLongJumpValidator
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
 
 class NoLongJumpValidatorTest extends AnyWordSpec with Matchers {
   private def withNewBaseCpg[T](fun: Cpg => T): T = {

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DdgGenerator.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/dotgenerator/DdgGenerator.scala
@@ -1,12 +1,12 @@
 package io.shiftleft.dataflowengineoss.dotgenerator
 
-import io.shiftleft.codepropertygraph.generated.{EdgeKeys, EdgeTypes, Operators, nodes}
+import io.shiftleft.codepropertygraph.generated.{EdgeKeys, EdgeTypes, nodes}
+import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.semanticcpg.dotgenerator.DotSerializer.{Edge, Graph}
-import overflowdb.Node
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.utils.MemberAccess.isGenericMemberAccessName
+import overflowdb.Node
 import overflowdb.traversal.jIteratortoTraversal
 
 import scala.collection.mutable

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/Path.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/Path.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.dataflowengineoss.language
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import overflowdb.traversal.help.Table
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.help.Table
 
 case class Path(elements: List[nodes.TrackingPoint])
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/nodemethods/TrackingPointMethods.scala
@@ -2,12 +2,11 @@ package io.shiftleft.dataflowengineoss.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes.TrackingPoint
-import io.shiftleft.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement}
-import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointMethodsBase
-import overflowdb.traversal.Traversal
-import overflowdb.traversal._
 import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.queryengine.{Engine, EngineContext, PathElement}
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointMethodsBase
+import overflowdb.traversal.{Traversal, _}
 
 import scala.collection.mutable
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/package.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/language/package.scala
@@ -4,7 +4,6 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.dataflowengineoss.language.dotextension.DdgNodeDot
 import io.shiftleft.dataflowengineoss.language.nodemethods.{ExpressionMethods, TrackingPointMethods}
 import io.shiftleft.semanticcpg.language.nodemethods.AstNodeMethods
-import io.shiftleft.semanticcpg.language.types.expressions.generalizations.AstNode
 import overflowdb.traversal.Traversal
 
 package object language {

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpCpg14.scala
@@ -2,10 +2,10 @@ package io.shiftleft.dataflowengineoss.layers.dataflows
 
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
 case class Cpg14DumpOptions(var outDir: String) extends LayerCreatorOptions {}
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdg.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpDdg.scala
@@ -2,10 +2,10 @@ package io.shiftleft.dataflowengineoss.layers.dataflows
 
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
 case class DdgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpPdg.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/DumpPdg.scala
@@ -2,10 +2,10 @@ package io.shiftleft.dataflowengineoss.layers.dataflows
 
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
+import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
 case class PdgDumpOptions(var outDir: String) extends LayerCreatorOptions {}
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.dataflowengineoss.passes.reachingdef
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
-import org.slf4j.{Logger, LoggerFactory}
-import overflowdb.traversal._
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.utils.MemberAccess.isGenericMemberAccessName
+import org.slf4j.{Logger, LoggerFactory}
+import overflowdb.traversal._
 
 /**
   * The variables defined/used in the reaching def problem can

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/UsageAnalyzer.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/UsageAnalyzer.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.dataflowengineoss.passes.reachingdef
 
-import io.shiftleft.codepropertygraph.generated.{Operators, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
+import io.shiftleft.codepropertygraph.generated.{Operators, nodes}
 import io.shiftleft.semanticcpg.accesspath.MatchResult
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointMethodsBase.ImplicitsAPI

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -1,16 +1,15 @@
 package io.shiftleft.dataflowengineoss.queryengine
 
 import io.shiftleft.codepropertygraph.generated.nodes.Call
-
-import java.util.concurrent.{Callable, ExecutorCompletionService, ExecutorService, Executors}
 import io.shiftleft.codepropertygraph.generated.{EdgeKeys, EdgeTypes, nodes}
+import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.semanticsloader.{FlowSemantic, Semantics}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.dataflowengineoss.language._
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.Edge
 import overflowdb.traversal.{NodeOps, Traversal}
 
+import java.util.concurrent.{Callable, ExecutorCompletionService, ExecutorService, Executors}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/ResultTable.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.dataflowengineoss.queryengine
 
 import io.shiftleft.codepropertygraph.generated.nodes
+
 import scala.jdk.CollectionConverters._
 
 class ResultTable {

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/semanticsloader/Parser.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/semanticsloader/Parser.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.dataflowengineoss.semanticsloader
 
 import io.shiftleft.dataflowengineoss.{SemanticsBaseListener, SemanticsLexer, SemanticsParser}
-import org.antlr.v4.runtime.{CharStream, CharStreams, CommonTokenStream}
 import org.antlr.v4.runtime.tree.ParseTreeWalker
+import org.antlr.v4.runtime.{CharStream, CharStreams, CommonTokenStream}
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/codedumper/CodeDumperTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/codedumper/CodeDumperTests.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.fuzzyc2cpg.codedumper
 
-import java.util.regex.Pattern
-
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import io.shiftleft.semanticcpg.language._
+
+import java.util.regex.Pattern
 
 class CodeDumperTests extends FuzzyCCodeToCpgSuite {
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CDataFlowTests.scala
@@ -1,11 +1,11 @@
 package io.shiftleft.fuzzyc2cpg.querying
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.dataflowengineoss.language._
+import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.fuzzyc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
-import io.shiftleft.dataflowengineoss.language._
-import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 
 class CDataFlowTests1 extends DataFlowCodeToCpgSuite {
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CallGraphTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CallGraphTests.scala
@@ -1,8 +1,7 @@
 package io.shiftleft.fuzzyc2cpg.querying
 
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
-import io.shiftleft.semanticcpg.language.NoResolve
+import io.shiftleft.semanticcpg.language.{NoResolve, _}
 
 class CallGraphTests extends FuzzyCCodeToCpgSuite {
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/DataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/DataFlowTests.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.fuzzyc2cpg.querying
 
+import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.fuzzyc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.dataflowengineoss.language._
 
 class DataFlowTests extends DataFlowCodeToCpgSuite {
   override val code =

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/FreeListDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/FreeListDataFlowTests.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.fuzzyc2cpg.querying
 
+import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.fuzzyc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.dataflowengineoss.language._
 
 class FreeListDataFlowTests extends DataFlowCodeToCpgSuite {
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NewCDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NewCDataFlowTests.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.fuzzyc2cpg.querying
 
+import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.fuzzyc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.dataflowengineoss.language._
-import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 
 class NewCDataFlowTests1 extends DataFlowCodeToCpgSuite {
   override val code =

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/TrackingPointTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/TrackingPointTests.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.fuzzyc2cpg.querying
 
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.dataflowengineoss.semanticsloader.Semantics
 import io.shiftleft.fuzzyc2cpg.testfixtures.DataFlowCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.dataflowengineoss.language._
 
 class TrackingPointTests extends DataFlowCodeToCpgSuite {
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/CallTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/CallTests.scala
@@ -2,8 +2,7 @@ package io.shiftleft.fuzzyc2cpg.standard
 
 import io.shiftleft.codepropertygraph.generated.{Operators, nodes}
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
-import io.shiftleft.semanticcpg.language.NoResolve
-import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.{NoResolve, _}
 
 class CallTests extends FuzzyCCodeToCpgSuite {
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/MethodReturnTests.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.fuzzyc2cpg.standard
 
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
+import io.shiftleft.semanticcpg.language._
 
 class MethodReturnTests extends FuzzyCCodeToCpgSuite {
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/testfixtures/CodeDirToCpgFixture.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/testfixtures/CodeDirToCpgFixture.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.fuzzyc2cpg.testfixtures
 
-import java.io.File
-
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
 import io.shiftleft.semanticcpg.testfixtures.LanguageFrontend
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.File
 
 class CodeDirToCpgFixture extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/testfixtures/FuzzyCCodeToCpgSuite.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/testfixtures/FuzzyCCodeToCpgSuite.scala
@@ -1,9 +1,10 @@
 package io.shiftleft.fuzzyc2cpg.testfixtures
 
-import java.io.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
 import io.shiftleft.semanticcpg.testfixtures.{CodeToCpgFixture, LanguageFrontend}
+
+import java.io.File
 
 class FuzzycFrontend extends LanguageFrontend {
   def execute(sourceCodePath: File): Cpg = {

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/FuzzyC2Cpg.scala
@@ -1,20 +1,19 @@
 package io.shiftleft.fuzzyc2cpg
 
-import org.slf4j.LoggerFactory
-import java.nio.file.Files
-import java.util.concurrent.ConcurrentHashMap
-
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.fuzzyc2cpg.passes.{AstCreationPass, CMetaDataPass, StubRemovalPass, TypeNodePass}
 import io.shiftleft.passes.{IntervalKeyPool, KeyPoolCreator}
 import io.shiftleft.semanticcpg.passes.CfgCreationPass
 import io.shiftleft.x2cpg.SourceFiles
+import org.slf4j.LoggerFactory
 import overflowdb.{Config, Graph}
 
+import java.nio.file.Files
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.mutable.ListBuffer
-import scala.util.control.NonFatal
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 case class Global(usedTypes: ConcurrentHashMap[String, Boolean] = new ConcurrentHashMap[String, Boolean]())
 

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/AstCreationPass.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/AstCreationPass.scala
@@ -2,8 +2,8 @@ package io.shiftleft.fuzzyc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.fuzzyc2cpg.passes.astcreation.{AntlrCModuleParserDriver, AstVisitor}
 import io.shiftleft.fuzzyc2cpg.Global
+import io.shiftleft.fuzzyc2cpg.passes.astcreation.{AntlrCModuleParserDriver, AstVisitor}
 import io.shiftleft.passes.{DiffGraph, IntervalKeyPool, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language.types.structure.Namespace
 import org.slf4j.LoggerFactory

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPass.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/StubRemovalPass.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.fuzzyc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes.Method
+import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
+import io.shiftleft.semanticcpg.language._
 
 /**
   * A pass that ensures that for any method m for which a body exists,

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/TypeNodePass.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/TypeNodePass.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.fuzzyc2cpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.passes.{CpgPass, DiffGraph, KeyPool}
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.passes.{CpgPass, DiffGraph, KeyPool}
 
 class TypeNodePass(usedTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] = None)
     extends CpgPass(cpg, "types", keyPool) {

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
@@ -1,11 +1,8 @@
 package io.shiftleft.fuzzyc2cpg.passes.astcreation
 
-import io.shiftleft.fuzzyc2cpg.ast.AstNode
-import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor
-import org.slf4j.LoggerFactory
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Operators, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
-import io.shiftleft.fuzzyc2cpg.{Defines, Global}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Operators, nodes}
+import io.shiftleft.fuzzyc2cpg.ast.AstNode
 import io.shiftleft.fuzzyc2cpg.ast.declarations.{ClassDefStatement, IdentifierDecl}
 import io.shiftleft.fuzzyc2cpg.ast.expressions.{
   AdditiveExpression,
@@ -54,8 +51,11 @@ import io.shiftleft.fuzzyc2cpg.ast.statements.jump.{
   ThrowStatement
 }
 import io.shiftleft.fuzzyc2cpg.ast.statements.{ExpressionStatement, IdentifierDeclStatement}
+import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor
+import io.shiftleft.fuzzyc2cpg.{Defines, Global}
 import io.shiftleft.passes.DiffGraph
 import io.shiftleft.proto.cpg.Cpg.{DispatchTypes, EvaluationStrategies}
+import org.slf4j.LoggerFactory
 
 import scala.jdk.CollectionConverters._
 

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstVisitor.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstVisitor.scala
@@ -1,14 +1,14 @@
 package io.shiftleft.fuzzyc2cpg.passes.astcreation
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import io.shiftleft.fuzzyc2cpg.{Global, ModuleLexer, ModuleParser}
 import io.shiftleft.fuzzyc2cpg.ast.declarations.ClassDefStatement
 import io.shiftleft.fuzzyc2cpg.ast.langc.functiondef.FunctionDef
 import io.shiftleft.fuzzyc2cpg.ast.statements.IdentifierDeclStatement
 import io.shiftleft.fuzzyc2cpg.ast.walking.ASTNodeVisitor
 import io.shiftleft.fuzzyc2cpg.parser.{AntlrParserDriverObserver, TokenSubStream}
-import org.antlr.v4.runtime.{CharStream, ParserRuleContext}
+import io.shiftleft.fuzzyc2cpg.{Global, ModuleLexer, ModuleParser}
 import org.antlr.v4.runtime.tree.ParseTree
+import org.antlr.v4.runtime.{CharStream, ParserRuleContext}
 
 class AstVisitor(driver: AntlrCModuleParserDriver, astParentNode: nodes.NewNamespaceBlock, global: Global)
     extends ASTNodeVisitor

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/StableOutputTests.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/StableOutputTests.scala
@@ -2,6 +2,7 @@ package io.shiftleft.fuzzyc2cpg
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
 import scala.jdk.CollectionConverters._
 
 class StableOutputTests extends AnyWordSpec with Matchers {

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/AstCreationPassTests.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/AstCreationPassTests.scala
@@ -2,11 +2,11 @@ package io.shiftleft.fuzzyc2cpg.passes
 
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators, nodes}
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators, nodes}
 import overflowdb.traversal._
 
 class AstCreationPassTests extends AnyWordSpec with Matchers {

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPassTests.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/CfgCreationPassTests.scala
@@ -2,14 +2,15 @@ package io.shiftleft.fuzzyc2cpg.passes
 
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
-import scala.jdk.CollectionConverters._
-import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.passes.CfgCreationPass
 import io.shiftleft.semanticcpg.passes.cfgcreation.Cfg.{AlwaysEdge, CaseEdge, CfgEdgeType, FalseEdge, TrueEdge}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters._
 
 class CfgCreationPassTests extends AnyWordSpec with Matchers {
 

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/TypeNodePassTests.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/TypeNodePassTests.scala
@@ -4,9 +4,10 @@ import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
-import scala.jdk.CollectionConverters._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters._
 
 class TypeNodePassTests extends AnyWordSpec with Matchers {
   "TypeNodePass" should {

--- a/macros/src/main/scala/io/shiftleft/macros/Macros.scala
+++ b/macros/src/main/scala/io/shiftleft/macros/Macros.scala
@@ -4,6 +4,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.console.Query
 import overflowdb.traversal.Traversal
+
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/OverlaysTests.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.semanticcpg
 
+import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testing.MockCpg
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.shiftleft.semanticcpg.language._
 
 class OverlaysTests extends AnyWordSpec with Matchers {
 

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/accesspath/TrackingPointToAccessPathTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/accesspath/TrackingPointToAccessPathTests.scala
@@ -2,10 +2,10 @@ package io.shiftleft.semanticcpg.accesspath
 
 import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.generated._
+import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointMethodsBase.toTrackedAccessPath
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb._
-import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointMethodsBase.toTrackedAccessPath
 
 class TrackingPointToAccessPathTests extends AnyWordSpec {
 

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, CfgNode, Expression}
+import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Expression}
 import io.shiftleft.codepropertygraph.generated.{NodeKeys, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
 import org.json4s.JString

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/FileTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/FileTests.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes
-import org.scalatest.{LoneElement, Matchers, WordSpec}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import org.scalatest.LoneElement
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPassTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPassTests.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.passes
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.passes.DiffGraph
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.matchers.should.Matchers

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/CapturingLinkerTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/CapturingLinkerTests.scala
@@ -2,11 +2,11 @@ package io.shiftleft.semanticcpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, NodeTypes}
-import overflowdb._
 import io.shiftleft.semanticcpg.passes.linking.capturinglinker.CapturingLinker
 import io.shiftleft.semanticcpg.testfixtures.EmptyGraphFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.semanticcpg.passes
 
 import io.shiftleft.OverflowDbTestInstance
-import overflowdb._
 import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgAdapter, CfgDominator, CfgDominatorFrontier, DomTreeAdapter}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorPassTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorPassTests.scala
@@ -1,12 +1,12 @@
 package io.shiftleft.semanticcpg.passes
 
 import io.shiftleft.OverflowDbTestInstance
-import overflowdb._
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/ContainsEdgePassTest.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/ContainsEdgePassTest.scala
@@ -1,12 +1,12 @@
 package io.shiftleft.semanticcpg.passes
 
-import overflowdb._
 import io.shiftleft.OverflowDbTestInstance
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.passes.containsedges.ContainsEdgePass
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/MethodDecoratorPassTests.scala
@@ -2,11 +2,11 @@ package io.shiftleft.semanticcpg.passes
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated._
-import overflowdb._
 import io.shiftleft.semanticcpg.passes.methoddecorations.MethodDecoratorPass
 import io.shiftleft.semanticcpg.testfixtures.EmptyGraphFixture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import overflowdb._
 
 class MethodDecoratorPassTests extends AnyWordSpec with Matchers {
   "MethodDecoratorTest" in EmptyGraphFixture { graph =>

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/CodeToCpgFixture.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.semanticcpg.testfixtures
 
-import java.io.{File, PrintWriter}
-import java.nio.file.Files
-
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.{File, PrintWriter}
+import java.nio.file.Files
 
 class CodeToCpgFixture(val frontend: LanguageFrontend) extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/LanguageFrontend.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/LanguageFrontend.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg.testfixtures
 
-import java.io.File
-
 import io.shiftleft.codepropertygraph.Cpg
+
+import java.io.File
 
 /**
   * LanguageFrontend encapsulates the logic that translates the source code directory

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/TrackedBase.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/TrackedBase.scala
@@ -1,9 +1,6 @@
 package io.shiftleft.semanticcpg.accesspath
 
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeKeys, nodes}
-import io.shiftleft.semanticcpg.language.nodemethods.TrackingPointMethodsBase
-import io.shiftleft.semanticcpg.utils.MemberAccess
-import scala.jdk.CollectionConverters._
+import io.shiftleft.codepropertygraph.generated.nodes
 
 trait TrackedBase
 case class TrackedNamedVariable(name: String) extends TrackedBase

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Show.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Show.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import overflowdb.Node
+
 import scala.jdk.CollectionConverters._
 
 /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -1,7 +1,5 @@
 package io.shiftleft.semanticcpg.language
 
-import java.util.{List => JList}
-
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.codepropertygraph.generated.nodes._
 import org.json4s.native.Serialization.{write, writePretty}
@@ -9,6 +7,7 @@ import org.json4s.{CustomSerializer, Extraction}
 import overflowdb.traversal.Traversal
 import overflowdb.traversal.help.{Doc, TraversalHelp}
 
+import java.util.{List => JList}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -2,8 +2,8 @@ package io.shiftleft.semanticcpg.language.callgraphextension
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{PathAwareTraversal, Traversal}
 import overflowdb.traversal.help.Doc
+import overflowdb.traversal.{PathAwareTraversal, Traversal}
 
 class Method(val traversal: Traversal[nodes.Method]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
@@ -4,8 +4,6 @@ import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.dotgenerator.DotAstGenerator
 import overflowdb.traversal.Traversal
 
-import scala.language.postfixOps
-
 class AstNodeDot[NodeType <: nodes.AstNode](val traversal: Traversal[NodeType]) extends AnyVal {
 
   def dotAst: Traversal[String] = DotAstGenerator.dotAst(traversal)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
+import overflowdb.traversal.Traversal
 
 import scala.jdk.CollectionConverters._
-import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
 
 class CfgNodeMethods(val node: nodes.CfgNode) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import overflowdb.traversal.Traversal
+
 import scala.jdk.CollectionConverters._
 
 class StoredNodeMethods(val node: nodes.StoredNode) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
@@ -3,8 +3,6 @@ package io.shiftleft.semanticcpg.language.nodemethods
 import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes
 
-import scala.annotation.tailrec
-
 class WithinMethodMethods(val node: nodes.WithinMethod) extends AnyVal {
   def method: nodes.Method = node match {
     case node: nodes.Method             => node

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{CpgNode, StoredNode}
 import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.{CpgNode, StoredNode}
 import io.shiftleft.semanticcpg.language.callgraphextension.{Call, Method}
 import io.shiftleft.semanticcpg.language.dotextension.{AstNodeDot, CfgNodeDot}
 import io.shiftleft.semanticcpg.language.nodemethods._
@@ -10,7 +10,7 @@ import io.shiftleft.semanticcpg.language.types.expressions.generalizations._
 import io.shiftleft.semanticcpg.language.types.expressions.{Call => OriginalCall, _}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 import io.shiftleft.semanticcpg.language.types.structure.{Method => OriginalMethod, _}
-import overflowdb.traversal.{Traversal, _}
+import overflowdb.traversal.Traversal
 
 /**
   Language for traversing the code property graph

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Block.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/Block.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
-import overflowdb.traversal.Traversal
-import overflowdb.traversal.help
 import overflowdb.traversal.help.Doc
+import overflowdb.traversal.{Traversal, help}
 
 @help.Traversal(elementType = classOf[nodes.Block])
 class Block(val traversal: Traversal[nodes.Block]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOut.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
-import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
+
 import scala.jdk.CollectionConverters._
 
 class MethodParameterOut(val traversal: Traversal[nodes.MethodParameterOut]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/LayerCreator.scala
@@ -5,8 +5,7 @@ import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.Overlays
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 abstract class LayerCreator {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -4,7 +4,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{Languages, NodeTypes}
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.passes.{BindingMethodOverridesPass, FileCreationPass}
 import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
 import io.shiftleft.semanticcpg.passes.codepencegraph.CdgPass
 import io.shiftleft.semanticcpg.passes.compat.argumentcompat.ArgumentCompat
@@ -22,6 +21,7 @@ import io.shiftleft.semanticcpg.passes.methodexternaldecorator.MethodExternalDec
 import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.semanticcpg.passes.receiveredges.ReceiverEdgePass
 import io.shiftleft.semanticcpg.passes.trim.TrimPass
+import io.shiftleft.semanticcpg.passes.{BindingMethodOverridesPass, FileCreationPass}
 
 object Scpg {
   val overlayName: String = "semanticcpg"

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/package.scala
@@ -1,8 +1,5 @@
 package io.shiftleft
 
-import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.Operators
-
 /**
   * Domain specific language for querying code property graphs
   *

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/BindingMethodOverridesPass.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.semanticcpg.passes
-import scala.collection.mutable
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{nodes, NodeKeyNames}
+import io.shiftleft.codepropertygraph.generated.{NodeKeyNames, nodes}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
-import scala.jdk.CollectionConverters._
+
+import scala.collection.mutable
 
 class BindingMethodOverridesPass(cpg: Cpg) extends CpgPass(cpg) {
   val overwritten = mutable.HashSet[nodes.Binding]()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgcreation/CfgCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgcreation/CfgCreator.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.passes.cfgcreation
 
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Operators, nodes}
 import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Operators, nodes}
 import io.shiftleft.passes.DiffGraph
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.cfgcreation.Cfg.CfgEdgeType

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
@@ -7,7 +7,6 @@ import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominatorFrontier, ReverseCpgCfgAdapter}
 import org.slf4j.{Logger, LoggerFactory}
-import overflowdb._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/argumentcompat/ArgumentCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/argumentcompat/ArgumentCompat.scala
@@ -6,6 +6,7 @@ import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 import overflowdb.traversal._
+
 import scala.jdk.CollectionConverters._
 
 class ArgumentCompat(cpg: Cpg) extends CpgPass(cpg) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/methodinstcompat/MethodInstCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/methodinstcompat/MethodInstCompat.scala
@@ -4,8 +4,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{NodeKeys, NodeTypes, nodes}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 import overflowdb._
 
 import scala.collection.mutable

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/TypeDeclStubCreator.scala
@@ -4,8 +4,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.types.structure.Namespace
-import io.shiftleft.semanticcpg.language.types.structure.File
+import io.shiftleft.semanticcpg.language.types.structure.{File, Namespace}
 
 /**
   * This pass has no other pass as prerequisite.


### PR DESCRIPTION
Run `sbt format` once. It's a one-off job that will be checked by GH Actions now.
On failure, an appropriate suggestion to run `sbt format` will be displayed.