### PR TITLE
Re-added Hash Property to Method

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -454,7 +454,8 @@ object Base {
                      lineNumberEnd,
                      columnNumberEnd,
                      order,
-                     filename)
+                     filename,
+                     hash)
       .extendz(declaration, cfgNode, astNode)
 
     val methodParameterIn: NodeType = builder


### PR DESCRIPTION
Somewhere along the line the change introduced by PR #1148 was lost. This is important to Plume for its incremental updates as described here: https://plume-oss.github.io/plume-docs/plume-basics/incremental/. This PR re-introduces the `hash` property to methods.