### PR TITLE
use jdk11 for main build, but use source/target=1.8

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,10 +17,11 @@ jobs:
       run: git submodule update --init --recursive
     - name: apt-get update
       run: sudo apt-get update
-    - name: Set up JDK 1.8
-      run: sudo apt-get install openjdk-8-jdk
-    - name: Print sbt version
-      run: sbt --version
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: 11
     - name: Compile and run tests
       run: sbt compile test
     - name: Check formatting

--- a/build.sbt
+++ b/build.sbt
@@ -89,9 +89,14 @@ ThisBuild / scalacOptions ++= Seq(
   "-language:implicitConversions",
   "-Ycache-macro-class-loader:last-modified",
   "-Ybackend-parallelism",
-  "4"
+  "4",
+  "-target:jvm-1.8"
 )
-ThisBuild / compile / javacOptions ++= Seq("-g") //debug symbols
+ThisBuild / compile / javacOptions ++= Seq(
+  "-g", //debug symbols
+  "-source", "1.8",
+  "-target", "1.8",
+  "-Xlint")
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / onLoad := {


### PR DESCRIPTION
idea: we want to be able to use these artifacts in downstream builds that require jdk8