### PR TITLE
bring in overflowdb dependencyTree via codepropertygraph

### DIFF
--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -3,6 +3,7 @@ name := "codepropertygraph"
 dependsOn(Projects.protoBindings, Projects.domainClasses)
 
 libraryDependencies ++= Seq(
+  "io.shiftleft" %% "overflowdb-traversal" % Versions.overflowdb,
   "com.github.pathikrit"     %% "better-files"         % "3.9.1",
   "org.scala-lang.modules"   %% "scala-java8-compat"   % "0.9.0",
   "org.slf4j"                %  "slf4j-api"            % "1.7.30",


### PR DESCRIPTION
otherwise, for reasons :tm:, the universal plugin (used for staging)
drops overflowdb from the classpath, if e.g. cpg-domain-classes are
excluded