### PR TITLE
CPG Schema: cleanup METHOD/TYPE Schema

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -62,7 +62,6 @@ object Ast extends SchemaBase {
     method.extendz(astNode)
     methodParameterIn.extendz(astNode)
     methodParameterOut.extendz(astNode)
-    local.extendz(astNode)
 
     // Type-related nodes that are part of the AST
 
@@ -117,6 +116,15 @@ object Ast extends SchemaBase {
       .protoId(8)
       .addProperties(typeFullName)
       .extendz(expression)
+
+    val local: NodeType = builder
+      .addNodeType(
+        name = "LOCAL",
+        comment = "This node represents a local variable."
+      )
+      .protoId(23)
+      .addProperties(typeFullName)
+      .extendz(declaration, localLike, astNode)
 
     val callNode: NodeType = builder
       .addNodeType(

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -48,6 +48,7 @@ object Ast extends SchemaBase {
                     |""".stripMargin
       )
       .addProperties(order, code)
+      .addProperties(lineNumber, columnNumber)
 
     val callRepr = builder
       .addNodeBaseType(

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -51,24 +51,6 @@ object Base extends SchemaBase {
       )
       .protoId(21)
 
-    val lineNumber = builder
-      .addProperty(
-        name = "LINE_NUMBER",
-        valueType = ValueTypes.INTEGER,
-        cardinality = Cardinality.ZeroOrOne,
-        comment = "Line where the code starts"
-      )
-      .protoId(2)
-
-    val columnNumber = builder
-      .addProperty(
-        name = "COLUMN_NUMBER",
-        valueType = ValueTypes.INTEGER,
-        cardinality = Cardinality.ZeroOrOne,
-        comment = "Column where the code starts"
-      )
-      .protoId(11)
-
     val isExternal = builder
       .addProperty(
         name = "IS_EXTERNAL",

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -24,7 +24,6 @@ object Cfg extends SchemaBase {
         name = "CFG_NODE",
         comment = "Any node that can occur as part of a control flow graph"
       )
-      .addProperties(lineNumber, columnNumber)
       .extendz(withinMethod, astNode)
 
     // Method and MethodReturn nodes are used as ENTRY and EXIT nodes respectively

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
@@ -36,6 +36,24 @@ object FileSystem extends SchemaBase {
       )
       .protoId(106)
 
+    val lineNumber = builder
+      .addProperty(
+        name = "LINE_NUMBER",
+        valueType = ValueTypes.INTEGER,
+        cardinality = Cardinality.ZeroOrOne,
+        comment = "Line where the code starts"
+      )
+      .protoId(2)
+
+    val columnNumber = builder
+      .addProperty(
+        name = "COLUMN_NUMBER",
+        valueType = ValueTypes.INTEGER,
+        cardinality = Cardinality.ZeroOrOne,
+        comment = "Column where the code starts"
+      )
+      .protoId(11)
+
     val sourceFile = builder
       .addEdgeType(
         name = "SOURCE_FILE",

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
@@ -41,7 +41,9 @@ object FileSystem extends SchemaBase {
         name = "LINE_NUMBER",
         valueType = ValueTypes.INTEGER,
         cardinality = Cardinality.ZeroOrOne,
-        comment = "Line where the code starts"
+        comment = """This optional field provides the line number of the program construct
+            |represented by the node.
+            |""".stripMargin
       )
       .protoId(2)
 
@@ -50,7 +52,10 @@ object FileSystem extends SchemaBase {
         name = "COLUMN_NUMBER",
         valueType = ValueTypes.INTEGER,
         cardinality = Cardinality.ZeroOrOne,
-        comment = "Column where the code starts"
+        comment = """
+            |This optional fields provides the column number of the program construct
+            |represented by the node.
+            |""".stripMargin
       )
       .protoId(11)
 
@@ -59,7 +64,10 @@ object FileSystem extends SchemaBase {
         name = "LINE_NUMBER_END",
         valueType = ValueTypes.INTEGER,
         cardinality = Cardinality.ZeroOrOne,
-        comment = "Line where the code ends"
+        comment = """
+        |This optional fields provides the line number at which the program construct
+        |represented by the node ends.
+        """.stripMargin
       )
       .protoId(12)
 
@@ -68,7 +76,10 @@ object FileSystem extends SchemaBase {
         name = "COLUMN_NUMBER_END",
         valueType = ValueTypes.INTEGER,
         cardinality = Cardinality.ZeroOrOne,
-        comment = "Column where the code ends"
+        comment = """
+            |This optional fields provides the column number at which the program construct
+            |represented by the node ends.
+        """.stripMargin
       )
       .protoId(16)
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
@@ -54,6 +54,24 @@ object FileSystem extends SchemaBase {
       )
       .protoId(11)
 
+    val lineNumberEnd = builder
+      .addProperty(
+        name = "LINE_NUMBER_END",
+        valueType = ValueTypes.INTEGER,
+        cardinality = Cardinality.ZeroOrOne,
+        comment = "Line where the code ends"
+      )
+      .protoId(12)
+
+    val columnNumberEnd = builder
+      .addProperty(
+        name = "COLUMN_NUMBER_END",
+        valueType = ValueTypes.INTEGER,
+        cardinality = Cardinality.ZeroOrOne,
+        comment = "Column where the code ends"
+      )
+      .protoId(16)
+
     val sourceFile = builder
       .addEdgeType(
         name = "SOURCE_FILE",

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -14,7 +14,7 @@ object Method extends SchemaBase {
   override def description: String =
     """
       |The Method Layer contains declarations of methods, functions, and procedures.
-      |Input parameterss output parameters (including return parameters) and local variables are
+      |Input parameters and output parameters (including return parameters) are
       |represented, however, method contents is not present in this layer.
       |""".stripMargin
 
@@ -60,19 +60,25 @@ object Method extends SchemaBase {
             |`LINE_NUMBER`, `COLUMN_NUMBER`, `LINE_NUMBER_END`, and `COLUMN_NUMBER_END` and
             |the name of the source file is specified in `FILENAME`. An optional hash value
             |MAY be calculated over the function contents and included in the `HASH` field.
+            |
+            |Finally, the fully qualified name of the program constructs that the method
+            |is immediately contained in is stored in the `AST_PARENT_FULL_NAME` field
+            |and its type is indicated in the `AST_PARENT_TYPE` field to be one of
+            |`METHOD`, `TYPE_DECL` or `NAMESPACE_BLOCK`.
             |""".stripMargin
       )
       .protoId(1)
       .addProperties(fullName, isExternal, signature, lineNumberEnd, columnNumberEnd, filename, hash)
-      .extendz(declaration)
-
-    method
       .addProperties(astParentType, astParentFullName)
+      .extendz(declaration)
 
     val methodParameterIn: NodeType = builder
       .addNodeType(
         name = "METHOD_PARAMETER_IN",
-        comment = "This node represents a formal parameter going towards the callee side"
+        comment = """
+            |This node represents a formal input parameter. The field `NAME` contains its
+            |name, while the field `TYPE_FULL_NAME` contains the fully qualified type name.
+            |""".stripMargin
       )
       .protoId(34)
       .addProperties(typeFullName)
@@ -81,25 +87,23 @@ object Method extends SchemaBase {
     val methodParameterOut: NodeType = builder
       .addNodeType(
         name = "METHOD_PARAMETER_OUT",
-        comment = "This node represents a formal output parameter. It does not need to be created by the frontend."
+        comment = """This node represents a formal output parameter. Corresponding output parameters
+            |for input parameters MUST NOT be created by the frontend as they are automatically
+            |created upon first loading the CPG.
+            |""".stripMargin
       )
       .protoId(33)
       .addProperties(typeFullName)
       .extendz(declaration)
 
-    val local: NodeType = builder
-      .addNodeType(
-        name = "LOCAL",
-        comment = "A local variable"
-      )
-      .protoId(23)
-      .addProperties(typeFullName)
-      .extendz(declaration, localLike)
-
     val methodReturn: NodeType = builder
       .addNodeType(
         name = "METHOD_RETURN",
-        comment = "A formal method return"
+        comment = """This node represents an (unnamed) formal method return parameter. It carries its
+            |fully qualified type name in `TYPE_FULL_NAME`. The `CODE` field MAY be set freely,
+            |e.g., to the constant `RET`, however, subsequent layer creators MUST NOT depend
+            |on this value.
+            |""".stripMargin
       )
       .protoId(3)
       .addProperties(typeFullName)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -82,8 +82,6 @@ object Method extends SchemaBase {
       .protoId(3)
       .addProperties(typeFullName)
 
-    // To be removed
-
     method
       .addOutEdge(edge = sourceFile, inNode = file)
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -13,8 +13,7 @@ object Method extends SchemaBase {
 
   override def description: String =
     """
-      | Structural layer (namespace blocks, method declarations, and type declarations).
-      | This layer is provided by the frontend and may be modified by passes.
+      |The Method Layer contains declarations of methods, functions, and procedures.
       |""".stripMargin
 
   class Schema(builder: SchemaBuilder, base: Base.Schema, typeDeclSchema: Type.Schema, fs: FileSystem.Schema) {

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -35,24 +35,6 @@ object Method extends SchemaBase {
       )
       .protoId(22)
 
-    val lineNumberEnd = builder
-      .addProperty(
-        name = "LINE_NUMBER_END",
-        valueType = ValueTypes.INTEGER,
-        cardinality = Cardinality.ZeroOrOne,
-        comment = "Line where the code ends"
-      )
-      .protoId(12)
-
-    val columnNumberEnd = builder
-      .addProperty(
-        name = "COLUMN_NUMBER_END",
-        valueType = ValueTypes.INTEGER,
-        cardinality = Cardinality.ZeroOrOne,
-        comment = "Column where the code ends"
-      )
-      .protoId(16)
-
     val method: NodeType = builder
       .addNodeType(
         name = "METHOD",

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -14,6 +14,8 @@ object Method extends SchemaBase {
   override def description: String =
     """
       |The Method Layer contains declarations of methods, functions, and procedures.
+      |Input parameterss output parameters (including return parameters) and local variables are
+      |represented, however, method contents is not present in this layer.
       |""".stripMargin
 
   class Schema(builder: SchemaBuilder, base: Base.Schema, typeDeclSchema: Type.Schema, fs: FileSystem.Schema) {
@@ -27,10 +29,13 @@ object Method extends SchemaBase {
         name = "SIGNATURE",
         valueType = ValueTypes.STRING,
         cardinality = Cardinality.One,
-        comment = """Method signature. The format is defined by the language front-end, and the
-                    |backend simply compares strings to resolve function overloading, i.e. match
-                    |call-sites to METHODs. In theory, consecutive integers would be valid,
-                    |but in practice this should be human readable
+        comment = """
+                    |The method signature encodes the types of parameters in a string.
+                    |The string SHOULD be human readable and suitable for differentiating methods
+                    |with different parameter types sufficiently to allow for resolving of
+                    |function overloading. The present specification does not enforce a strict
+                    |format for the signature, that is, it can be chosen by the frontend
+                    |implementor to fit the source language.
                     |""".stripMargin
       )
       .protoId(22)
@@ -38,7 +43,24 @@ object Method extends SchemaBase {
     val method: NodeType = builder
       .addNodeType(
         name = "METHOD",
-        comment = "A method/function/procedure"
+        comment = """Programming languages offer many closely-related concepts for describing blocks
+            |of code that can be executed with input parameters and return output parameters,
+            |possibly causing side effects. In the CPG specification, we refer to all of these
+            |concepts (procedures, functions, methods, etc.) as methods. A single METHOD node
+            |must exist for each method found in the source program.
+            |
+            |The `FULL_NAME` field specifies the method's fully-qualified name, including
+            |information about the namespace it is contained in if applicable, the name field
+            |is the function's short name. The field `IS_EXTERNAL` indicates whether it was
+            |possible to identify a method body for the method. This is true for methods that
+            |are defined in the source program, and false for methods that are dynamically
+            |linked to the program, that is, methods that exist in an external dependency.
+            |
+            |Line and column number information is specified in the optional fields
+            |`LINE_NUMBER`, `COLUMN_NUMBER`, `LINE_NUMBER_END`, and `COLUMN_NUMBER_END` and
+            |the name of the source file is specified in `FILENAME`. An optional hash value
+            |MAY be calculated over the function contents and included in the `HASH` field.
+            |""".stripMargin
       )
       .protoId(1)
       .addProperties(fullName, isExternal, signature, lineNumberEnd, columnNumberEnd, filename, hash)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -82,16 +82,6 @@ object Method extends SchemaBase {
       .protoId(3)
       .addProperties(typeFullName)
 
-    val parameterLink = builder
-      .addEdgeType(
-        name = "PARAMETER_LINK",
-        comment = "Links together corresponding METHOD_PARAMETER_IN and METHOD_PARAMETER_OUT nodes. Created by backend."
-      )
-      .protoId(12)
-
-    methodParameterIn
-      .addOutEdge(edge = parameterLink, inNode = methodParameterOut)
-
     // To be removed
 
     val vtable = builder

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -84,15 +84,6 @@ object Method extends SchemaBase {
 
     // To be removed
 
-    val vtable = builder
-      .addEdgeType(
-        name = "VTABLE",
-        comment = "Indicates that a method is part of the vtable of a certain type declaration"
-      )
-      .protoId(30)
-
-    typeDecl.addOutEdge(edge = vtable, inNode = method)
-
     method
       .addOutEdge(edge = sourceFile, inNode = file)
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -89,7 +89,7 @@ object Method extends SchemaBase {
         comment = "A local variable"
       )
       .protoId(23)
-      .addProperties(typeFullName, lineNumber, columnNumber)
+      .addProperties(typeFullName)
       .extendz(declaration, localLike)
 
     val methodReturn: NodeType = builder

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Shortcuts.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Shortcuts.scala
@@ -48,6 +48,16 @@ object Shortcuts extends SchemaBase {
       )
       .protoId(28)
 
+    val parameterLink = builder
+      .addEdgeType(
+        name = "PARAMETER_LINK",
+        comment = "Links together corresponding METHOD_PARAMETER_IN and METHOD_PARAMETER_OUT nodes. Created by backend."
+      )
+      .protoId(12)
+
+    methodParameterIn
+      .addOutEdge(edge = parameterLink, inNode = methodParameterOut)
+
     file
       .addOutEdge(edge = contains, inNode = typeDecl)
       .addOutEdge(edge = contains, inNode = method)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Type.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Type.scala
@@ -30,9 +30,9 @@ object Type extends SchemaBase {
         name = "TYPE_FULL_NAME",
         valueType = ValueTypes.STRING,
         cardinality = Cardinality.One,
-        comment = """This field contains the fully-qualified static type name of the entity
-                    |represented by a node. It is the name of an instantiated type, e.g.,
-                    |`List<Integer>`, not `List[T]`.
+        comment = """This field contains the fully-qualified static type name of the program
+                    |construct represented by a node. It is the name of an instantiated type, e.g.,
+                    |`List<Integer>`, rather than `List[T]`.
                     |""".stripMargin
       )
       .protoId(51)
@@ -42,7 +42,9 @@ object Type extends SchemaBase {
         name = "ALIAS_TYPE_FULL_NAME",
         valueType = ValueTypes.STRING,
         cardinality = Cardinality.ZeroOrOne,
-        comment = "Type full name of which a TYPE_DECL is an alias of"
+        comment = """This property holds the fully qualified name of the type that the node is
+            |a type alias of.
+            |""".stripMargin
       )
       .protoId(158)
 
@@ -156,7 +158,9 @@ object Type extends SchemaBase {
     val bindsTo = builder
       .addEdgeType(
         name = "BINDS_TO",
-        comment = "Type argument binding to a type parameter"
+        comment = """This edge connects type arguments to type parameters to indicate
+            |that the type argument is used to instantiate the type parameter.
+            |""".stripMargin
       )
       .protoId(22)
 


### PR DESCRIPTION
* Documentation for nodes of the method schema
* Removal of the `VTABLE` edge
* Moving of LINE_NUMBER and COLUMN_NUMBER to ASTNode
* Move PARAMETER_LINK to shortcuts
* Remove `TYPE_DECL_ALIAS` edge