### PR TITLE
Close connections gracefully in CPGQL server

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
@@ -57,7 +57,18 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
       connection.send(cask.Ws.Text("connected"))
       openConnections += connection
       cask.WsActor {
-        case cask.Ws.Close(_, _) => openConnections -= connection
+        case cask.Ws.ChannelClosed() => {
+          println("Connection closed.")
+          openConnections -= connection
+        }
+        case cask.Ws.Error(e) => {
+          println("Connection error: " + e.getMessage)
+          openConnections -= connection
+        }
+        case cask.Ws.Close(_, _) => {
+          println("Connection closed.")
+          openConnections -= connection
+        }
       }
     }
   }

--- a/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgqlserver/CPGQLServer.scala
@@ -57,15 +57,11 @@ class CPGQLServer(ammonite: EmbeddedAmmonite,
       connection.send(cask.Ws.Text("connected"))
       openConnections += connection
       cask.WsActor {
-        case cask.Ws.ChannelClosed() => {
-          println("Connection closed.")
-          openConnections -= connection
-        }
         case cask.Ws.Error(e) => {
           println("Connection error: " + e.getMessage)
           openConnections -= connection
         }
-        case cask.Ws.Close(_, _) => {
+        case cask.Ws.Close(_, _) | cask.Ws.ChannelClosed() => {
           println("Connection closed.")
           openConnections -= connection
         }


### PR DESCRIPTION
Previously the server did not dispose of closed connections and instead
tried to send messages to them leading to exceptions.