### PR TITLE
Bring back in TYPE_FULL_NAME on CALL nodes.

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -499,7 +499,7 @@ object Base {
         comment = "A (method)-call"
       )
       .protoId(15)
-      .addProperties(methodFullName)
+      .addProperties(methodFullName, typeFullName)
       .extendz(expression, callRepr)
 
     val local: NodeType = builder


### PR DESCRIPTION
This was once accedidentially put to deprecated and in the resent past
remove while transitioning to scala base schema.