### PR TITLE
Move TYPE_FULL_NAME on CALL from deprecation back to normal.

### DIFF
--- a/schema/src/main/resources/schemas/base.json
+++ b/schema/src/main/resources/schemas/base.json
@@ -210,7 +210,7 @@
          ]
         },
         {"id": 15, "name" : "CALL",
-         "keys": ["CODE", "NAME", "ORDER", "METHOD_FULL_NAME", "ARGUMENT_INDEX", "SIGNATURE", "LINE_NUMBER", "COLUMN_NUMBER"],
+         "keys": ["CODE", "NAME", "ORDER", "METHOD_FULL_NAME", "ARGUMENT_INDEX", "SIGNATURE", "TYPE_FULL_NAME", "LINE_NUMBER", "COLUMN_NUMBER"],
          "comment" : "A (method)-call",
          "is": ["EXPRESSION", "CALL_REPR"],
          "outEdges" : [

--- a/schema/src/main/resources/schemas/deprecated.json
+++ b/schema/src/main/resources/schemas/deprecated.json
@@ -1,7 +1,7 @@
 {
   "nodeTypes" : [
     { "name" : "CALL",
-      "keys": [ "METHOD_INST_FULL_NAME", "TYPE_FULL_NAME"]
+      "keys": [ "METHOD_INST_FULL_NAME"]
     }
   ]
 }


### PR DESCRIPTION
It was put there by accident.