### PR TITLE
upgrade odb codgen

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
+++ b/console/src/main/scala/io/shiftleft/console/workspacehandling/Project.scala
@@ -26,15 +26,15 @@ case class Project(projectFile: ProjectFile, var path: Path, var cpg: Option[Cpg
 
   def inputPath: String = projectFile.inputPath
 
-  def appliedOverlays: List[String] = {
-    cpg.map(Overlays.appliedOverlays).getOrElse(List())
+  def appliedOverlays: Seq[String] = {
+    cpg.map(Overlays.appliedOverlays).getOrElse(Nil)
   }
 
   def availableOverlays: List[String] = {
     File(path.resolve("overlays")).list.map(_.name).toList
   }
 
-  def overlayDirs: List[File] = {
+  def overlayDirs: Seq[File] = {
     val overlayDir = File(path.resolve("overlays"))
     appliedOverlays.map(o => overlayDir / o)
   }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/TypeDeclTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/standard/TypeDeclTests.scala
@@ -48,7 +48,7 @@ class TypeDeclTests extends FuzzyCCodeToCpgSuite {
     x.isExternal shouldBe true
     x.inheritsFromTypeFullName shouldBe List()
     x.aliasTypeFullName shouldBe None
-    x.order shouldBe -1
+    x.order shouldBe null
     x.filename shouldBe FileTraversal.UNKNOWN
   }
 

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,6 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "1.83"
+libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "1.83+5-bf689966"
 
 val generateDomainClasses = taskKey[Seq[File]]("generate overflowdb domain classes for our schema")
 generateDomainClasses := Def.taskDyn {

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,6 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "1.83+5-bf689966"
+libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "1.83+6-48fed444"
 
 val generateDomainClasses = taskKey[Seq[File]]("generate overflowdb domain classes for our schema")
 generateDomainClasses := Def.taskDyn {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/Overlays.scala
@@ -26,7 +26,7 @@ object Overlays {
     }
   }
 
-  def appliedOverlays(cpg: Cpg): List[String] = {
+  def appliedOverlays(cpg: Cpg): Seq[String] = {
     cpg.metaData.headOption match {
       case Some(metaData) => Option(metaData.overlays).getOrElse(Nil)
       case None =>


### PR DESCRIPTION
Note the change in TypeDeclTests - this is an intentional change in the
codegen, it used to contain a special handling for integers, which 
defaulted to -1. Please let me know if this breaks any other assumptions
down the line... Looks to me like `order` should be an optional property.