### PR TITLE
Allow adding multiple ARGUMENT edges

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/Ast.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/Ast.scala
@@ -58,4 +58,11 @@ case class Ast(nodes: List[NewNode],
   def withArgEdge(src: NewNode, dst: NewNode): Ast = {
     this.copy(argEdges = argEdges ++ List(AstEdge(src, dst)))
   }
+
+  def withArgEdges(src: NewNode, dsts: Seq[NewNode]): Ast = {
+    this.copy(argEdges = argEdges ++ dsts.map { d =>
+      AstEdge(src, d)
+    })
+  }
+
 }


### PR DESCRIPTION
It happens often that you want to add multiple ARGUMENT edges from the same source. With the existing `Ast` class, that's only possibly using a foldLeft and that's lengthy. Introduced a short utility method to take care of this.