### PR TITLE
Remove `sbt` installation.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,8 +18,6 @@ jobs:
       run: sudo apt-get update
     - name: Set up JDK 1.8
       run: sudo apt-get install openjdk-8-jdk
-    - name: Install specific sbt version
-      run: sudo apt-get install -y --allow-downgrades sbt=1.3.12
     - name: Print sbt version
       run: sbt --version
     - name: Compile and run tests


### PR DESCRIPTION
Because it's already present on the system.

C.f. <https://github.com/actions/virtual-environments/issues/2944#issuecomment-802860627> and <https://github.com/actions/virtual-environments/pull/2983/files>.