### PR TITLE
Fix bug in param handling of data flow engine

### DIFF
--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotDdgGeneratorTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotDdgGeneratorTests.scala
@@ -23,7 +23,7 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       implicit val s = semantics
       val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
       lines.head.startsWith("digraph foo") shouldBe true
-      lines.count(x => x.contains("->")) shouldBe 31
+      lines.count(x => x.contains("->")) shouldBe 32
       lines.last.startsWith("}") shouldBe true
     }
   }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CDataFlowTests.scala
@@ -968,3 +968,22 @@ class CDataFlowTests31 extends DataFlowCodeToCpgSuite {
       .count(_.inNode() == cpg.ret.head) shouldBe 1
   }
 }
+
+class CDataFlowTests32 extends DataFlowCodeToCpgSuite {
+  override val code =
+    """
+       void f(int x, int y)
+        {
+          g(x, y);
+        }
+    """
+
+  "Test 32: should find flow from outer params to inner params" in {
+    implicit val s: Semantics = semantics
+    def source = cpg.method.name("f").parameter
+    def sink = cpg.method.name("g").parameter
+    sink.size shouldBe 2
+    source.size shouldBe 2
+    sink.reachableBy(source).size shouldBe 4
+  }
+}


### PR DESCRIPTION
Previously, when looking for flows from parameters, only flows from the last parameter were taken into account due to a logic bug in the data flow engine: the flow graph we considered had method parameters wired "in parallel" as opposed to in sequence and since we terminate when one path is found, we'll only ever find the one to the last parameter. This is fixed now.