### PR TITLE
Add `range` operator to schema

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
@@ -237,6 +237,12 @@ object Operators extends SchemaBase {
         valueType = ValueTypes.STRING,
         comment = "Replaces an expression with its string value."
       ),
+      Constant(
+        name = "range",
+        value = "<operator>.range",
+        valueType = ValueTypes.STRING,
+        comment = "Defines a range of values, e.g. `for (i in 1..10) print(i)`."
+      ),
     )
 
   }


### PR DESCRIPTION
Used in languages like Kotlin, Swift, Perl or Bash.
