### PR TITLE
Fix setting of `name` field in `TypeNodePass`

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/typenodes/TypeNodePass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/typenodes/TypeNodePass.scala
@@ -12,9 +12,10 @@ class TypeNodePass(usedTypes: List[String], cpg: Cpg, keyPool: Option[KeyPool] =
   override def run(): Iterator[DiffGraph] = {
     val diffGraph = DiffGraph.newBuilder
     usedTypes.sorted.foreach { typeName =>
+      val shortName = typeName.split('.').lastOption.getOrElse(typeName)
       val node = nodes
         .NewType()
-        .name(typeName)
+        .name(shortName)
         .fullName(typeName)
         .typeDeclFullName(typeName)
       diffGraph.addNode(node)


### PR DESCRIPTION
Previously, the `TypeNodePass` was only used for the C frontend where `name` and `fullName` are the same. Since we're using it for Java now, I needed to fix setting of the `name` field for `TYPE` nodes to only include the unqualified type name.
