### PR TITLE
Linker: don't create dummy nodes for default property values

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.5.5

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/FileCreationPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/FileCreationPass.scala
@@ -26,13 +26,15 @@ class FileCreationPass(cpg: Cpg) extends CpgPass(cpg) {
     }
 
     def createFileIfDoesNotExist(srcNode: StoredNode, destFullName: String): Unit = {
-      val dstFullName = if (destFullName == "") { FileTraversal.UNKNOWN } else { destFullName }
-      val newFile = newFileNameToNode.getOrElseUpdate(dstFullName, {
-        val file = NewFile().name(dstFullName).order(0)
-        dstGraph.addNode(file)
-        file
-      })
-      dstGraph.addEdgeFromOriginal(srcNode, newFile, EdgeTypes.SOURCE_FILE)
+      if (destFullName != srcNode.propertyDefaultValue(PropertyNames.FILENAME)) {
+        val dstFullName = if (destFullName == "") { FileTraversal.UNKNOWN } else { destFullName }
+        val newFile = newFileNameToNode.getOrElseUpdate(dstFullName, {
+          val file = NewFile().name(dstFullName).order(0)
+          dstGraph.addNode(file)
+          file
+        })
+        dstGraph.addEdgeFromOriginal(srcNode, newFile, EdgeTypes.SOURCE_FILE)
+      }
     }
 
     // Create SOURCE_FILE edges from nodes of various types

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -220,14 +220,14 @@ object Linker {
           val defaultValueMaybe = Option(srcStoredNode.propertyDefaultValue(dstFullNameKey))
           if (defaultValueMaybe.isEmpty || defaultValueMaybe.get != dstFullName) {
             dstNodeMap.get(dstFullName) match {
-            case Some(dstNode) =>
-              dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
-            case None =>
-              if (dstNotExistsHandler.isDefined) {
-                dstNotExistsHandler.get(srcStoredNode, dstFullName)
-              } else {
-                logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
-              }
+              case Some(dstNode) =>
+                dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
+              case None =>
+                if (dstNotExistsHandler.isDefined) {
+                  dstNotExistsHandler.get(srcStoredNode, dstFullName)
+                } else {
+                  logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
+                }
             }
           }
         }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -216,16 +216,18 @@ object Linker {
         srcNode.propertyOption(new PropertyKey[String](dstFullNameKey)).ifPresent { dstFullName =>
           // for `UNKNOWN` this is not always set, so we're using an Option here
           val srcStoredNode = srcNode.asInstanceOf[StoredNode]
-          if (dstFullName != "<[empty]>") {
+
+          val defaultValueMaybe = Option(srcStoredNode.propertyDefaultValue(dstFullNameKey))
+          if (defaultValueMaybe.isEmpty || defaultValueMaybe.get != dstFullName) {
             dstNodeMap.get(dstFullName) match {
-              case Some(dstNode) =>
-                dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
-              case None =>
-                if (dstNotExistsHandler.isDefined) {
-                  dstNotExistsHandler.get(srcStoredNode, dstFullName)
-                } else {
-                  logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
-                }
+            case Some(dstNode) =>
+              dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
+            case None =>
+              if (dstNotExistsHandler.isDefined) {
+                dstNotExistsHandler.get(srcStoredNode, dstFullName)
+              } else {
+                logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
+              }
             }
           }
         }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -221,7 +221,7 @@ object Linker {
               dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
             case None if dstNotExistsHandler.isDefined =>
               dstNotExistsHandler.get(srcStoredNode, dstFullName)
-            case _ => 
+            case _ =>
               logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
           }
         }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -216,19 +216,13 @@ object Linker {
         srcNode.propertyOption(new PropertyKey[String](dstFullNameKey)).ifPresent { dstFullName =>
           // for `UNKNOWN` this is not always set, so we're using an Option here
           val srcStoredNode = srcNode.asInstanceOf[StoredNode]
-
-          val defaultValueMaybe = Option(srcStoredNode.propertyDefaultValue(dstFullNameKey))
-          if (defaultValueMaybe.isEmpty || defaultValueMaybe.get != dstFullName) {
-            dstNodeMap.get(dstFullName) match {
-              case Some(dstNode) =>
-                dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
-              case None =>
-                if (dstNotExistsHandler.isDefined) {
-                  dstNotExistsHandler.get(srcStoredNode, dstFullName)
-                } else {
-                  logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
-                }
-            }
+          dstNodeMap.get(dstFullName) match {
+            case Some(dstNode) =>
+              dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
+            case None if dstNotExistsHandler.isDefined =>
+              dstNotExistsHandler.get(srcStoredNode, dstFullName)
+            case _ => 
+              logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
           }
         }
       } else {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/linker/Linker.scala
@@ -216,15 +216,17 @@ object Linker {
         srcNode.propertyOption(new PropertyKey[String](dstFullNameKey)).ifPresent { dstFullName =>
           // for `UNKNOWN` this is not always set, so we're using an Option here
           val srcStoredNode = srcNode.asInstanceOf[StoredNode]
-          dstNodeMap.get(dstFullName) match {
-            case Some(dstNode) =>
-              dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
-            case None =>
-              if (dstNotExistsHandler.isDefined) {
-                dstNotExistsHandler.get(srcStoredNode, dstFullName)
-              } else {
-                logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
-              }
+          if (dstFullName != "<[empty]>") {
+            dstNodeMap.get(dstFullName) match {
+              case Some(dstNode) =>
+                dstGraph.addEdgeInOriginal(srcStoredNode, dstNode, edgeType)
+              case None =>
+                if (dstNotExistsHandler.isDefined) {
+                  dstNotExistsHandler.get(srcStoredNode, dstFullName)
+                } else {
+                  logFailedDstLookup(edgeType, srcNode.label, srcNode.id.toString, dstNodeLabel, dstFullName)
+                }
+            }
           }
         }
       } else {


### PR DESCRIPTION
prior to this change, the CS/FlowPrettyPrinterExt didn't report file names any more, 
which was due to the FileCreationPass creating additional (empty) file nodes, caused by not handling default values in the Linker.