### PR TITLE
fix classCast exceptions for implicit calls in callgraphExtensions

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -46,7 +46,7 @@ class Method(val traversal: Traversal[nodes.Method]) extends AnyVal {
     * Incoming call sites
     * */
   def callIn(implicit callResolver: ICallResolver): Traversal[nodes.Call] =
-    traversal.flatMap(method => callResolver.getMethodCallsitesAsTraversal(method).cast[nodes.Call])
+    traversal.flatMap(method => callResolver.getMethodCallsitesAsTraversal(method).collectAll[nodes.Call])
 
   /**
     * Traverse to direct and transitive callers of the method.
@@ -73,6 +73,6 @@ class Method(val traversal: Traversal[nodes.Method]) extends AnyVal {
     * */
   @Doc("Call sites (outgoing calls)")
   def call: Traversal[nodes.Call] =
-    traversal.out(EdgeTypes.CONTAINS).hasLabel(NodeTypes.CALL).cast[nodes.Call]
+    traversal.out(EdgeTypes.CONTAINS).collectAll[nodes.Call]
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/Method.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.callgraphextension
 
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.help.Doc
 import overflowdb.traversal.{PathAwareTraversal, Traversal}


### PR DESCRIPTION
Per interface, the call resolver returns `CallRepr`; however, we simply cast this to `Call` in `someMethod.call`. It is possible to get other `CallRepr` here, namely `ImplicitCall` and `PostExecutionCall`. These then lead to a ClassCastException.

This interface mismatch is somewhat unfortunate. The immediate way forward is to just silently swallow other callRepr here, because typical users (ourselves in framework passes and scripts) of the extension methods are unprepared to deal with other CallRepr. Sufficiently sophisticated users (ourselves when working on core engine stuff) who want to deal with the fancy CallRepr subtypes can use the direct API of the CallResolver.

This should fix https://github.com/ShiftLeftSecurity/product/issues/7632 and should obsolete https://github.com/ShiftLeftSecurity/codescience/pull/5017 (but kudos to @mpollmeier for the super fast workaround!)

This is an alternative to https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1220