### PR TITLE
Add `code` field to `AST_NODE`

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -47,7 +47,7 @@ object Ast extends SchemaBase {
                     |while in the right-most sibling, it is set to n-1 where n is the number of siblings.
                     |""".stripMargin
       )
-      .addProperties(order)
+      .addProperties(order, code)
 
     val callRepr = builder
       .addNodeBaseType(

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/ControlFlowGraph.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/ControlFlowGraph.scala
@@ -24,7 +24,7 @@ object ControlFlowGraph extends SchemaBase {
         name = "CFG_NODE",
         comment = "Any node that can occur as part of a control flow graph"
       )
-      .addProperties(lineNumber, columnNumber, code)
+      .addProperties(lineNumber, columnNumber)
       .extendz(withinMethod, astNode)
 
     // Method and MethodReturn nodes are used as ENTRY and EXIT nodes respectively

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -71,7 +71,7 @@ object Method extends SchemaBase {
         comment = "This node represents a formal parameter going towards the callee side"
       )
       .protoId(34)
-      .addProperties(code, typeFullName, lineNumber, columnNumber)
+      .addProperties(typeFullName, lineNumber, columnNumber)
       .extendz(declaration, localLike, trackingPoint)
 
     val methodParameterOut: NodeType = builder
@@ -80,7 +80,7 @@ object Method extends SchemaBase {
         comment = "This node represents a formal output parameter. It does not need to be created by the frontend."
       )
       .protoId(33)
-      .addProperties(code, typeFullName, lineNumber, columnNumber)
+      .addProperties(typeFullName, lineNumber, columnNumber)
       .extendz(declaration, trackingPoint)
 
     val local: NodeType = builder
@@ -89,7 +89,7 @@ object Method extends SchemaBase {
         comment = "A local variable"
       )
       .protoId(23)
-      .addProperties(code, typeFullName, lineNumber, columnNumber)
+      .addProperties(typeFullName, lineNumber, columnNumber)
       .extendz(declaration, localLike)
 
     val methodReturn: NodeType = builder

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/TypeDecl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/TypeDecl.scala
@@ -85,7 +85,7 @@ object TypeDecl extends SchemaBase {
         comment = "Member of a class struct or union"
       )
       .protoId(9)
-      .addProperties(code, typeFullName)
+      .addProperties(typeFullName)
       .extendz(declaration)
 
     val typeParameter: NodeType = builder


### PR DESCRIPTION
Bringing in the spec cleanup in small steps now in order to see which parts are causing trouble downstream. This PR adds a `code` field to the `AST_NODE` base class.