### PR TITLE
Replace `ExistingCpgFixture` tests with `MockCpg` tests

### DIFF
--- a/resources/testcode/cpgs/binding/cpg.bin.zip
+++ b/resources/testcode/cpgs/binding/cpg.bin.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f61097e3299e808be947e4bd7c57611f32b95025dac43f9c171c7069b02c11d
-size 6378

--- a/resources/testcode/cpgs/expression/cpg.bin.zip
+++ b/resources/testcode/cpgs/expression/cpg.bin.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a7931e0682051ac4e17db15b29c9e719eff5cd19d4e6ddef38dedadf75c8e616
-size 18027

--- a/resources/testcode/cpgs/file/cpg.bin.zip
+++ b/resources/testcode/cpgs/file/cpg.bin.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7304c861cf8995a033667fccdf4ab5b66e8d4055537414635f1d346c145bd58
-size 17697

--- a/resources/testcode/cpgs/splitmeup/cpg.bin.zip
+++ b/resources/testcode/cpgs/splitmeup/cpg.bin.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ecec7569a352db925b988f727e9196bc66fc53d95dc2701e6b0f116f7f021a4
-size 26644

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/ExpressionTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/expressions/ExpressionTests.scala
@@ -1,42 +1,45 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class ExpressionTests extends AnyWordSpec with Matchers {
 
-  "generic cpg" should ExistingCpgFixture("expression") { fixture =>
-    "expand to next expression in CFG" in {
-      val expressions: List[nodes.Expression] =
-        fixture.cpg.method.name("methodForCfgTest").cfgFirst.cfgNext.isExpression.toList
+  val cpg = MockCpg()
+    .withMethod("methodForCfgTest")
+    .withCallInMethod("methodForCfgTest", "call1")
+    .withCallInMethod("methodForCfgTest", "call2")
+    .withCustom { (graph, cpg) =>
+      val method = cpg.method("methodForCfgTest").head
+      val call1 = cpg.call.name("call1").head
+      val call2 = cpg.call.name("call2").head
+      graph.addEdge(method, call1, EdgeTypes.CFG)
+      graph.addEdge(call1, call2, EdgeTypes.CFG)
+      graph.addEdge(call2, method.methodReturn.head, EdgeTypes.CFG)
+    }
+    .cpg
 
-      expressions.size shouldBe 1
-      expressions.head.code shouldBe "aaa"
+  "generic cpg" should {
+    "expand to next expression in CFG" in {
+      val List(x: nodes.Call) = cpg.method.name("methodForCfgTest").cfgFirst.cfgNext.isExpression.l
+      x.name shouldBe "call2"
     }
 
     "don't expand to previous of first expression in CFG. Aka it should be empty" in {
-      val expressions: List[nodes.Expression] =
-        fixture.cpg.method.name("methodForCfgTest").cfgFirst.cfgPrev.isExpression.toList
-
-      expressions.size shouldBe 0
+      cpg.method.name("methodForCfgTest").cfgFirst.cfgPrev.isExpression.size shouldBe 0
     }
 
     "expand to previous expression in CFG" in {
-      val expressions: List[nodes.Expression] =
-        fixture.cpg.method.name("methodForCfgTest").cfgLast.cfgPrev.isExpression.toList
-
-      expressions.size shouldBe 1
-      expressions.head.code shouldBe "temp"
+      val List(x: nodes.Call) =
+        cpg.method.name("methodForCfgTest").cfgLast.cfgPrev.isExpression.l
+      x.name shouldBe "call1"
     }
 
     "don't expand to next of last expression in CFG. Aka it should be empty" in {
-      val expressions: List[nodes.Expression] =
-        fixture.cpg.method.name("methodForCfgTest").cfgLast.cfgNext.isExpression.toList
-
-      expressions.size shouldBe 0
+      cpg.method.name("methodForCfgTest").cfgLast.cfgNext.isExpression.size shouldBe 0
     }
   }
 }

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/BindingTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/BindingTests.scala
@@ -1,52 +1,67 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class BindingTests extends AnyWordSpec with Matchers {
 
-  "Binding steps" should ExistingCpgFixture("binding") { fixture =>
+  val cpg = MockCpg()
+    .withTypeDecl("BindingTest")
+    .withMethod("<init>")
+    .withMethod("boundMethod")
+    .withCustom { (graph, cpg) =>
+      val typeDecl = cpg.typeDecl.name("BindingTest").head
+      val binding1 = nodes.NewBinding().name("<init>")
+      val binding2 = nodes.NewBinding().name("boundMethod")
+      graph.addEdge(typeDecl, binding1, EdgeTypes.BINDS)
+      graph.addEdge(typeDecl, binding2, EdgeTypes.BINDS)
+      graph.addEdge(binding1, cpg.method("<init>").head, EdgeTypes.REF)
+      graph.addEdge(binding2, cpg.method("boundMethod").head, EdgeTypes.REF)
+    }
+    .cpg
+
+  "Binding steps" should {
     "expand from BindingTest class to one method binding" in {
       val queryResult: List[nodes.Binding] =
-        fixture.cpg.typeDecl.name("BindingTest").methodBinding.l
+        cpg.typeDecl.name("BindingTest").methodBinding.l
 
       queryResult.map(_.name) should contain theSameElementsAs List("<init>", "boundMethod")
     }
 
     "expand from method binding to bound method" in {
       val queryResult: List[nodes.Method] =
-        fixture.cpg.typeDecl.name("BindingTest").methodBinding.boundMethod.l
+        cpg.typeDecl.name("BindingTest").methodBinding.boundMethod.l
 
       queryResult.map(_.name) should contain theSameElementsAs List("<init>", "boundMethod")
     }
 
     "expand from bound method to method binding" in {
       val queryResult: List[nodes.Binding] =
-        fixture.cpg.method.name("boundMethod").referencingBinding.l
+        cpg.method.name("boundMethod").referencingBinding.l
 
       queryResult.map(_.name) should contain theSameElementsAs List("boundMethod")
     }
 
     "expand from method binding to binding type decl" in {
       val queryResult: List[nodes.TypeDecl] =
-        fixture.cpg.method.name("boundMethod").referencingBinding.bindingTypeDecl.l
+        cpg.method.name("boundMethod").referencingBinding.bindingTypeDecl.l
 
       queryResult.map(_.name) should contain theSameElementsAs List("BindingTest")
     }
 
     "expand from BindingTest class to bound method" in {
       val queryResult: List[nodes.Method] =
-        fixture.cpg.typeDecl.name("BindingTest").boundMethod.l
+        cpg.typeDecl.name("BindingTest").boundMethod.l
 
       queryResult.map(_.name) should contain theSameElementsAs List("<init>", "boundMethod")
     }
 
     "expand from bound method to binding class" in {
       val queryResult: List[nodes.TypeDecl] =
-        fixture.cpg.method.name("boundMethod").bindingTypeDecl.l
+        cpg.method.name("boundMethod").bindingTypeDecl.l
 
       queryResult.map(_.name) should contain theSameElementsAs List("BindingTest")
     }

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/FileTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/FileTests.scala
@@ -2,38 +2,43 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.LoneElement
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class FileTests extends AnyWordSpec with Matchers with LoneElement {
   val fileName = "io/shiftleft/testcode/file/FileTest.java"
+  val cpg = MockCpg()
+    .withFile(fileName)
+    .withNamespace("io.shiftleft.testcode.file", inFile = Some(fileName))
+    .withTypeDecl("FileTest", inFile = Some(fileName), inNamespace = Some("io.shiftleft.testcode.file"))
+    .withMethod("method", inTypeDecl = Some("FileTest"))
+    .cpg
 
-  "generic cpg" should ExistingCpgFixture("file") { fixture =>
+  "generic cpg" should {
     s"find file $fileName" in {
-      val queryResult: List[nodes.File] = fixture.cpg.file.l
+      val queryResult: List[nodes.File] = cpg.file.l
 
       queryResult.map(_.name) should contain(fileName)
     }
 
     "be able to expand to class FileTest" in {
       val queryResult: List[nodes.TypeDecl] =
-        fixture.cpg.file.name(fileName).typeDecl.l
+        cpg.file.name(fileName).typeDecl.l
 
       queryResult.loneElement.name shouldBe "FileTest"
     }
 
     "be able to expand to namespace" in {
       val queryResult: List[nodes.Namespace] =
-        fixture.cpg.file.name(fileName).namespace.l
-
+        cpg.file.name(fileName).namespace.l
       queryResult.loneElement.name shouldBe "io.shiftleft.testcode.file"
     }
 
     "be able to get file in which a formal method return is defined" in {
       val queryResult: List[nodes.File] =
-        fixture.cpg.method.name("method").methodReturn.file.l
+        cpg.method.name("method").methodReturn.file.l
 
       queryResult.loneElement.name shouldBe fileName
     }

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTests.scala
@@ -1,20 +1,31 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
-import io.shiftleft.codepropertygraph.generated.ModifierTypes
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, ModifierTypes, nodes}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class MemberTests extends AnyWordSpec with Matchers {
 
-  "Member traversals" should ExistingCpgFixture("type") { fixture =>
+  val cpg = MockCpg()
+    .withTypeDecl("foo")
+    .withCustom { (graph, _) =>
+      val staticMember = nodes.NewMember().name("static_member")
+      val modifier = nodes.NewModifier().modifierType(ModifierTypes.STATIC)
+      graph.addNode(staticMember)
+      graph.addNode(modifier)
+      graph.addEdge(staticMember, modifier, EdgeTypes.AST)
+    }
+    .cpg
+
+  "Member traversals" should {
     "should find two members: `member` and `static_member`" in {
-      fixture.cpg.member.name.toSet shouldBe Set("member", "static_member")
+      cpg.member.name.toSet shouldBe Set("amember", "static_member")
     }
 
     "filter by modifier" in {
-      val member = fixture.cpg.member.hasModifier(ModifierTypes.STATIC).name.toSet
+      val member = cpg.member.hasModifier(ModifierTypes.STATIC).name.toSet
       member shouldBe Set("static_member")
     }
   }

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/MemberAccessLinkerTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/MemberAccessLinkerTests.scala
@@ -2,16 +2,23 @@ package io.shiftleft.semanticcpg.passes
 
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.testfixtures.ExistingCpgFixture
+import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class MemberAccessLinkerTests extends AnyWordSpec with Matchers {
 
-  "have a reference to correct member" in ExistingCpgFixture("memberaccesslinker") { fixture =>
-    val members = fixture.cpg.call(Operators.indirectMemberAccess).referencedMember.l
-    members.size shouldBe 1
-    members.head.name shouldBe "aaa"
+  val cpg = MockCpg().withCustom { (graph, _) =>
+    val call = nodes.NewCall().name(Operators.indirectMemberAccess)
+    val member = nodes.NewMember().name("aaa")
+    graph.addNode(call)
+    graph.addNode(member)
+    graph.addEdge(call, member, EdgeTypes.REF)
+  }.cpg
+
+  "have a reference to correct member" in {
+    val List(m) = cpg.call(Operators.indirectMemberAccess).referencedMember.l
+    m.name shouldBe "aaa"
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
@@ -34,7 +34,7 @@ package object testing {
         )
       }
 
-    def withNamespace(name: String): MockCpg =
+    def withNamespace(name: String, inFile: Option[String] = None): MockCpg =
       withCustom { (graph, _) =>
         {
           val namespaceBlock = nodes.NewNamespaceBlock().name(name)
@@ -42,6 +42,10 @@ package object testing {
           graph.addNode(namespaceBlock)
           graph.addNode(namespace)
           graph.addEdge(namespaceBlock, namespace, EdgeTypes.REF)
+          if (inFile.isDefined) {
+            val fileNode = cpg.file.name(inFile.get).head
+            graph.addEdge(namespaceBlock, fileNode, EdgeTypes.SOURCE_FILE)
+          }
         }
       }
 


### PR DESCRIPTION
Replaced more tests that rely on CPG blobs with tests that use MockCpg.