### PR TITLE
configure missing implicit pprinter

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -254,6 +254,7 @@ trait BridgeBase {
     val replConfig = List(
       "repl.prompt() = \"" + promptStr() + "\"",
       configurePPrinterMaybe,
+      "implicit val implicitPPrinter = repl.pprinter()"
       "banner()"
     )
     ammonite

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -254,7 +254,7 @@ trait BridgeBase {
     val replConfig = List(
       "repl.prompt() = \"" + promptStr() + "\"",
       configurePPrinterMaybe,
-      "implicit val implicitPPrinter = repl.pprinter()"
+      "implicit val implicitPPrinter = repl.pprinter()",
       "banner()"
     )
     ammonite


### PR DESCRIPTION
fixes e.g. `browse` command, example usage `browse(Seq(1,2,3))`