### PR TITLE
Revert "Remove ArgumentCompat pass after more than 2 years."

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -6,6 +6,7 @@ import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.cfgdominator.CfgDominatorPass
 import io.shiftleft.semanticcpg.passes.codepencegraph.CdgPass
+import io.shiftleft.semanticcpg.passes.compat.argumentcompat.ArgumentCompat
 import io.shiftleft.semanticcpg.passes.containsedges.ContainsEdgePass
 import io.shiftleft.semanticcpg.passes.languagespecific.fuzzyc.MethodStubCreator
 import io.shiftleft.semanticcpg.passes.linking.calllinker.StaticCallLinker
@@ -51,6 +52,7 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
     language match {
       case Languages.JAVA =>
         Iterator(
+          new ArgumentCompat(cpg),
           new ReceiverEdgePass(cpg),
           new MethodDecoratorPass(cpg),
           new Linker(cpg),
@@ -99,6 +101,7 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
       case Languages.JAVASCRIPT =>
         Iterator(
           new CfgCreationPass(cpg),
+          new ArgumentCompat(cpg),
           new MethodStubCreator(cpg),
           new MethodDecoratorPass(cpg),
           new Linker(cpg),

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/argumentcompat/ArgumentCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/compat/argumentcompat/ArgumentCompat.scala
@@ -1,0 +1,40 @@
+package io.shiftleft.semanticcpg.passes.compat.argumentcompat
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.AstNode
+import io.shiftleft.passes.{CpgPass, DiffGraph}
+import io.shiftleft.semanticcpg.language._
+import org.slf4j.{Logger, LoggerFactory}
+import overflowdb.traversal._
+
+import scala.jdk.CollectionConverters._
+
+class ArgumentCompat(cpg: Cpg) extends CpgPass(cpg) {
+  override def run(): Iterator[DiffGraph] = {
+    val oldFormat = cpg.graph.edges(EdgeTypes.ARGUMENT).isEmpty
+
+    if (oldFormat) {
+      ArgumentCompat.logger.info(s"Using old CPG format not containing ARGUMENT edges.")
+
+      val diffGraph = DiffGraph.newBuilder
+      cpg.call.foreach(addArgumentEdges(_, diffGraph))
+      cpg.ret.foreach(addArgumentEdges(_, diffGraph))
+      Iterator(diffGraph.build())
+    } else {
+      Iterator.empty
+    }
+  }
+
+  private def addArgumentEdges(callOrReturn: AstNode, diffGraph: DiffGraph.Builder): Unit = {
+    callOrReturn._astOut.asScala.foreach { argument =>
+      if (!argument._argumentIn.hasNext) {
+        diffGraph.addEdgeInOriginal(callOrReturn, argument, EdgeTypes.ARGUMENT)
+      }
+    }
+  }
+}
+
+object ArgumentCompat {
+  private val logger: Logger = LoggerFactory.getLogger(classOf[ArgumentCompat])
+}


### PR DESCRIPTION
Reverts ShiftLeftSecurity/codepropertygraph#1303

This is still needed for py2cpg... let's bring this back for now until we've adapted py2cpg. 