### PR TITLE
Fix `NamespaceCreator` pass

### DIFF
--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NodeTypeStartersTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NodeTypeStartersTests.scala
@@ -70,7 +70,7 @@ class NodeTypeStartersTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should allow retrieving namespaces" in {
-    cpg.namespace.name.l shouldBe List("<global>")
+    cpg.namespace.name.head.endsWith("<global>") shouldBe true
   }
 
   "should allow retrieving namespace blocks" in {

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/FileTests.scala
@@ -45,7 +45,7 @@ class FileTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should allow traversing to namespaces" in {
-    cpg.file.namespace.name("<global>").l.size shouldBe 2
+    cpg.file.namespace.name("<global>").l.size shouldBe 1
   }
 
 }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/NamespaceBlockTests.scala
@@ -44,8 +44,13 @@ class NamespaceBlockTests extends FuzzyCCodeToCpgSuite {
   }
 
   "should allow traversing from namespace block to namespace" in {
-    cpg.namespaceBlock.filenameNot(FileTraversal.UNKNOWN).namespace.name.l shouldBe List(
-      NamespaceTraversal.globalNamespaceName)
+    cpg.namespaceBlock
+      .filenameNot(FileTraversal.UNKNOWN)
+      .namespace
+      .name
+      .l
+      .head
+      .endsWith(NamespaceTraversal.globalNamespaceName) shouldBe true
   }
 
 }

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/NamespaceCreatorTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/NamespaceCreatorTests.scala
@@ -12,9 +12,9 @@ import overflowdb._
 class NamespaceCreatorTests extends AnyWordSpec with Matchers {
   "NamespaceCreateor test " in EmptyGraphFixture { graph =>
     val cpg = new Cpg(graph)
-    val block1 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace1")
-    val block2 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace1")
-    val block3 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace2")
+    val block1 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace1", Properties.FULL_NAME -> "namespace1")
+    val block2 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace1", Properties.FULL_NAME -> "namespace1")
+    val block3 = graph + (NodeTypes.NAMESPACE_BLOCK, Properties.NAME -> "namespace2", Properties.FULL_NAME -> "namespace2")
 
     val namespaceCreator = new NamespaceCreator(new Cpg(graph))
     namespaceCreator.createAndApply()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/namespacecreator/NamespaceCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/namespacecreator/NamespaceCreator.scala
@@ -22,11 +22,11 @@ class NamespaceCreator(cpg: Cpg) extends CpgPass(cpg) {
     val dstGraph = DiffGraph.newBuilder
     cpg.namespaceBlock
       .groupBy { nb: NamespaceBlock =>
-        nb.name
+        nb.fullName
       }
       .foreach {
-        case (name: String, blocks) =>
-          val namespace = NewNamespace().name(name)
+        case (fullName: String, blocks) =>
+          val namespace = NewNamespace().name(fullName)
           dstGraph.addNode(namespace)
           blocks.foreach(block => dstGraph.addEdgeFromOriginal(block, namespace, EdgeTypes.REF))
       }


### PR DESCRIPTION
The field `namespace.name` is supposed to hold the fully qualified name of the namespace, not the simple name. This PR fixes that.