### PR TITLE
Fixed two potential crashes for c2cpg

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/testfixtures/CCodeToCpgSuite.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/testfixtures/CCodeToCpgSuite.scala
@@ -14,7 +14,8 @@ class C2CpgFrontend extends LanguageFrontend {
     val c2cpg = new C2Cpg()
     val config = Config(inputPaths = Set(sourceCodePath.getAbsolutePath),
                         outputPath = cpgFile.getAbsolutePath,
-                        sourceFileExtensions = Set(fileSuffix))
+                        sourceFileExtensions = Set(fileSuffix),
+                        includeComments = true)
     c2cpg.runAndOutput(config)
   }
   override val fileSuffix: String = ".c"

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/C2Cpg.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/C2Cpg.scala
@@ -42,7 +42,7 @@ class C2Cpg {
     val sourceFileNames = SourceFiles.determine(config.inputPaths, config.sourceFileExtensions)
 
     new MetaDataPass(cpg, Languages.C, Some(metaDataKeyPool)).createAndApply()
-    val astCreationPass = new AstCreationPass(sourceFileNames, cpg, functionKeyPool, createParseConfig(config))
+    val astCreationPass = new AstCreationPass(sourceFileNames, cpg, functionKeyPool, config, createParseConfig(config))
     astCreationPass.createAndApply()
     new CfgCreationPass(cpg).createAndApply()
     new StubRemovalPass(cpg).createAndApply()
@@ -61,6 +61,7 @@ object C2Cpg {
                           sourceFileExtensions: Set[String] = Set(".c", ".cc", ".cpp", ".h", ".hpp"),
                           includePaths: Set[String] = Set.empty,
                           defines: Set[String] = Set.empty,
+                          includeComments: Boolean = false,
                           logProblems: Boolean = false,
                           logPreprocessor: Boolean = false)
       extends X2CpgConfig[Config] {
@@ -76,6 +77,9 @@ object C2Cpg {
       import builder._
       OParser.sequence(
         programName(classOf[C2Cpg].getSimpleName),
+        opt[Unit]("include-comments")
+          .text(s"includes all comments into the CPG")
+          .action((_, c) => c.copy(includeComments = true)),
         opt[Unit]("log-problems")
           .text(s"enables logging of all parse problems")
           .action((_, c) => c.copy(logProblems = true)),

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
@@ -66,10 +66,10 @@ class CdtParser(private val parseConfig: ParseConfig) extends ParseProblemsLogge
       logger.info(s"Parsed '${t.getFilePath}' in $duration ($c preprocessor error(s), $p problems)")
       r
     case (r @ ParseResult(_, _, _, Some(e)), duration) =>
-      logger.warn(s"Failed to parsed '$file' (took: $duration): ${e.getMessage}")
+      logger.warn(s"Failed to parse '$file' (took: $duration): ${e.getMessage}")
       r
     case (r @ ParseResult(_, _, _, None), duration) =>
-      logger.warn(s"Failed to parsed '$file' (took: $duration)")
+      logger.warn(s"Failed to parse '$file' (took: $duration)")
       r
   }
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
@@ -17,7 +17,10 @@ object CdtParser {
 
   private val logger = LoggerFactory.getLogger(classOf[CdtParser])
 
-  case class ParseResult(translationUnit: Option[IASTTranslationUnit], preprocessorErrorCount: Int, problems: Int)
+  case class ParseResult(translationUnit: Option[IASTTranslationUnit],
+                         preprocessorErrorCount: Int,
+                         problems: Int,
+                         failure: Option[Throwable] = None)
 
 }
 
@@ -43,8 +46,7 @@ class CdtParser(private val parseConfig: ParseConfig) extends ParseProblemsLogge
         lang.getASTTranslationUnit(fileContent, info, fileContentProvider, null, opts, log)
       ) match {
         case Failure(e) =>
-          e.printStackTrace()
-          ParseResult(None, -1, -1)
+          ParseResult(None, -1, -1, Some(e))
         case Success(translationUnit) =>
           val problems = CPPVisitor.getProblems(translationUnit)
           if (parseConfig.logProblems) logProblems(problems.toList)
@@ -60,11 +62,14 @@ class CdtParser(private val parseConfig: ParseConfig) extends ParseProblemsLogge
   }
 
   def parse(file: Path): ParseResult = parseInternal(file) match {
-    case (r @ ParseResult(None, _, _), duration) =>
-      logger.warn(s"Failed to parsed '$file' (took: $duration)")
-      r
-    case (r @ ParseResult(Some(t), c, p), duration) =>
+    case (r @ ParseResult(Some(t), c, p, _), duration) =>
       logger.info(s"Parsed '${t.getFilePath}' in $duration ($c preprocessor error(s), $p problems)")
+      r
+    case (r @ ParseResult(_, _, _, Some(e)), duration) =>
+      logger.warn(s"Failed to parsed '$file' (took: $duration): ${e.getMessage}")
+      r
+    case (r @ ParseResult(_, _, _, None), duration) =>
+      logger.warn(s"Failed to parsed '$file' (took: $duration)")
       r
   }
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreationPass.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreationPass.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.c2cpg.passes
 
+import io.shiftleft.c2cpg.C2Cpg
 import io.shiftleft.c2cpg.parser.CdtParser.ParseResult
 import io.shiftleft.c2cpg.parser.{CdtParser, ParseConfig}
 import io.shiftleft.codepropertygraph.Cpg
@@ -11,6 +12,7 @@ import scala.jdk.CollectionConverters._
 class AstCreationPass(filenames: List[String],
                       cpg: Cpg,
                       keyPool: IntervalKeyPool,
+                      config: C2Cpg.Config,
                       parseConfig: ParseConfig = ParseConfig.empty)
     extends ParallelCpgPass[String](cpg, keyPools = Some(keyPool.split(filenames.size))) {
 
@@ -25,8 +27,8 @@ class AstCreationPass(filenames: List[String],
     val parseResult = parser.parse(Paths.get(filename))
 
     parseResult match {
-      case ParseResult(Some(ast), _, _) =>
-        new AstCreator(filename, global).createAst(ast)
+      case ParseResult(Some(ast), _, _, _) =>
+        new AstCreator(filename, global, config).createAst(ast)
       case _ =>
         Iterator()
     }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
@@ -738,11 +738,12 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
     val expr = astForExpression(arrayIndexExpression.getArrayExpression, 1)
     val arg = astForNode(arrayIndexExpression.getArgument, 2)
 
-    Ast(cpgArrayIndexing)
+    var ast = Ast(cpgArrayIndexing)
       .withChild(expr)
       .withChild(arg)
-      .withArgEdge(cpgArrayIndexing, expr.root.get)
-      .withArgEdge(cpgArrayIndexing, arg.root.get)
+    if (expr.root.isDefined) ast = ast.withArgEdge(cpgArrayIndexing, expr.root.get)
+    if (arg.root.isDefined) ast = ast.withArgEdge(cpgArrayIndexing, arg.root.get)
+    ast
   }
 
   private def astForCastExpression(castExpression: IASTCastExpression, order: Int): Ast = {
@@ -760,11 +761,12 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
         .lineNumber(line(argNode))
         .columnNumber(column(argNode)))
 
-    Ast(cpgCastExpression)
+    var ast = Ast(cpgCastExpression)
       .withChild(arg)
       .withChild(expr)
       .withArgEdge(cpgCastExpression, arg.root.get)
-      .withArgEdge(cpgCastExpression, expr.root.get)
+    if (expr.root.isDefined) ast = ast.withArgEdge(cpgCastExpression, expr.root.get)
+    ast
   }
 
   private def astForNewExpression(newExpression: ICPPASTNewExpression, order: Int): Ast = {
@@ -800,7 +802,9 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
     val cpgDeleteNode =
       newCallNode(delExpression, Operators.delete, Operators.delete, DispatchTypes.STATIC_DISPATCH, order)
     val arg = astForExpression(delExpression.getOperand, 1)
-    Ast(cpgDeleteNode).withChild(arg).withArgEdge(cpgDeleteNode, arg.root.get)
+    var ast = Ast(cpgDeleteNode).withChild(arg)
+    if (arg.root.isDefined) ast = ast.withArgEdge(cpgDeleteNode, arg.root.get)
+    ast
   }
 
   private def astForQualifiedName(qualId: CPPASTQualifiedName, order: Int): Ast = {
@@ -1192,12 +1196,10 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
       val left = astForNode(enumerator.getName, 1)
       val right = astForNode(enumerator.getValue, 2)
 
-      Seq(Ast(cpgMember),
-          Ast(callNode)
-            .withChild(left)
-            .withArgEdge(callNode, left.root.get)
-            .withChild(right)
-            .withArgEdge(callNode, right.root.get))
+      var ast = Ast(cpgMember).withChild(left).withChild(right)
+      if (left.root.isDefined) ast = ast.withArgEdge(callNode, left.root.get)
+      if (right.root.isDefined) ast = ast.withArgEdge(callNode, right.root.get)
+      Seq(ast)
     } else {
       Seq(Ast(cpgMember))
     }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
@@ -1196,10 +1196,10 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
       val left = astForNode(enumerator.getName, 1)
       val right = astForNode(enumerator.getValue, 2)
 
-      var ast = Ast(cpgMember).withChild(left).withChild(right)
+      var ast = Ast(callNode).withChild(left).withChild(right)
       if (left.root.isDefined) ast = ast.withArgEdge(callNode, left.root.get)
       if (right.root.isDefined) ast = ast.withArgEdge(callNode, right.root.get)
-      Seq(ast)
+      Seq(Ast(cpgMember), ast)
     } else {
       Seq(Ast(cpgMember))
     }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
@@ -20,7 +20,9 @@ import org.eclipse.cdt.internal.core.dom.parser.cpp.{
 }
 import org.slf4j.LoggerFactory
 
+import java.io.{BufferedReader, FileInputStream, InputStreamReader}
 import scala.annotation.tailrec
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 object AstCreator {
@@ -39,7 +41,8 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
 
   import AstCreator._
 
-  private val fileLines = better.files.File(filename).lines.toSeq.map(l => l.length)
+  private val reader = new BufferedReader(new InputStreamReader(new FileInputStream(filename), "utf-8"));
+  private val fileLines = reader.lines().iterator().asScala.map(_.length)
 
   private val scope = new Scope[String, (NewNode, String), NewNode]()
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
@@ -42,7 +42,7 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
   import AstCreator._
 
   private val reader = new BufferedReader(new InputStreamReader(new FileInputStream(filename), "utf-8"));
-  private val fileLines = reader.lines().iterator().asScala.map(_.length)
+  private val fileLines = reader.lines().iterator().asScala.toSeq.map(_.length)
 
   private val scope = new Scope[String, (NewNode, String), NewNode]()
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
@@ -787,11 +787,12 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
         } else {
           Seq.empty
         }
+      val validArgs = args.filter(_.root.isDefined)
       Ast(cpgNewExpression)
         .withChild(cpgTypeId)
-        .withChildren(args)
+        .withChildren(validArgs)
         .withArgEdge(cpgNewExpression, cpgTypeId.root.get)
-        .withArgEdges(cpgNewExpression, args.map(_.root.get))
+        .withArgEdges(cpgNewExpression, validArgs.map(_.root.get))
     }
   }
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory
 
 import java.io.{BufferedReader, FileInputStream, InputStreamReader}
 import scala.annotation.tailrec
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 
 object AstCreator {
 

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/CpgTestFixture.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/CpgTestFixture.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.c2cpg
 
+import io.shiftleft.c2cpg.C2Cpg.Config
 import io.shiftleft.c2cpg.passes.{AstCreationPass, StubRemovalPass}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Languages
@@ -20,7 +21,7 @@ case class CpgTestFixture(projectName: String) {
   private val filenames: List[String] = SourceFiles.determine(Set(dirName), Set(".c"))
 
   new MetaDataPass(cpg, Languages.C).createAndApply()
-  new AstCreationPass(filenames, cpg, keyPool).createAndApply()
+  new AstCreationPass(filenames, cpg, keyPool, Config()).createAndApply()
   if (cpg.method.nonEmpty) {
     new CfgCreationPass(cpg).createAndApply()
   }

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/EnumTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/EnumTests.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.c2cpg
 
 import better.files.File
+import io.shiftleft.c2cpg.C2Cpg.Config
 import io.shiftleft.c2cpg.passes.{AstCreationPass, StubRemovalPass}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -25,7 +26,7 @@ class EnumTests extends AnyWordSpec with Matchers with Inside {
         val keyPool = new IntervalKeyPool(1001, 2000)
         val typesKeyPool = new IntervalKeyPool(2001, 3000)
         val filenames = List(file.path.toAbsolutePath.toString)
-        val astCreationPass = new AstCreationPass(filenames, cpg, keyPool)
+        val astCreationPass = new AstCreationPass(filenames, cpg, keyPool, Config())
         astCreationPass.createAndApply()
         new CfgCreationPass(cpg).createAndApply()
         new StubRemovalPass(cpg).createAndApply()

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/NamespaceTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/NamespaceTests.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.c2cpg
 
 import better.files.File
+import io.shiftleft.c2cpg.C2Cpg.Config
 import io.shiftleft.c2cpg.passes.{AstCreationPass, StubRemovalPass}
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.Operators
@@ -25,7 +26,7 @@ class NamespaceTests extends AnyWordSpec with Matchers with Inside {
         val keyPool = new IntervalKeyPool(1001, 2000)
         val typesKeyPool = new IntervalKeyPool(2001, 3000)
         val filenames = List(file.path.toAbsolutePath.toString)
-        val astCreationPass = new AstCreationPass(filenames, cpg, keyPool)
+        val astCreationPass = new AstCreationPass(filenames, cpg, keyPool, Config())
         astCreationPass.createAndApply()
         new CfgCreationPass(cpg).createAndApply()
         new StubRemovalPass(cpg).createAndApply()

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.c2cpg.passes
 
 import better.files.File
+import io.shiftleft.c2cpg.C2Cpg.Config
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
@@ -23,7 +24,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
         val cpg = Cpg.emptyCpg
         val keyPool = new IntervalKeyPool(1001, 2000)
         val filenames = List(file1.path.toAbsolutePath.toString, file2.path.toAbsolutePath.toString)
-        new AstCreationPass(filenames, cpg, keyPool).createAndApply()
+        new AstCreationPass(filenames, cpg, keyPool, Config()).createAndApply()
 
         f(cpg)
       }
@@ -39,7 +40,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
         file.write("//foo")
         file.path.toAbsolutePath.toString
       }
-      new AstCreationPass(expectedFilenames, cpg, new IntervalKeyPool(1, 1000)).createAndApply()
+      new AstCreationPass(expectedFilenames, cpg, new IntervalKeyPool(1, 1000), Config()).createAndApply()
 
       "create one NamespaceBlock per file" in {
         val expectedNamespaceFullNames = expectedFilenames.map(f => s"$f:<global>").toSet

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
@@ -3,7 +3,7 @@ package io.shiftleft.c2cpg.passes
 import better.files.File
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, DispatchTypes, Operators}
+import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Operators}
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
 import org.scalatest.matchers.should.Matchers
@@ -394,11 +394,12 @@ class AstCreationPassTests extends AnyWordSpec with Matchers {
       cpg.method.name("method").ast.isCall.l match {
         case List(call: Call) =>
           call.name shouldBe "foo"
-          call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
-          val rec = call.receiver.l
-          rec.length shouldBe 1
-          rec.head.code shouldBe "foo"
-          call.argument(0).code shouldBe "foo"
+          // TODO: fix call receiver
+          // call.dispatchType shouldBe DispatchTypes.DYNAMIC_DISPATCH
+          // val rec = call.receiver.l
+          // rec.length shouldBe 1
+          // rec.head.code shouldBe "foo"
+          // call.argument(0).code shouldBe "foo"
           call.argument(1).code shouldBe "x"
         case _ => fail()
       }

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/CfgCreationPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/CfgCreationPassTests.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.c2cpg.passes
 
 import better.files.File
+import io.shiftleft.c2cpg.C2Cpg.Config
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.CfgNode
 import io.shiftleft.passes.IntervalKeyPool
@@ -23,7 +24,7 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
       file1.write(s"RET func() { $file1Code }")
       val keyPoolFile1 = new IntervalKeyPool(1001, 2000)
       val filenames = List(file1.path.toAbsolutePath.toString)
-      new AstCreationPass(filenames, cpg, keyPoolFile1).createAndApply()
+      new AstCreationPass(filenames, cpg, keyPoolFile1, Config()).createAndApply()
       new CfgCreationPass(cpg).createAndApply()
     }
 

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/StubRemovalPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/StubRemovalPassTests.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.c2cpg.passes
 
 import better.files.File
+import io.shiftleft.c2cpg.C2Cpg.Config
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
@@ -18,7 +19,7 @@ class StubRemovalPassTests extends AnyWordSpec with Matchers {
         val cpg = Cpg.emptyCpg
         val keyPool = new IntervalKeyPool(1001, 2000)
         val filenames = List(file1.path.toAbsolutePath.toString)
-        new AstCreationPass(filenames, cpg, keyPool).createAndApply()
+        new AstCreationPass(filenames, cpg, keyPool, Config()).createAndApply()
         new CfgCreationPass(cpg).createAndApply()
         new StubRemovalPass(cpg).createAndApply()
         f(cpg)

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/TypeNodePassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/TypeNodePassTests.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.c2cpg.passes
 
 import better.files.File
+import io.shiftleft.c2cpg.C2Cpg.Config
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.IntervalKeyPool
 import io.shiftleft.semanticcpg.language._
@@ -19,7 +20,7 @@ class TypeNodePassTests extends AnyWordSpec with Matchers {
         val cpg = Cpg.emptyCpg
         val keyPool = new IntervalKeyPool(1001, 2000)
         val filenames = List(file1.path.toAbsolutePath.toString)
-        val astCreator = new AstCreationPass(filenames, cpg, keyPool)
+        val astCreator = new AstCreationPass(filenames, cpg, keyPool, Config())
         astCreator.createAndApply()
         new TypeNodePass(astCreator.usedTypes(), cpg).createAndApply()
 


### PR DESCRIPTION
1) call receivers were messed up - removing them for now to get ocular/joern sessions running correctly
2) goto code fields were wrong in the presence of macros.

Also: improved error handling, improved handling of empty AST sub-results.