### PR TITLE
cache hashes of accesspaths; keep exclusions of accesspaths sorted

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessElement.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessElement.scala
@@ -1,19 +1,40 @@
 package io.shiftleft.semanticcpg.accesspath
 
-sealed abstract class AccessElement(name: String) {
+sealed abstract class AccessElement(name: String) extends Comparable[AccessElement] {
   override def toString: String = name
+  def kind: Int
+  override def hashCode(): Int = kind + name.hashCode
+
+  override def compareTo(other: AccessElement): Int = {
+    this.kind.compareTo(other.kind) match {
+      case 0         => this.name.compareTo(other.toString)
+      case different => different
+    }
+  }
 }
 
-case class ConstantAccess(constant: String) extends AccessElement(constant)
+case class ConstantAccess(constant: String) extends AccessElement(constant) {
+  override def kind: Int = 0x01010101
+}
 
-case object VariableAccess extends AccessElement("?")
+case object VariableAccess extends AccessElement("?") {
+  override def kind: Int = 0x02020202
+}
 
-case object VariablePointerShift extends AccessElement("<?>")
+case object VariablePointerShift extends AccessElement("<?>") {
+  override def kind: Int = 0x03030303
+}
 
 // this will eventually get an optional extent (how many bytes wide is the memory load/store)
-case object IndirectionAccess extends AccessElement("*")
+case object IndirectionAccess extends AccessElement("*") {
+  override def kind: Int = 0x04040404
+}
 
-case object AddressOf extends AccessElement("&")
+case object AddressOf extends AccessElement("&") {
+  override def kind: Int = 0x05050505
+}
 
 // this will eventually obtain an optional byteOffset
-case class PointerShift(logicalOffset: Int) extends AccessElement(s"<${logicalOffset}>")
+case class PointerShift(logicalOffset: Int) extends AccessElement(s"<${logicalOffset}>") {
+  override def kind: Int = 0x06060606
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPath.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/accesspath/AccessPath.scala
@@ -51,10 +51,9 @@ object AccessPath {
       val nElements = el.elements.length - 1
       while (nElements - i > -1) {
         el.elements(nElements - i) match {
-          case (AddressOf | VariablePointerShift | _: PointerShift) =>
+          case (AddressOf | VariablePointerShift | _: PointerShift) => i += 1
           case _                                                    => return i
         }
-        i += 1
       }
       i
     }


### PR DESCRIPTION
The caching of accesspath hashes gives > 5% speedup on dataflow heavy loads (cumulative to https://github.com/ShiftLeftSecurity/overflowdb/pull/194).

It is also saves some expansions (more context merges) in the closed source tracker; and it is a useful preparation for OVERRIDE/PRESERVE handling of policies.