### PR TITLE
Remove tracking point (almost)

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -87,7 +87,6 @@ object Ast extends SchemaBase {
         name = "EXPRESSION",
         comment = "Expression as a specialisation of tracking point"
       )
-      .extendz(trackingPoint)
 
     expression.extendz(astNode)
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -165,13 +165,6 @@ object Base extends SchemaBase {
       comment = "Any node that can exist in a method"
     )
 
-    val trackingPoint = builder
-      .addNodeBaseType(
-        name = "TRACKING_POINT",
-        comment = "Any node that can occur in a data flow"
-      )
-      .extendz(withinMethod)
-
     val declaration = builder
       .addNodeBaseType(
         name = "DECLARATION",

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
@@ -26,6 +26,7 @@ class CpgSchema(builder: SchemaBuilder) {
   val closure = Closure(builder, base, method, ast, callGraph)
   val tagsAndLocation = TagsAndLocation(builder, base, typeSchema, method, ast, fs)
   val finding = Finding(builder, base)
+  val deprecated = Deprecated(builder, base, method, typeSchema, ast, tagsAndLocation)
   val protoSerialize = ProtoSerialize(builder, ast)
 }
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Deprecated.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Deprecated.scala
@@ -1,0 +1,99 @@
+package io.shiftleft.codepropertygraph.schema
+
+import overflowdb.schema.{Cardinality, NodeType, SchemaBuilder, SchemaInfo}
+import overflowdb.storage.ValueTypes
+
+object Deprecated extends SchemaBase {
+
+  override def index: Int = Int.MaxValue
+
+  override def description: String =
+    """Elements that we need to keep around for now but that must not be used
+      |in new code. These elements will also not be displayed in the spec.
+      |""".stripMargin
+
+  def apply(builder: SchemaBuilder,
+            base: Base.Schema,
+            methodSchema: Method.Schema,
+            typeSchema: Type.Schema,
+            ast: Ast.Schema,
+            tagsAndLocation: TagsAndLocation.Schema) =
+    new Schema(builder, base, methodSchema, typeSchema, ast, tagsAndLocation)
+
+  class Schema(builder: SchemaBuilder,
+               base: Base.Schema,
+               methodSchema: Method.Schema,
+               typeSchema: Type.Schema,
+               ast: Ast.Schema,
+               tagsAndLocation: TagsAndLocation.Schema) {
+    implicit private val schemaInfo = SchemaInfo.forClass(getClass)
+
+    import methodSchema._
+    import base._
+    import typeSchema._
+    import ast._
+    import tagsAndLocation._
+
+    val trackingPoint = builder
+      .addNodeBaseType(
+        name = "TRACKING_POINT",
+        comment = "Any node that can occur in a data flow"
+      )
+      .extendz(withinMethod)
+
+    val sourceType = builder
+      .addProperty(
+        name = "SOURCE_TYPE",
+        valueType = ValueTypes.STRING,
+        cardinality = Cardinality.One,
+        comment = ""
+      )
+      .protoId(115)
+
+    val sinkType = builder
+      .addProperty(
+        name = "SINK_TYPE",
+        valueType = ValueTypes.STRING,
+        cardinality = Cardinality.One,
+        comment = ""
+      )
+      .protoId(116)
+
+    val source: NodeType = builder
+      .addNodeType(
+        name = "SOURCE",
+        comment = ""
+      )
+      .protoId(202)
+      .addProperties(sourceType)
+
+    val sink: NodeType = builder
+      .addNodeType(
+        name = "SINK",
+        comment = ""
+      )
+      .protoId(203)
+      .addProperties(sinkType)
+
+    source
+      .addContainedNode(trackingPoint, "node", Cardinality.One)
+      .addContainedNode(method, "method", Cardinality.One)
+      .addContainedNode(tag, "methodTags", Cardinality.List)
+      .addContainedNode(method, "callingMethod", Cardinality.ZeroOrOne)
+      .addContainedNode(callNode, "callsite", Cardinality.ZeroOrOne)
+      .addContainedNode(tag, "tags", Cardinality.List)
+      .addContainedNode(tpe, "nodeType", Cardinality.One)
+
+    sink
+      .addContainedNode(trackingPoint, "node", Cardinality.One)
+      .addContainedNode(tpe, "nodeType", Cardinality.One)
+      .addContainedNode(method, "method", Cardinality.One)
+      .addContainedNode(tag, "methodTags", Cardinality.List)
+      .addContainedNode(method, "callingMethod", Cardinality.ZeroOrOne)
+      .addContainedNode(callNode, "callsite", Cardinality.ZeroOrOne)
+      .addContainedNode(methodParameterIn, "parameterIn", Cardinality.ZeroOrOne)
+      .addContainedNode(tag, "parameterInTags", Cardinality.List)
+
+  }
+
+}

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -72,7 +72,7 @@ object Method extends SchemaBase {
       )
       .protoId(34)
       .addProperties(typeFullName)
-      .extendz(declaration, localLike, trackingPoint)
+      .extendz(declaration, localLike)
 
     val methodParameterOut: NodeType = builder
       .addNodeType(
@@ -99,7 +99,6 @@ object Method extends SchemaBase {
       )
       .protoId(3)
       .addProperties(typeFullName)
-      .extendz(trackingPoint)
 
     val binding: NodeType = builder
       .addNodeType(

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -81,7 +81,7 @@ object Method extends SchemaBase {
       )
       .protoId(33)
       .addProperties(typeFullName)
-      .extendz(declaration, trackingPoint)
+      .extendz(declaration)
 
     val local: NodeType = builder
       .addNodeType(

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/TagsAndLocation.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/TagsAndLocation.scala
@@ -88,24 +88,6 @@ object TagsAndLocation extends SchemaBase {
       )
       .protoId(105)
 
-    val sourceType = builder
-      .addProperty(
-        name = "SOURCE_TYPE",
-        valueType = ValueTypes.STRING,
-        cardinality = Cardinality.One,
-        comment = ""
-      )
-      .protoId(115)
-
-    val sinkType = builder
-      .addProperty(
-        name = "SINK_TYPE",
-        valueType = ValueTypes.STRING,
-        cardinality = Cardinality.One,
-        comment = ""
-      )
-      .protoId(116)
-
     val taggedBy = builder
       .addEdgeType(
         name = "TAGGED_BY",
@@ -113,7 +95,7 @@ object TagsAndLocation extends SchemaBase {
       )
       .protoId(11)
 
-    // node tpes
+    // node types
 
     val tag: NodeType = builder
       .addNodeType(
@@ -147,22 +129,6 @@ object TagsAndLocation extends SchemaBase {
       .protoId(208)
       .addProperties()
 
-    val source: NodeType = builder
-      .addNodeType(
-        name = "SOURCE",
-        comment = ""
-      )
-      .protoId(202)
-      .addProperties(sourceType)
-
-    val sink: NodeType = builder
-      .addNodeType(
-        name = "SINK",
-        comment = ""
-      )
-      .protoId(203)
-      .addProperties(sinkType)
-
 // node relations
     location
       .addContainedNode(builder.anyNode, "node", Cardinality.ZeroOrOne)
@@ -170,25 +136,6 @@ object TagsAndLocation extends SchemaBase {
     tagNodePair
       .addContainedNode(tag, "tag", Cardinality.One)
       .addContainedNode(builder.anyNode, "node", Cardinality.One)
-
-    source
-      .addContainedNode(trackingPoint, "node", Cardinality.One)
-      .addContainedNode(method, "method", Cardinality.One)
-      .addContainedNode(tag, "methodTags", Cardinality.List)
-      .addContainedNode(method, "callingMethod", Cardinality.ZeroOrOne)
-      .addContainedNode(callNode, "callsite", Cardinality.ZeroOrOne)
-      .addContainedNode(tag, "tags", Cardinality.List)
-      .addContainedNode(tpe, "nodeType", Cardinality.One)
-
-    sink
-      .addContainedNode(trackingPoint, "node", Cardinality.One)
-      .addContainedNode(tpe, "nodeType", Cardinality.One)
-      .addContainedNode(method, "method", Cardinality.One)
-      .addContainedNode(tag, "methodTags", Cardinality.List)
-      .addContainedNode(method, "callingMethod", Cardinality.ZeroOrOne)
-      .addContainedNode(callNode, "callsite", Cardinality.ZeroOrOne)
-      .addContainedNode(methodParameterIn, "parameterIn", Cardinality.ZeroOrOne)
-      .addContainedNode(tag, "parameterInTags", Cardinality.List)
 
     method
       .addOutEdge(edge = taggedBy, inNode = tag)
@@ -243,8 +190,6 @@ object TagsAndLocation extends SchemaBase {
 
     methodParameterOut
       .addOutEdge(edge = taggedBy, inNode = tag)
-
-// constants
 
   }
 

--- a/schema2json/src/main/scala/Schema2Json.scala
+++ b/schema2json/src/main/scala/Schema2Json.scala
@@ -101,20 +101,34 @@ object Schema2Json extends App {
   }
 
   private def edgeTypesAsJson = {
-    schema.edgeTypes.sortBy(_.name).map { edge =>
-      ("name" -> edge.name) ~
-        ("comment" -> edge.comment) ~
-        ("schema" -> schemaName(edge.schemaInfo))
+    schema.edgeTypes.sortBy(_.name).flatMap { edge =>
+      val schName = schemaName(edge.schemaInfo)
+      if (schName == deprecatedSchemaName) {
+        None
+      } else {
+        Some(
+          ("name" -> edge.name) ~
+            ("comment" -> edge.comment) ~
+            ("schema" -> schName)
+        )
+      }
     }
   }
 
   private def propertiesAsJson = {
     schema.properties
       .sortBy(_.name)
-      .map { prop =>
-        ("name" -> prop.name) ~
-          ("comment" -> prop.comment) ~
-          ("schema" -> schemaName(prop.schemaInfo))
+      .flatMap { prop =>
+        val schName = schemaName(prop.schemaInfo)
+        if (schName == deprecatedSchemaName) {
+          None
+        } else {
+          Some(
+            ("name" -> prop.name) ~
+              ("comment" -> prop.comment) ~
+              ("schema" -> schName)
+          )
+        }
       }
   }
 

--- a/schema2json/src/main/scala/Schema2Json.scala
+++ b/schema2json/src/main/scala/Schema2Json.scala
@@ -8,6 +8,7 @@ import overflowdb.schema.{AbstractNodeType, NodeBaseType, NodeType, SchemaInfo}
 object Schema2Json extends App {
 
   val schema = CpgSchema.instance
+  val deprecatedSchemaName = "Deprecated"
 
   implicit val formats: AnyRef with Formats =
     Serialization.formats(NoTypeHints)
@@ -41,6 +42,7 @@ object Schema2Json extends App {
       .sortBy(schemaIndex)
       .flatMap(_.definedIn)
       .distinct
+      .filter { _.getDeclaringClass.getSimpleName != deprecatedSchemaName }
       .map { info =>
         val name = info.getDeclaringClass.getSimpleName
         val description = info.getDeclaringClass.getDeclaredMethod("description").invoke(null).asInstanceOf[String]
@@ -55,41 +57,46 @@ object Schema2Json extends App {
   private def nodeTypesAsJson = {
     (schema.nodeTypes ++ schema.nodeBaseTypes)
       .sortBy(x => (schemaIndex(x), x.name))
-      .map { nodeType =>
+      .flatMap { nodeType =>
         val baseTypeNames = nodeType.extendz.map(_.name)
         val allPropertyNames = nodeType.properties.map(_.name)
         val cardinalities = nodeType.properties.map(_.cardinality.name)
+        val schName = schemaName(nodeType)
 
-        val inheritedProperties = nodeType.extendz
-          .flatMap { base =>
-            base.properties.map(_.name).map(x => x -> base.name)
-          }
-          .toMap
-          .toList
-          .map(x => (("baseType" -> x._2), ("name" -> x._1)))
-
-        val inheritedPropertyNames = inheritedProperties.map(_._2._2)
-        val nonInheritedProperties = allPropertyNames.filterNot(x => inheritedPropertyNames.contains(x))
-
-        val containedNodes = nodeType match {
-          case nt: NodeType =>
-            nt.containedNodes.map { n =>
-              Map("name" -> n.localName, "type" -> n.nodeType.name, "cardinality" -> n.cardinality.name)
+        if (schName == deprecatedSchemaName) {
+          None
+        } else {
+          val inheritedProperties = nodeType.extendz
+            .flatMap { base =>
+              base.properties.map(_.name).map(x => x -> base.name)
             }
-          case _ => List()
-        }
+            .toMap
+            .toList
+            .map(x => (("baseType" -> x._2), ("name" -> x._1)))
 
-        ("name" -> nodeType.name) ~
-          ("comment" -> nodeType.comment) ~
-          ("extends" -> baseTypeNames) ~
-          ("allProperties" -> allPropertyNames) ~
-          ("cardinalities" -> cardinalities) ~
-          ("inheritedProperties" -> inheritedProperties.map(x => x._1 ~ x._2)) ~
-          ("properties" -> nonInheritedProperties) ~
-          ("schema" -> schemaName(nodeType)) ~
-          ("schemaIndex" -> schemaIndex(nodeType)) ~
-          ("isAbstract" -> nodeType.isInstanceOf[NodeBaseType]) ~
-          ("containedNodes" -> containedNodes)
+          val inheritedPropertyNames = inheritedProperties.map(_._2._2)
+          val nonInheritedProperties = allPropertyNames.filterNot(x => inheritedPropertyNames.contains(x))
+
+          val containedNodes = nodeType match {
+            case nt: NodeType =>
+              nt.containedNodes.map { n =>
+                Map("name" -> n.localName, "type" -> n.nodeType.name, "cardinality" -> n.cardinality.name)
+              }
+            case _ => List()
+          }
+          val json = ("name" -> nodeType.name) ~
+            ("comment" -> nodeType.comment) ~
+            ("extends" -> baseTypeNames) ~
+            ("allProperties" -> allPropertyNames) ~
+            ("cardinalities" -> cardinalities) ~
+            ("inheritedProperties" -> inheritedProperties.map(x => x._1 ~ x._2)) ~
+            ("properties" -> nonInheritedProperties) ~
+            ("schema" -> schName) ~
+            ("schemaIndex" -> schemaIndex(nodeType)) ~
+            ("isAbstract" -> nodeType.isInstanceOf[NodeBaseType]) ~
+            ("containedNodes" -> containedNodes)
+          Some(json)
+        }
       }
   }
 


### PR DESCRIPTION
This is a compromise: we currently still use `TrackingPoint` in `Source`, and I actually wanted to move both away from the OSS spec. Unfortunately, `LocationCreator` has a case for `Source` and `source.location` breaks if we just remove it. We could have also introduced an implicit conversion in `codescience` to take care of this, but if we ever forgot to import it, we would have ended up with a silently failing `source.location`. That all sounds too dangerous.

What I really want is for tracking point to not be present in the OSS spec and unused in any open source code. As a compromise between removing it entirely and keeping it, I've introduced a `Deprecated` schema file where it is hosted, along with `Source` and `Sink`. This means that to use it in other schema files, `Deprecated` needs to be explicitly imported. Moreover, the schema dumper filters out the deprecated schema.