### PR TITLE
add a comment

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -49,6 +49,7 @@ class AstNode[A <: nodes.AstNode](val traversal: Traversal[A]) extends AnyVal {
     traversal.out(EdgeTypes.AST).cast[nodes.AstNode].sortBy { c =>
       {
         val o = c.order
+        /** using `Integer` here to prevent boxing during sorting */ 
         if (o == null) new Integer(-2) else o
       }
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNode.scala
@@ -49,7 +49,8 @@ class AstNode[A <: nodes.AstNode](val traversal: Traversal[A]) extends AnyVal {
     traversal.out(EdgeTypes.AST).cast[nodes.AstNode].sortBy { c =>
       {
         val o = c.order
-        /** using `Integer` here to prevent boxing during sorting */ 
+
+        /** using `Integer` here to prevent boxing during sorting */
         if (o == null) new Integer(-2) else o
       }
     }


### PR DESCRIPTION
this was only on the PR so far: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1142
IMO it makes sense to have it in the code to not lose it