### PR TITLE
No more dependence on proto CPG blobs

### DIFF
--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/TestProtoCpg.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/TestProtoCpg.scala
@@ -1,0 +1,42 @@
+package io.shiftleft.codepropertygraph.cpgloading
+
+import better.files.File
+import io.shiftleft.proto.cpg.Cpg
+import io.shiftleft.proto.cpg.Cpg.CpgStruct
+
+import java.io.FileOutputStream
+
+object TestProtoCpg {
+
+  def createTestProtoCpg: File = {
+    val outDir = better.files.File.newTemporaryDirectory("cpgloadertests")
+    val outStream = new FileOutputStream((outDir / "1.proto").pathAsString)
+    CpgStruct
+      .newBuilder()
+      .addNode(
+        CpgStruct.Node
+          .newBuilder()
+          .setKey(1)
+          .setType(CpgStruct.Node.NodeType.valueOf("METHOD"))
+          .addProperty(
+            CpgStruct.Node.Property
+              .newBuilder()
+              .setName(Cpg.NodePropertyName.valueOf("FULL_NAME"))
+              .setValue(Cpg.PropertyValue
+                .newBuilder()
+                .setStringValue("foo")
+                .build())
+              .build
+          )
+          .build())
+      .build()
+      .writeTo(outStream)
+    outStream.close()
+
+    val zipFile = better.files.File.newTemporaryFile("cpgloadertests", ".bin.zip")
+    outDir.zipTo(zipFile)
+    outDir.delete()
+    zipFile
+  }
+
+}

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -2,7 +2,7 @@ name := "console"
 
 enablePlugins(JavaAppPackaging)
 
-dependsOn(Projects.codepropertygraph,
+dependsOn(Projects.codepropertygraph % "compile ->compile; test -> test",
           Projects.semanticcpg,
           Projects.macros,
           Projects.fuzzyc2cpg)

--- a/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
@@ -2,17 +2,29 @@ package io.shiftleft.console.scripting
 
 import cats.effect.IO
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.cpgloading.TestProtoCpg
 import io.shiftleft.console.scripting.ScriptManager.{ScriptCollections, ScriptDescription, ScriptDescriptions}
-import io.shiftleft.utils.ProjectRoot
-import org.scalatest.Inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{BeforeAndAfterAll, Inside}
 
 import java.nio.file.{FileSystemNotFoundException, NoSuchFileException, Path}
 import scala.io.Source
 import scala.util.Try
 
-class ScriptManagerTest extends AnyWordSpec with Matchers with Inside {
+class ScriptManagerTest extends AnyWordSpec with Matchers with Inside with BeforeAndAfterAll {
+
+  var zipFile: better.files.File = _
+  protected var DEFAULT_CPG_NAME: String = _
+
+  override def beforeAll(): Unit = {
+    zipFile = TestProtoCpg.createTestProtoCpg
+    DEFAULT_CPG_NAME = zipFile.pathAsString
+  }
+
+  override def afterAll(): Unit = {
+    zipFile.delete()
+  }
 
   private object TestScriptExecutor extends AmmoniteExecutor {
     override protected def predef: String = ""
@@ -27,8 +39,6 @@ class ScriptManagerTest extends AnyWordSpec with Matchers with Inside {
   }
 
   private object TestScriptManager extends ScriptManager(TestScriptExecutor)
-
-  protected val DEFAULT_CPG_NAME = ProjectRoot.relativise("resources/testcode/cpgs/method/cpg.bin.zip")
 
   def withScriptManager(f: ScriptManager => Unit): Unit = {
     f(TestScriptManager)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
 // TODO: switch to addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 // This version is ancient and not supported
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
-// addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "2.0.13")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"   % "1.3.5")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.5")
 // TODO: switch to addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 // This version is ancient and not supported
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
-addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
+// addSbtPlugin("com.github.sbt" % "sbt-findbugs" % "2.0.0")
 addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "2.0.13")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.1.0")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager"   % "1.3.5")

--- a/resources/testcode/cpgs/hello-shiftleft-0.0.5/cpg.bin.zip
+++ b/resources/testcode/cpgs/hello-shiftleft-0.0.5/cpg.bin.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74f4073018634fb22db24d439c3e8951ec82400acb9f9a4d63a6a09d856df056
-size 603902

--- a/resources/testcode/cpgs/method/cpg.bin.zip
+++ b/resources/testcode/cpgs/method/cpg.bin.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9dd00a0d5bf313c6cb089ac80f67a04d147fb1f2a4843b11934ea86779633b02
-size 22827


### PR DESCRIPTION
There were still a few tests left that relied on proto CPG blobs generated by java2cpg. Replaced them with fake CPGs generated at test time. This is a prerequisite for a CPG spec cleanup I'm doing.