### PR TITLE
Language primitives for control structure traversal

### DIFF
--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/AstTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/AstTests.scala
@@ -66,7 +66,7 @@ class CAstTests extends FuzzyCCodeToCpgSuite {
       .name("foo")
       .ast
       .isControlStructure
-      .parserTypeName("IfStatement")
+      .isIf
       .l
       .size shouldBe 2
 
@@ -74,7 +74,7 @@ class CAstTests extends FuzzyCCodeToCpgSuite {
       .name("foo")
       .ast
       .isControlStructure
-      .parserTypeName("ElseStatement")
+      .isElse
       .l
       .size shouldBe 1
   }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/ControlStructureTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/ControlStructureTests.scala
@@ -1,0 +1,78 @@
+package io.shiftleft.fuzzyc2cpg.standard
+
+import io.shiftleft.fuzzyc2cpg.testfixtures.FuzzyCCodeToCpgSuite
+import io.shiftleft.semanticcpg.language._
+
+class ControlStructureTests extends FuzzyCCodeToCpgSuite {
+
+  override val code =
+    """
+      |void foo(int x, int y) {
+      | try {
+      |    goto foo;
+      |    foo:
+      | } catch(exc_t exc) {
+      |   // ...
+      | }
+      |
+      | for(int i = 0; i < 10; i++) {
+      |     if (x > y) {
+      |     continue;
+      |    }
+      |    while(y++ < x) {
+      |     printf("foo\n");
+      |   }
+      | }
+      |
+      |switch(y) {
+      |  case 1:
+      |   printf("bar\n");
+      |   break;
+      |  default:
+      |};
+      |
+      | int i = 0;
+      | do {
+      |   i++;
+      | } while(i < 11);
+      |}
+      |
+      |""".stripMargin
+
+  "should identify `try` block" in {
+    cpg.method("foo").tryBlock.code.l shouldBe List("try")
+  }
+
+  "should identify `if` block" in {
+    cpg.method("foo").ifBlock.condition.code.l shouldBe List("x > y")
+  }
+
+  "should identify `switch` block" in {
+    cpg.method("foo").switchBlock.code.l shouldBe List("switch(y)")
+  }
+
+  "should identify `for` block" in {
+    cpg.method("foo").forBlock.condition.code.l shouldBe List("i < 10")
+  }
+
+  "should identify `while` block" in {
+    cpg.method("foo").whileBlock.condition.code.l shouldBe List("y++ < x")
+  }
+
+  "should identify `do` block" in {
+    cpg.method("foo").doBlock.condition.code.l shouldBe List("i < 11")
+  }
+
+  "should identify `goto`" in {
+    cpg.method("foo").goto.code.l shouldBe List("goto foo;")
+  }
+
+  "should identify `break`" in {
+    cpg.method("foo").break.code.l shouldBe List("break;")
+  }
+
+  "should identify `continue`" in {
+    cpg.method("foo").continue.code.l shouldBe List("continue;")
+  }
+
+}

--- a/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
+++ b/fuzzyc2cpg/src/main/scala/io/shiftleft/fuzzyc2cpg/passes/astcreation/AstCreator.scala
@@ -912,6 +912,7 @@ private[astcreation] class AstCreator(diffGraph: DiffGraph.Builder,
       case "IfStatement"       => ControlStructureTypes.IF
       case "ElseStatement"     => ControlStructureTypes.ELSE
       case "SwitchStatement"   => ControlStructureTypes.SWITCH
+      case "TryStatement"      => ControlStructureTypes.TRY
       case someThingElse       => someThingElse
     }
     NewControlStructure()

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -3,6 +3,7 @@ package io.shiftleft.semanticcpg.language
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Properties}
+import io.shiftleft.semanticcpg.language._
 import overflowdb._
 import overflowdb.traversal._
 import overflowdb.traversal.help.{Doc, TraversalSource}
@@ -33,6 +34,46 @@ class NodeTypeStarters(cpg: Cpg) {
   @Doc("All control structures (source-based frontends)")
   def controlStructure: Traversal[ControlStructure] =
     cpg.graph.nodes(NodeTypes.CONTROL_STRUCTURE).cast[ControlStructure]
+
+  @Doc("All try blocks (`ControlStructure` nodes)")
+  def tryBlock: Traversal[ControlStructure] =
+    controlStructure.isTry
+
+  @Doc("All if blocks (`ControlStructure` nodes)")
+  def ifBlock: Traversal[ControlStructure] =
+    controlStructure.isIf
+
+  @Doc("All else blocks (`ControlStructure` nodes)")
+  def elseBlock: Traversal[ControlStructure] =
+    controlStructure.isElse
+
+  @Doc("All switch blocks (`ControlStructure` nodes)")
+  def switchBlock: Traversal[ControlStructure] =
+    controlStructure.isSwitch
+
+  @Doc("All do blocks (`ControlStructure` nodes)")
+  def doBlock: Traversal[ControlStructure] =
+    controlStructure.isDo
+
+  @Doc("All for blocks (`ControlStructure` nodes)")
+  def forBlock: Traversal[ControlStructure] =
+    controlStructure.isFor
+
+  @Doc("All while blocks (`ControlStructure` nodes)")
+  def whileBlock: Traversal[ControlStructure] =
+    controlStructure.isWhile
+
+  @Doc("All gotos (`ControlStructure` nodes)")
+  def goto: Traversal[ControlStructure] =
+    controlStructure.isGoto
+
+  @Doc("All breaks (`ControlStructure` nodes)")
+  def break: Traversal[ControlStructure] =
+    controlStructure.isBreak
+
+  @Doc("All continues (`ControlStructure` nodes)")
+  def continue: Traversal[ControlStructure] =
+    controlStructure.isContinue
 
   /**
     Traverse to all source files

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, ControlStructure, Expression}
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Properties}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
 import overflowdb.traversal.help.Doc
@@ -29,5 +29,45 @@ class ControlStructureTraversal(val traversal: Traversal[ControlStructure]) exte
   @Doc("Sub tree taken when condition evaluates to false")
   def whenFalse: Traversal[AstNode] =
     traversal.out.has(Properties.ORDER, thirdChildIndex).cast[AstNode]
+
+  @Doc("Only `Try` control structures")
+  def isTry: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.TRY)
+
+  @Doc("Only `If` control structures")
+  def isIf: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.IF)
+
+  @Doc("Only `Else` control structures")
+  def isElse: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.ELSE)
+
+  @Doc("Only `Switch` control structures")
+  def isSwitch: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.SWITCH)
+
+  @Doc("Only `Do` control structures")
+  def isDo: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.DO)
+
+  @Doc("Only `For` control structures")
+  def isFor: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.FOR)
+
+  @Doc("Only `While` control structures")
+  def isWhile: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.WHILE)
+
+  @Doc("Only `Goto` control structures")
+  def isGoto: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.GOTO)
+
+  @Doc("Only `Break` control structures")
+  def isBreak: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.BREAK)
+
+  @Doc("Only `Continue` control structures")
+  def isContinue: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.CONTINUE)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -40,6 +40,46 @@ class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
   def controlStructure(regex: String): Traversal[ControlStructure] =
     traversal.ast.isControlStructure.code(regex)
 
+  @Doc("All try blocks (`ControlStructure` nodes)")
+  def tryBlock: Traversal[ControlStructure] =
+    controlStructure.isTry
+
+  @Doc("All if blocks (`ControlStructure` nodes)")
+  def ifBlock: Traversal[ControlStructure] =
+    controlStructure.isIf
+
+  @Doc("All else blocks (`ControlStructure` nodes)")
+  def elseBlock: Traversal[ControlStructure] =
+    controlStructure.isElse
+
+  @Doc("All switch blocks (`ControlStructure` nodes)")
+  def switchBlock: Traversal[ControlStructure] =
+    controlStructure.isSwitch
+
+  @Doc("All do blocks (`ControlStructure` nodes)")
+  def doBlock: Traversal[ControlStructure] =
+    controlStructure.isDo
+
+  @Doc("All for blocks (`ControlStructure` nodes)")
+  def forBlock: Traversal[ControlStructure] =
+    controlStructure.isFor
+
+  @Doc("All while blocks (`ControlStructure` nodes)")
+  def whileBlock: Traversal[ControlStructure] =
+    controlStructure.isWhile
+
+  @Doc("All gotos (`ControlStructure` nodes)")
+  def goto: Traversal[ControlStructure] =
+    controlStructure.isGoto
+
+  @Doc("All breaks (`ControlStructure` nodes)")
+  def break: Traversal[ControlStructure] =
+    controlStructure.isBreak
+
+  @Doc("All continues (`ControlStructure` nodes)")
+  def continue: Traversal[ControlStructure] =
+    controlStructure.isContinue
+
   /**
     * The type declaration associated with this method, e.g., the class it is defined in.
     * */


### PR DESCRIPTION
We recently introduced the `controlStructureType` field but never got around to extending the query language accordingly, e.g., to allow traversing to all if-blocks or all while-blocks. This PR adds the necessary language primitives as well as a querying test.