### PR TITLE
Adjusting file extensions to the default values

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -20,7 +20,7 @@ case class FuzzyCCpgGenerator(config: FuzzyCFrontendConfig, rootPath: Path) exte
                         outputPath: String = "cpg.bin.zip",
                         namespaces: List[String] = List()): Option[String] = {
     val fuzzyc = new FuzzyC2Cpg()
-    val cpg = fuzzyc.runAndOutput(Set(inputPath), Set(".c"), Some(outputPath))
+    val cpg = fuzzyc.runAndOutput(Set(inputPath), Set(".c", ".cc", ".cpp", ".h", ".hpp"), Some(outputPath))
     cpg.close()
     Some(outputPath)
   }


### PR DESCRIPTION
Adjusting the file extensions to the default of joern-parse (and fuzzyc2cpg.sh)
```
  --source-file-ext <value>
                           source file extensions to include when gathering source files. Defaults are .c, .cc, .cpp, .h and .hpp
```
