### PR TITLE
restore ANY type in fuzzyC2cpg

### DIFF
--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NodeTypeStartersTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NodeTypeStartersTests.scala
@@ -66,7 +66,7 @@ class NodeTypeStartersTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should allow retrieving (used) types" in {
-    cpg.typ.name.toSet shouldBe Set("int", "void", "char * *")
+    cpg.typ.name.toSet shouldBe Set("ANY", "int", "void", "char * *")
   }
 
   "should allow retrieving namespaces" in {

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
@@ -898,6 +898,7 @@ private[astcreation] class AstCreator(diffGraph: DiffGraph.Builder,
       .dispatchType(DispatchTypes.STATIC_DISPATCH.name())
       .signature("TODO")
       .methodFullName(methodName)
+      .typeFullName(registerType(Defines.anyTypeName))
       .code(astNode.getEscapedCodeStr)
       .order(context.childNum)
       .argumentIndex(context.childNum)


### PR DESCRIPTION
https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1111 broke dataflow display in ocular/codescience. This restores the required type information.

Generally, we should maybe consider enabling the existing unit tests in codescience for this in CI. I'm not saying that the disabled tests are useless -- they allowed rapid bisecting of the issue -- but it would have been even better to catch the problem early, or even before merging.

Related issue https://github.com/ShiftLeftSecurity/product/issues/7017