### PR TITLE
Change operator extensions

### DIFF
--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/CDataFlowTests.scala
@@ -851,7 +851,7 @@ class CDataFlowTests26 extends DataFlowCodeToCpgSuite {
     val flows = sink.to(Traversal).reachableByFlows(source.to(Traversal)).l
     flows.size shouldBe 0
 
-    val source2 = cpg.assignment.codeExact("a->b = 10").target.l
+    val source2 = cpg.assignment.filter { _.call.code == "a->b = 10" }.target.l
     val sink2 = cpg.method.name("sink").parameter.l
     source2.size shouldBe 1
     sink2.size shouldBe 1
@@ -938,7 +938,7 @@ class CDataFlowTests30 extends DataFlowCodeToCpgSuite {
     val flows = sink.to(Traversal).reachableByFlows(source.to(Traversal)).l
     flows.size shouldBe 0
 
-    val source2 = cpg.assignment.codeExact("b = 10").target.l
+    val source2 = cpg.assignment.filter { _.call.code == "b = 10" }.target.l
     val sink2 = cpg.method.name("sink").parameter.l
     source2.size shouldBe 1
     sink2.size shouldBe 1

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NewCDataFlowTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/querying/NewCDataFlowTests.scala
@@ -94,7 +94,7 @@ class NewCDataFlowTests5 extends DataFlowCodeToCpgSuite {
 
   "should find that flow is blocked by assignment" in {
     val source = cpg.call("source").l
-    val assignment = cpg.assignment.codeExact("x = y")
+    val assignment = cpg.assignment.filter { _.call.code == "x = y" }
     val sink = cpg.call("sink").l
 
     val flows = sink.reachableByFlows(source).l
@@ -161,7 +161,7 @@ class NewCDataFlowTests8 extends DataFlowCodeToCpgSuite {
 
   "should find that flow is blocked by assignment" in {
     val source = cpg.call("source").l
-    val assignment = cpg.assignment.codeExact("x.y = z")
+    val assignment = cpg.assignment.filter { _.call.code == "x.y = z" }
     val sink = cpg.call("sink").l
     val flows = sink.reachableByFlows(source).l
 

--- a/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/AstCreationPassTests.scala
+++ b/fuzzyc2cpg/src/test/scala/io/shiftleft/fuzzyc2cpg/passes/AstCreationPassTests.scala
@@ -103,7 +103,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
           case _ => fail()
         }
 
-        cpg.assignment.l.sortBy(_.order) match {
+        cpg.assignment.l.sortBy(_.call.order) match {
           case List(a1, a2) =>
             List(a1.target.code, a1.source.code) shouldBe List("local", "x")
             List(a2.target.code, a2.source.code) shouldBe List("local2", "y")
@@ -175,7 +175,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
               cndNode.code shouldBe "x < 1"
             case _ => fail()
           }
-          controlStruct.whenTrue.assignments.code.l shouldBe List("x += 1")
+          controlStruct.whenTrue.assignments.map { _.call }.code.l shouldBe List("x += 1")
         case _ => fail()
       }
     }
@@ -200,7 +200,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
             case _ => fail()
 
           }
-          controlStruct.whenTrue.assignments.code.l shouldBe List("y = 0")
+          controlStruct.whenTrue.assignments.map { _.call }.code.l shouldBe List("y = 0")
         case _ => fail()
       }
     }
@@ -297,7 +297,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
     def childContainsAssignments(node: AstNode, i: Int, list: List[String]) = {
       node.astChildren.order(i).l match {
         case List(child) =>
-          child.assignments.code.l shouldBe list
+          child.assignments.map { _.call.code }.l shouldBe list
         case _ => fail()
       }
     }
@@ -736,7 +736,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
                                                                    | }
       """.stripMargin) { cpg =>
       cpg.method.name("method").lineNumber.l shouldBe List(6)
-      cpg.method.name("method").block.assignments.lineNumber.l shouldBe List(8)
+      cpg.method.name("method").block.assignments.flatMap { _.call.lineNumber }.l shouldBe List(8)
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Implicits.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Implicits.scala
@@ -4,6 +4,8 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Expression}
 import io.shiftleft.semanticcpg.language.operatorextension.nodemethods._
 import overflowdb.traversal.Traversal
+import io.shiftleft.semanticcpg.language.operatorextension.opnodes._
+import io.shiftleft.codepropertygraph.generated.nodes.Call
 
 trait Implicits {
   implicit def toNodeTypeStartersOperatorExtension(cpg: Cpg): NodeTypeStarters = new NodeTypeStarters(cpg)
@@ -18,4 +20,7 @@ trait Implicits {
   implicit def toTargetTrav(steps: Traversal[Expression]): TargetTraversal = new TargetTraversal(steps)
   implicit def toOpAstNodeExt[A <: AstNode](node: A): OpAstNodeMethods[A] = new OpAstNodeMethods(node)
   implicit def toOpAstNodeTrav[A <: AstNode](steps: Traversal[A]): OpAstNode[A] = new OpAstNode(steps)
+  implicit def unwrap(assignment: Assignment): Call = assignment.call
+  implicit def unwrap(assignment: Arithmetic): Call = assignment.call
+  implicit def unwrap(assignment: ArrayAccess): Call = assignment.call
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Nodes.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Nodes.scala
@@ -3,10 +3,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 
 object opnodes {
-  case class Assignment(val call: Call) // extends Call(call.graph, call.id)
-  case class Arithmetic(val call: Call) // extends Call(call.graph, call.id)
-  case class ArrayAccess(val call: Call) // extends Call(call.graph, call.id)
-  implicit def unwrap(assignment: Assignment): Call = assignment.call
-  implicit def unwrap(assignment: Arithmetic): Call = assignment.call
-  implicit def unwrap(assignment: ArrayAccess): Call = assignment.call
+  case class Assignment(val call: Call)
+  case class Arithmetic(val call: Call)
+  case class ArrayAccess(val call: Call)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Nodes.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Nodes.scala
@@ -3,7 +3,10 @@ package io.shiftleft.semanticcpg.language.operatorextension
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 
 object opnodes {
-  class Assignment(call: Call) extends Call(call.graph, call.id)
-  class Arithmetic(call: Call) extends Call(call.graph, call.id)
-  class ArrayAccess(call: Call) extends Call(call.graph, call.id)
+  case class Assignment(val call: Call) // extends Call(call.graph, call.id)
+  case class Arithmetic(val call: Call) // extends Call(call.graph, call.id)
+  case class ArrayAccess(val call: Call) // extends Call(call.graph, call.id)
+  implicit def unwrap(assignment: Assignment): Call = assignment.call
+  implicit def unwrap(assignment: Arithmetic): Call = assignment.call
+  implicit def unwrap(assignment: ArrayAccess): Call = assignment.call
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
@@ -7,8 +7,8 @@ import overflowdb.traversal.Traversal
 
 class ArrayAccessMethods(val arrayAccess: opnodes.ArrayAccess) extends AnyVal {
   def array: Expression =
-    arrayAccess.argument(1)
+    arrayAccess.call.argument(1)
 
   def subscripts: Traversal[Identifier] =
-    arrayAccess.argument(2).ast.isIdentifier
+    arrayAccess.call.argument(2).ast.isIdentifier
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
@@ -2,8 +2,9 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language.operatorextension.opnodes
+import io.shiftleft.semanticcpg.language.toCallMethods
 
 class AssignmentMethods(val assignment: opnodes.Assignment) extends AnyVal {
-  def target: Expression = assignment.argument(1)
-  def source: Expression = assignment.argument(2)
+  def target: Expression = assignment.call.argument(1)
+  def source: Expression = assignment.call.argument(2)
 }


### PR DESCRIPTION
The old implementation of operator extensions subclasses Call, and then allocates a new subclassed Call that wraps the same underlying CallDb object with the same id.

Unfortunately, this is breaks underlying assumptions of overflowdb: It is one of the main design constraints of overflowdb that there exists one and only one NodeRef (the superclass of Call) for every node (`public final Noderef ref;` in `NodeDb`). Creating a second one does not work and leads to undebuggable corruption:

-The noderef initially does not get registered.
-eventually, the canonical ref to the underlying nodeDb gets cleared, and the nodeDb gets written to disk
-the canonical ref gets reloaded. Now we have two NodeDb instances with the same id.
-one of them gets modified, and the modifications are invisible to the second one.
-No idea what happens when we try to serialize the entire thing again.

I think we should generally get rid of the OperatorExtensions. They are used very rarely. In lieu of complete removal, this PR changes the API to a supportable one.

cc @mpollmeier for whether my view on the validity of this old construction is correct.
cc @fabsx00 for the new (much uglier) API

If we merge this, then I'll do a second round in joern. Same if we decide to just kick out OperatorExtensions.