### PR TITLE
document and deprecate isArrayAccess to arrayAccess, due to break of naming conventions

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
@@ -5,5 +5,13 @@ import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
 
 class TargetTraversal(val traversal: Traversal[Expression]) extends AnyVal {
-  def isArrayAccess: Traversal[opnodes.ArrayAccess] = traversal.flatMap(_.isArrayAccess)
+
+  /** arrayAccess traverses to all array accesses below in the AST. For example, when called on the assignment
+    *   `x = buf[idxs[i]];``
+    * then it will return two array accesses.
+    */
+  def arrayAccess: Traversal[opnodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
+
+  @deprecated("isArrayAccess is deprecated in favor if arrayAccess, due to counterintuitive naming")
+  def isArrayAccess: Traversal[opnodes.ArrayAccess] = arrayAccess
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -7,11 +7,19 @@ import io.shiftleft.semanticcpg.language.operatorextension.opnodes
 import overflowdb.traversal.Traversal
 
 class TargetMethods(val expr: Expression) extends AnyVal {
-  def isArrayAccess: Traversal[opnodes.ArrayAccess] =
+
+  /** arrayAccess traverses to all array accesses below in the AST. For example, when called on the assignment
+    *   `x = buf[idxs[i]];``
+    * then it will return two array accesses.
+    */
+  def arrayAccess: Traversal[opnodes.ArrayAccess] =
     expr.ast.isCall
       .nameExact(Operators.computedMemberAccess,
                  Operators.indirectComputedMemberAccess,
                  Operators.indexAccess,
                  Operators.indirectIndexAccess)
       .map(new opnodes.ArrayAccess(_))
+
+  @deprecated("isArrayAccess is deprecated in favor if arrayAccess, due to counterintuitive naming")
+  def isArrayAccess: Traversal[opnodes.ArrayAccess] = arrayAccess
 }


### PR DESCRIPTION
The unfortunate name was afaiu introduced in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/480

Per slack, the semantics are as intended, it is just the name that suggests different semantics for this method.