### PR TITLE
Remove mentions of `ImplicitCall` and `PostExecutionCall`...

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -61,8 +61,7 @@ object DotSerializer {
         node.method.methodReturn
       case node: nodes.Call if MemberAccess.isGenericMemberAccessName(node.name) =>
         node.parentExpression.get
-      case node: nodes.Call         => node
-      case node: nodes.ImplicitCall => node
+      case node: nodes.CallRepr     => node
       case node: nodes.MethodReturn => node
       case node: nodes.Expression   => node
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/LocationCreator.scala
@@ -49,29 +49,13 @@ object LocationCreator {
           methodReturn.lineNumber,
           methodReturn.method
         )
-      case call: nodes.Call =>
+      case call: nodes.CallRepr =>
         apply(
           call,
           call.code,
           call.label,
           call.lineNumber,
           call.method
-        )
-      case implicitCall: nodes.ImplicitCall =>
-        apply(
-          implicitCall,
-          implicitCall.code,
-          implicitCall.label,
-          implicitCall.lineNumber,
-          implicitCall.method
-        )
-      case postExecutionCall: nodes.PostExecutionCall =>
-        apply(
-          postExecutionCall,
-          postExecutionCall.code,
-          postExecutionCall.label,
-          postExecutionCall.lineNumber,
-          postExecutionCall.method
         )
       case method: nodes.Method =>
         apply(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -12,10 +12,10 @@ class CfgNodeMethods(val node: nodes.CfgNode) extends AnyVal {
     * */
   def repr: String =
     node match {
-      case method: nodes.MethodBase             => method.name
-      case methodReturn: nodes.MethodReturnBase => methodReturn.code
-      case expr: nodes.Expression               => expr.code
-      case call: nodes.ImplicitCallBase         => call.code
+      case method: nodes.MethodBase                               => method.name
+      case methodReturn: nodes.MethodReturnBase                   => methodReturn.code
+      case expr: nodes.Expression                                 => expr.code
+      case call: nodes.CallRepr if !call.isInstanceOf[nodes.Call] => call.code
     }
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/WithinMethodMethods.scala
@@ -6,10 +6,10 @@ import io.shiftleft.codepropertygraph.generated.nodes
 class WithinMethodMethods(val node: nodes.WithinMethod) extends AnyVal {
   def method: nodes.Method = node match {
     case node: nodes.Method => node
-    case _: nodes.MethodParameterIn | _: nodes.MethodParameterOut | _: nodes.MethodReturn | _: nodes.ImplicitCall |
-        _: nodes.PostExecutionCall =>
+    case _: nodes.MethodParameterIn | _: nodes.MethodParameterOut | _: nodes.MethodReturn =>
       walkUpAst(node)
-    case _: nodes.Expression | _: nodes.JumpTarget => walkUpContains(node)
+    case _: nodes.CallRepr if !node.isInstanceOf[nodes.Call] => walkUpAst(node)
+    case _: nodes.Expression | _: nodes.JumpTarget           => walkUpContains(node)
   }
 
   private def walkUpAst(node: nodes.WithinMethod): nodes.Method =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNode.scala
@@ -27,8 +27,8 @@ class CfgNode[A <: nodes.CfgNode](val traversal: Traversal[A]) extends AnyVal {
         methodReturn.method
       case expression: nodes.Expression =>
         expression.method
-      case implicitCall: nodes.ImplicitCall =>
-        implicitCall._astIn.onlyChecked.asInstanceOf[nodes.Method]
+      case callRepr: nodes.CallRepr =>
+        callRepr._astIn.onlyChecked.asInstanceOf[nodes.Method]
     }
 
   /**


### PR DESCRIPTION
... from all but the TrackingPointsMethods class, which we will move to `codescience`.