### PR TITLE
Remove deprecated QueryDB properties

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/console/Query.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/console/Query.scala
@@ -9,12 +9,6 @@ case class Query(name: String,
                  title: String,
                  description: String,
                  score: Double,
-                 // intended to be filled by com.lihaoyi.sourcecode.Line
-                 docStartLine: Int = 0,
                  traversal: Cpg => Traversal[nodes.StoredNode],
-                 // intended to be filled by com.lihaoyi.sourcecode.Line
-                 docEndLine: Int = 0,
-                 // intended to be filled by com.lihaoyi.sourcecode.FileName
-                 docFileName: String = "",
                  traversalAsString: String = "",
                  tags: List[String] = List())


### PR DESCRIPTION
Not needed any more since the query sources are set via the `queryInit`
macro.