### PR TITLE
Fix file name compatibility pass.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/filecompat/FileNameCompat.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/filecompat/FileNameCompat.scala
@@ -20,8 +20,8 @@ class FileNameCompat(cpg: Cpg) extends CpgPass(cpg) {
     def updateDefaultFileName(node: StoredNode with HasFilename): Unit = {
       // When creating nodes via NewNode classes, filename is "", not null.
       // For operators, filename might also be null.
-      if (node.filename == null || node.filename == "") {
-        dstGraph.addNodeProperty(node, "FILENAME", node.file.name.headOption.getOrElse(""))
+      if (node.filename == "<empty>") {
+        dstGraph.addNodeProperty(node, "FILENAME", node.file.name.headOption.getOrElse("empty"))
       }
     }
 


### PR DESCRIPTION
Since default values got introduced, the absence of a meaningful file
name is indicated by "<empty>".

Potential fix for: https://github.com/ShiftLeftSecurity/product/issues/8166