### PR TITLE
don't handle schema extensions in plugin manager any more

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/PluginManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/PluginManager.scala
@@ -77,10 +77,6 @@ class PluginManager(val installDir: File) {
         dir.list.filter { f =>
           f.name.startsWith(s"joernext-$name")
         }
-      }.flatMap { dir =>
-        dir.list.filter { f =>
-          f.name.startsWith(s"joernext-$name")
-        }
       }
       filesToRemove.foreach(f => f.delete())
       filesToRemove.map(_.pathAsString)

--- a/console/src/main/scala/io/shiftleft/console/PluginManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/PluginManager.scala
@@ -4,7 +4,6 @@ import better.files.File
 import better.files.File.apply
 
 import java.nio.file.Path
-import scala.sys.process.Process
 import scala.util.{Failure, Success, Try}
 
 /**

--- a/console/src/main/scala/io/shiftleft/console/PluginManager.scala
+++ b/console/src/main/scala/io/shiftleft/console/PluginManager.scala
@@ -56,31 +56,6 @@ class PluginManager(val installDir: File) {
         }
       }
     }
-    installSchemaExtensions(file, pluginName)
-  }
-
-  private def installSchemaExtensions(file: File, pluginName: String): Unit = {
-    val copyOps = schemaDir.toList.flatMap { sDir =>
-      file.listRecursively.toList
-        .filter(_.path.toString.contains("schema"))
-        .filter(_.name.endsWith(".json"))
-        .map { json =>
-          val name = json.name
-          val dstFileName = s"joernext-$pluginName-$name"
-          cp(json, sDir / dstFileName)
-          json
-        }
-    }
-
-    if (copyOps.nonEmpty) {
-      println("Plugin modifies the schema. Running schema extender.")
-      try {
-        Process("./schema-extender.sh", installDir.toJava).!!
-      } catch {
-        case e: Exception =>
-          System.err.println(s"Error running schema-extender: ${e.getMessage}")
-      }
-    }
   }
 
   private def extractToTemporaryDir(file: File) = {
@@ -102,7 +77,7 @@ class PluginManager(val installDir: File) {
         dir.list.filter { f =>
           f.name.startsWith(s"joernext-$name")
         }
-      } ++ schemaDir.toList.flatMap { dir =>
+      }.flatMap { dir =>
         dir.list.filter { f =>
           f.name.startsWith(s"joernext-$name")
         }
@@ -118,16 +93,6 @@ class PluginManager(val installDir: File) {
       Some(pathToPluginDir)
     } else {
       println(s"Plugin directory at $pathToPluginDir does not exist")
-      None
-    }
-  }
-
-  def schemaDir: Option[Path] = {
-    val pathToSchemaDir = installDir.path.resolve("schema-extender/schemas/")
-    if (pathToSchemaDir.toFile.exists()) {
-      Some(pathToSchemaDir)
-    } else {
-      println(s"Schema directory at $pathToSchemaDir does not exist")
       None
     }
   }

--- a/console/src/test/scala/io/shiftleft/console/PluginManagerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/PluginManagerTests.scala
@@ -42,10 +42,10 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
     "remove existing plugin" in Fixture() { manager =>
       val testZipFileName = ProjectRoot.relativise("console/src/test/resources/test.zip")
       manager.add(testZipFileName)
-      manager.rm("test").map(x => File(x).name).toSet shouldBe Set("joernext-test-foo.jar", "joernext-test-foo.json")
+      manager.rm("test").map(x => File(x).name).toSet shouldBe Set("joernext-test-foo.jar")
       manager.listPlugins() shouldBe List()
       manager.add(testZipFileName)
-      manager.rm("test").map(x => File(x).name).toSet shouldBe Set("joernext-test-foo.jar", "joernext-test-foo.json")
+      manager.rm("test").map(x => File(x).name).toSet shouldBe Set("joernext-test-foo.jar")
       manager.listPlugins() shouldBe List()
     }
 

--- a/console/src/test/scala/io/shiftleft/console/PluginManagerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/PluginManagerTests.scala
@@ -31,17 +31,6 @@ class PluginManagerTests extends AnyWordSpec with Matchers {
       }
     }
 
-    "copy schema file in zip to schema dir and execute schema extender" in Fixture() { manager =>
-      val testZipFileName = ProjectRoot.relativise("console/src/test/resources/test.zip")
-      manager.add(testZipFileName)
-      manager.schemaDir match {
-        case Some(dir) =>
-          dir.toFile.list().toList shouldBe List("joernext-test-foo.json")
-          (manager.installDir / "out.txt").exists shouldBe true
-        case None => fail()
-      }
-    }
-
   }
 
   "PluginManager::rm" should {


### PR DESCRIPTION
This one may be controversial, so let me explain:
We used to define the schema in json, which meant we didn't have any
IDE and compiler support. Now that it's a Scala DSL we're in a much
better situation overall, however we cannot simply copy and merge
schema parts together by copying a json file. The schema needs to be
stitched together at compile time.

Now we could allow plugins to define their schema extension parts in
scala code snippets and copy them together during `./joern
--add-plugin` - this is pretty much what I wanted to achieve in
https://github.com/joernio/docker-ext/pull/9/ - the downside is that
we lose IDE/compiler support during plugin development...

tl;dr; there's different options/pros/cons, and we may find a better
model in the future, but for now I think this is the best compromise
with the new improved schema DSL.

I should add: the responsibility to create new domain classes and install them into joern now lies with the plugin itself - we can extract that logic into an sbt plugin later.