### PR TITLE
fix intellij / bsp build: remove the baseDirectory setting

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/ProjectRoot.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/ProjectRoot.scala
@@ -1,0 +1,30 @@
+package io.shiftleft.utils
+
+import better.files.File
+
+/**
+  * Finds the relative location of the project root.
+  *
+  * Used in tests which rely on the working directory - unfortunately Intellij and sbt have different default working
+  * directories for executing tests from subprojects: while sbt defaults to the project root, intellij defaults to
+  * the subproject.
+  *
+  * Previously a consistent behaviour was achieved by setting
+  * `Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value`,
+  * however that broke the bsp build within Intellij - it simply wouldn't recognise subprojects with this setting
+  * any more.
+  */
+object ProjectRoot {
+
+  def relativise(path: String): String =
+    s"$findRelativePath/$path"
+
+  def findRelativePath: String = {
+    val fileThatOnlyExistsInRoot = ".git"
+
+    if (File(fileThatOnlyExistsInRoot).exists) "."
+    else if (File(s"../$fileThatOnlyExistsInRoot").exists) ".."
+    else ???
+  }
+
+}

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.codepropertygraph.cpgloading
 
+import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.Config
@@ -14,7 +15,7 @@ import java.nio.file.FileSystemNotFoundException
   * */
 class CpgLoaderTests extends AnyWordSpec with Matchers {
 
-  val filename = "resources/testcode/cpgs/hello-shiftleft-0.0.5/cpg.bin.zip"
+  val filename = ProjectRoot.relativise("resources/testcode/cpgs/hello-shiftleft-0.0.5/cpg.bin.zip")
 
   "CpgLoader" should {
 

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -70,6 +70,3 @@ libraryDependencies ++= Seq(
 )
 
 publishArtifact in (Test, packageBin) := true
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/console/src/test/scala/io/shiftleft/console/PluginManagerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/PluginManagerTests.scala
@@ -2,6 +2,7 @@ package io.shiftleft.console
 
 import better.files.Dsl._
 import better.files._
+import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -16,12 +17,12 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
     }
 
     "not crash if file isn't a valid zip" in Fixture() { manager =>
-      val testZipFileName = "console/src/test/resources/nonzip.zip"
+      val testZipFileName = ProjectRoot.relativise("console/src/test/resources/nonzip.zip")
       manager.add(testZipFileName)
     }
 
     "copy jar files in zip to plugin dir" in Fixture() { manager =>
-      val testZipFileName = "console/src/test/resources/test.zip"
+      val testZipFileName = ProjectRoot.relativise("console/src/test/resources/test.zip")
       manager.add(testZipFileName)
       manager.pluginDir match {
         case Some(dir) =>
@@ -31,7 +32,7 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
     }
 
     "copy schema file in zip to schema dir and execute schema extender" in Fixture() { manager =>
-      val testZipFileName = "console/src/test/resources/test.zip"
+      val testZipFileName = ProjectRoot.relativise("console/src/test/resources/test.zip")
       manager.add(testZipFileName)
       manager.schemaDir match {
         case Some(dir) =>
@@ -50,7 +51,7 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
     }
 
     "remove existing plugin" in Fixture() { manager =>
-      val testZipFileName = "console/src/test/resources/test.zip"
+      val testZipFileName = ProjectRoot.relativise("console/src/test/resources/test.zip")
       manager.add(testZipFileName)
       manager.rm("test").map(x => File(x).name).toSet shouldBe Set("joernext-test-foo.jar", "joernext-test-foo.json")
       manager.listPlugins() shouldBe List()
@@ -68,7 +69,7 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
     }
 
     "display plugin after adding it" in Fixture() { manager =>
-      val testZipFileName = "console/src/test/resources/test.zip"
+      val testZipFileName = ProjectRoot.relativise("console/src/test/resources/test.zip")
       manager.add(testZipFileName)
       manager.listPlugins() shouldBe List("test")
     }

--- a/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.console.scripting
 
-import better.files.File
 import cats.effect.IO
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.console.scripting.ScriptManager.{ScriptCollections, ScriptDescription, ScriptDescriptions}
+import io.shiftleft.utils.ProjectRoot
 import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -28,13 +28,7 @@ class ScriptManagerTest extends AnyWordSpec with Matchers with Inside {
 
   private object TestScriptManager extends ScriptManager(TestScriptExecutor)
 
-  protected val DEFAULT_CPG_NAME: String = {
-    if (File(".").name == "console") {
-      (File("..") / "resources" / "testcode" / "cpgs" / "method" / "cpg.bin.zip").pathAsString
-    } else {
-      (File("resources") / "testcode" / "cpgs" / "method" / "cpg.bin.zip").pathAsString
-    }
-  }
+  protected val DEFAULT_CPG_NAME = ProjectRoot.relativise("resources/testcode/cpgs/method/cpg.bin.zip")
 
   def withScriptManager(f: ScriptManager => Unit): Unit = {
     f(TestScriptManager)

--- a/cpgvalidator/build.sbt
+++ b/cpgvalidator/build.sbt
@@ -10,6 +10,3 @@ libraryDependencies ++= Seq(
   "com.typesafe.play"        %% "play-json"       % "2.7.4",
   "org.scalatest"            %% "scalatest"       % Versions.scalatest % Test
 )
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/FactsImporter.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/FactsImporter.scala
@@ -7,8 +7,7 @@ import play.api.libs.json.{JsValue, Json}
 abstract class FactsImporter {
 
   protected lazy val cpgJson: JsValue =
-    File(ProjectRoot.relativise("schema/target/scala-2.13/src_managed/main/cpg.json"))
-      .fileInputStream
+    File(ProjectRoot.relativise("schema/target/scala-2.13/src_managed/main/cpg.json")).fileInputStream
       .map(Json.parse)
       .get()
 

--- a/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/FactsImporter.scala
+++ b/cpgvalidator/src/main/scala/io/shiftleft/cpgvalidator/facts/FactsImporter.scala
@@ -1,15 +1,16 @@
 package io.shiftleft.cpgvalidator.facts
 
+import better.files.File
+import io.shiftleft.utils.ProjectRoot
 import play.api.libs.json.{JsValue, Json}
-
-import java.io.FileInputStream
 
 abstract class FactsImporter {
 
   protected lazy val cpgJson: JsValue =
-    Json.parse(
-      new FileInputStream("./schema/target/scala-2.13/src_managed/main/cpg.json")
-    )
+    File(ProjectRoot.relativise("schema/target/scala-2.13/src_managed/main/cpg.json"))
+      .fileInputStream
+      .map(Json.parse)
+      .get()
 
   def loadFacts: List[FactConstructionClasses.Fact]
 

--- a/dataflowengineoss-tests/build.sbt
+++ b/dataflowengineoss-tests/build.sbt
@@ -18,6 +18,3 @@ scalacOptions in (Compile, doc) ++= Seq(
 
 compile / javacOptions ++= Seq("-g") //debug symbols
 publishArtifact in (Test, packageBin) := true
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/dataflowengineoss/build.sbt
+++ b/dataflowengineoss/build.sbt
@@ -15,6 +15,3 @@ Antlr4 / antlr4PackageName := Some("io.shiftleft.dataflowengineoss")
 Antlr4 / antlr4Version := Versions.antlr
 Antlr4 / javaSource := (sourceManaged in Compile).value
 sources in (Compile, doc) ~= (_ filter (_ => false))
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/fuzzyc2cpg-tests/build.sbt
+++ b/fuzzyc2cpg-tests/build.sbt
@@ -19,6 +19,3 @@ scalacOptions in (Compile, doc) ++= Seq(
 
 compile / javacOptions ++= Seq("-g") //debug symbols
 publishArtifact in (Test, packageBin) := true
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/fuzzyc2cpg-tests/build.sbt
+++ b/fuzzyc2cpg-tests/build.sbt
@@ -1,7 +1,7 @@
 name := "fuzzyc2cpg-tests"
 
 dependsOn(Projects.semanticcpg,
-          Projects.fuzzyc2cpg % Test,
+          Projects.fuzzyc2cpg,
           Projects.dataflowengineoss % Test,
           Projects.semanticcpgtests % "compile->compile; test->test"
 )

--- a/fuzzyc2cpg/build.sbt
+++ b/fuzzyc2cpg/build.sbt
@@ -64,6 +64,3 @@ Antlr4 / antlr4Version := Versions.antlr
 Antlr4 / javaSource := (sourceManaged in Compile).value
 
 enablePlugins(JavaAppPackaging)
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/CpgTestFixture.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/CpgTestFixture.scala
@@ -5,13 +5,14 @@ import io.shiftleft.fuzzyc2cpg.passes.{AstCreationPass, CMetaDataPass, StubRemov
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.{CfgCreationPass, FileCreationPass}
+import io.shiftleft.utils.ProjectRoot
 import io.shiftleft.x2cpg.SourceFiles
 import overflowdb.traversal.TraversalSource
 
 case class CpgTestFixture(projectName: String) {
 
   val cpg: Cpg = Cpg.emptyCpg
-  val dirName = String.format("fuzzyc2cpg/src/test/resources/testcode/%s", projectName)
+  val dirName = ProjectRoot.relativise(s"fuzzyc2cpg/src/test/resources/testcode/$projectName")
   val keyPoolFile1 = new IntervalKeyPool(1001, 2000)
   val cfgKeyPool = new IntervalKeyPool(2001, 3000)
   val filenames = SourceFiles.determine(Set(dirName), Set(".c"))

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -10,6 +10,3 @@ libraryDependencies ++= Seq(
 )
 
 publishArtifact in (Test, packageBin) := true
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.4.9

--- a/semanticcpg-tests/build.sbt
+++ b/semanticcpg-tests/build.sbt
@@ -15,6 +15,3 @@ scalacOptions in (Compile, doc) ++= Seq(
 
 compile / javacOptions ++= Seq("-g") //debug symbols
 publishArtifact in (Test, packageBin) := true
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value

--- a/semanticcpg/build.sbt
+++ b/semanticcpg/build.sbt
@@ -16,6 +16,3 @@ scalacOptions in (Compile, doc) ++= Seq(
 
 compile / javacOptions ++= Seq("-g") //debug symbols
 publishArtifact in (Test, packageBin) := true
-
-// execute tests in root project so that they work in sbt *and* intellij
-Test / baseDirectory := (ThisBuild / Test / run / baseDirectory).value


### PR DESCRIPTION
This innocent-looking setting made intellij choke on the subprojects and
didn't recognise them as scala projects properly. Unfortunately this
setting was necessary because intellij and sbt have different default
working directories for executing tests. 

This PR uses a hack to achieve the same: it looks for a file that (hopefully always)
only be in the project root. If the current working dir doesn't contain that file,
we must be in a subproject, and will therefor navigate up one directory.
Turns out: this same technique was already applied in ScriptManagerTest.scala before - someone else has a knack for hacks

And just to motivate why BSP is a good idea: it ensures that Intellij and sbt share the compiled classes etc., so we don't need to compile twice, with potentially different results. Initial import is also much faster. 

All tests from within Intellij seem to be green.