### PR TITLE
bring back unused dataflow args

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -3,6 +3,7 @@ package io.shiftleft.dataflowengineoss.layers.dataflows
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengineoss.passes.reachingdef.ReachingDefPass
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+
 import scala.annotation.nowarn
 
 object OssDataFlow {

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -3,6 +3,7 @@ package io.shiftleft.dataflowengineoss.layers.dataflows
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengineoss.passes.reachingdef.ReachingDefPass
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
+import scala.annotation.nowarn
 
 object OssDataFlow {
   val overlayName: String = "dataflowOss"
@@ -13,7 +14,8 @@ object OssDataFlow {
 
 class OssDataFlowOptions() extends LayerCreatorOptions {}
 
-class OssDataFlow extends LayerCreator {
+@nowarn
+class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
   override val description: String = OssDataFlow.description

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -3,7 +3,7 @@ package io.shiftleft.fuzzyc2cpg.testfixtures
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes
 import io.shiftleft.dataflowengineoss.language._
-import io.shiftleft.dataflowengineoss.layers.dataflows.OssDataFlow
+import io.shiftleft.dataflowengineoss.layers.dataflows.{OssDataFlow, OssDataFlowOptions}
 import io.shiftleft.dataflowengineoss.queryengine.EngineContext
 import io.shiftleft.dataflowengineoss.semanticsloader.{Parser, Semantics}
 import io.shiftleft.semanticcpg.language._
@@ -34,7 +34,9 @@ class DataFlowCodeToCpgSuite extends FuzzyCCodeToCpgSuite {
   override def passes(cpg: Cpg): Unit = {
     val context = new LayerCreatorContext(cpg)
     new Scpg().run(context)
-    new OssDataFlow().run(context)
+
+    val options = new OssDataFlowOptions()
+    new OssDataFlow(options).run(context)
   }
 
   protected implicit def int2IntegerOption(x: Int): Option[Integer] =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -21,6 +21,7 @@ import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.semanticcpg.passes.receiveredges.ReceiverEdgePass
 import io.shiftleft.semanticcpg.passes.trim.TrimPass
 import io.shiftleft.semanticcpg.passes.{BindingMethodOverridesPass, CfgCreationPass, FileCreationPass}
+
 import scala.annotation.nowarn
 
 object Scpg {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -21,6 +21,7 @@ import io.shiftleft.semanticcpg.passes.namespacecreator.NamespaceCreator
 import io.shiftleft.semanticcpg.passes.receiveredges.ReceiverEdgePass
 import io.shiftleft.semanticcpg.passes.trim.TrimPass
 import io.shiftleft.semanticcpg.passes.{BindingMethodOverridesPass, CfgCreationPass, FileCreationPass}
+import scala.annotation.nowarn
 
 object Scpg {
   val overlayName: String = "semanticcpg"
@@ -29,7 +30,8 @@ object Scpg {
   def defaultOpts = new LayerCreatorOptions()
 }
 
-class Scpg extends LayerCreator {
+@nowarn
+class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
 
   override val overlayName: String = Scpg.overlayName
   override val description: String = Scpg.description


### PR DESCRIPTION
to greenify joern

these were removed in 
https://github.com/ShiftLeftSecurity/codepropertygraph/commit/db005677184dd13eedd02803a7f878d42d96d406#diff-be302942d0bda197bf22d4b67e474601196c47e64e4d9e3ea1e257dad3056e89L16, 
however on second thought I guess there was reason they were there.