### PR TITLE
prevent nullpointer exceptions for querying astChildren of METHODs with missing ORDER field on LOCALs

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -46,7 +46,12 @@ class AstNode[A <: nodes.AstNode](val traversal: Traversal[A]) extends AnyVal {
     * Direct children of node in the AST. Siblings are ordered by their `order` fields
     * */
   def astChildren: Traversal[nodes.AstNode] =
-    traversal.out(EdgeTypes.AST).cast[nodes.AstNode].sortBy(_.order)
+    traversal.out(EdgeTypes.AST).cast[nodes.AstNode].sortBy { c =>
+      {
+        val o = c.order
+        if (o == null) new Integer(-2) else o
+      }
+    }
 
   /**
     * Parent AST node


### PR DESCRIPTION
In case you wonder about the `new Integer(-2)`: sortBy needs to return a reference type; if we returned an Int it would get boxed by the sorting routine anyways. So it makes no sense to unbox the `order`.