### PR TITLE
fixes the below warnings...

### DIFF
--- a/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala
@@ -250,7 +250,7 @@ class CPGQLServerTests extends AnyWordSpec with Matchers {
         postQueryResponse("uuid").str
       }
 
-    Await.result(correctNumberOfUUIDsReceived.future, DefaultPromiseAwaitTimeout * numQueries)
+    Await.result(correctNumberOfUUIDsReceived.future, DefaultPromiseAwaitTimeout * numQueries.toLong)
     wsUUIDs.toSet should be(postQueriesResponseUUIDs.toSet)
   }
 
@@ -287,7 +287,7 @@ class CPGQLServerTests extends AnyWordSpec with Matchers {
           res("uuid").str
         })
     }
-    Await.result(correctNumberOfUUIDsReceived.future, DefaultPromiseAwaitTimeout * queries.size)
+    Await.result(correctNumberOfUUIDsReceived.future, DefaultPromiseAwaitTimeout * queries.size.toLong)
     wsUUIDs.toSet should be(postQueriesResponseUUIDs.toSet)
   }
 }


### PR DESCRIPTION
```
[warn]
/home/mp/Projects/shiftleft/codepropertygraph/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala:253:84:
implicit numeric widening
[warn]     Await.result(correctNumberOfUUIDsReceived.future,
DefaultPromiseAwaitTimeout * numQueries)
[warn]
^
[warn]
/home/mp/Projects/shiftleft/codepropertygraph/console/src/test/scala/io/shiftleft/console/cpgqlserver/CPGQLServerTests.scala:290:92:
implicit numeric widening
[warn]     Await.result(correctNumberOfUUIDsReceived.future,
DefaultPromiseAwaitTimeout * queries.size)
[warn]
```