### PR TITLE
Fixed order/argumentIndex of MethodReturns

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MethodReturnTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MethodReturnTests.scala
@@ -19,7 +19,7 @@ class MethodReturnTests extends CCodeToCpgSuite {
     // we expect the METHOD_RETURN node to be the right-most
     // child so that when traversing the AST from left to
     // right in CFG construction, we visit it last.
-    x.order shouldBe 3
+    x.order shouldBe 2
   }
 
   "should allow traversing to method" in {

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MethodReturnTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MethodReturnTests.scala
@@ -19,7 +19,7 @@ class MethodReturnTests extends CCodeToCpgSuite {
     // we expect the METHOD_RETURN node to be the right-most
     // child so that when traversing the AST from left to
     // right in CFG construction, we visit it last.
-    x.order shouldBe 2
+    x.order shouldBe 3
   }
 
   "should allow traversing to method" in {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
@@ -424,7 +424,7 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
     val r = Ast(methodNode)
       .withChildren(parameterAsts)
       .withChild(astForMethodBody(Option(functDef.getBody), lastOrder))
-      .withChild(astForMethodReturn(functDef, lastOrder, typeForDeclSpecifier(functDef.getDeclSpecifier)))
+      .withChild(astForMethodReturn(functDef, lastOrder + 1, typeForDeclSpecifier(functDef.getDeclSpecifier)))
 
     scope.popScope()
     r

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreator.scala
@@ -420,7 +420,7 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
       astForParameter(p, order)
     }
 
-    val lastOrder = 2 + parameterAsts.size
+    val lastOrder = 1 + parameterAsts.size
     val r = Ast(methodNode)
       .withChildren(parameterAsts)
       .withChild(astForMethodBody(Option(functDef.getBody), lastOrder))
@@ -1267,7 +1267,7 @@ class AstCreator(filename: String, global: Global, config: C2Cpg.Config) {
       astForParameter(p, order)
     }
 
-    val lastOrder = 2 + parameterAsts.size
+    val lastOrder = 1 + parameterAsts.size
     val r = Ast(methodNode)
       .withChildren(parameterAsts)
       .withChild(astForMethodReturn(funcDecl, lastOrder, returnType))


### PR DESCRIPTION
The CFGCreator gets confused otherwise if multiple AST children have the same order/index.