### PR TITLE
Exit gracefully on CPGQLS startup exceptions

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -308,7 +308,20 @@ trait BridgeBase {
                                  config.serverAuthUsername,
                                  config.serverAuthPassword)
     println("Starting CPGQL server ...")
-    server.main(Array.empty)
+    try {
+      server.main(Array.empty)
+    } catch {
+      case _: java.net.BindException => {
+        println("Could not bind socket for CPGQL server, exiting.")
+        ammonite.shutdown()
+        System.exit(1)
+      }
+      case _: Throwable => {
+        println("Unhandled exception thrown while attempting to start CPGQL server, exiting.")
+        ammonite.shutdown()
+        System.exit(1)
+      }
+    }
   }
 
   private def runScript(scriptFile: Path, config: Config) = {

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -316,8 +316,11 @@ trait BridgeBase {
         ammonite.shutdown()
         System.exit(1)
       }
-      case _: Throwable => {
-        println("Unhandled exception thrown while attempting to start CPGQL server, exiting.")
+      case e: Throwable => {
+        println("Unhandled exception thrown while attempting to start CPGQL server: ")
+        println(e.getMessage)
+        println("Exiting.")
+
         ammonite.shutdown()
         System.exit(1)
       }


### PR DESCRIPTION
Without this change, an exception encountered during server startup
causes the shell session to be blocked, not accepting any input.

Example message:
```
$ ./joern --server
Starting CPGQL server ...
Unhandled exception thrown while attempting to start CPGQL server, exiting.
```
