### PR TITLE
clean up types and edge api for cfg analysis

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
@@ -1,7 +1,8 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 
@@ -10,11 +11,11 @@ import scala.collection.mutable
 /**
   * This pass has no prerequisites.
   */
-class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
+class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[Method](cpg) {
 
-  override def partIterator: Iterator[nodes.Method] = cpg.method.iterator
+  override def partIterator: Iterator[Method] = cpg.method.iterator
 
-  override def runOnPart(method: nodes.Method): Iterator[DiffGraph] = {
+  override def runOnPart(method: Method): Iterator[DiffGraph] = {
     val cfgAdapter = new CpgCfgAdapter()
     val dominatorCalculator = new CfgDominator(cfgAdapter)
 
@@ -33,7 +34,7 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
   }
 
   private def addDomTreeEdges(dstGraph: DiffGraph.Builder,
-                              cfgNodeToImmediateDominator: mutable.Map[nodes.StoredNode, nodes.StoredNode]): Unit = {
+                              cfgNodeToImmediateDominator: mutable.Map[StoredNode, StoredNode]): Unit = {
     // TODO do not iterate over potential hash map to ensure same interation order for
     // edge creation.
     cfgNodeToImmediateDominator.foreach {
@@ -42,9 +43,8 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
     }
   }
 
-  private def addPostDomTreeEdges(
-      dstGraph: DiffGraph.Builder,
-      cfgNodeToPostImmediateDominator: mutable.Map[nodes.StoredNode, nodes.StoredNode]): Unit = {
+  private def addPostDomTreeEdges(dstGraph: DiffGraph.Builder,
+                                  cfgNodeToPostImmediateDominator: mutable.Map[StoredNode, StoredNode]): Unit = {
     // TODO do not iterate over potential hash map to ensure same interation order for
     // edge creation.
     cfgNodeToPostImmediateDominator.foreach {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
@@ -1,22 +1,20 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{Method, StoredNode}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.Node
 
 import scala.collection.mutable
 
 /**
   * This pass has no prerequisites.
   */
-class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[Method](cpg) {
+class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[nodes.Method](cpg) {
 
-  override def partIterator: Iterator[Method] = cpg.method.iterator
+  override def partIterator: Iterator[nodes.Method] = cpg.method.iterator
 
-  override def runOnPart(method: Method): Iterator[DiffGraph] = {
+  override def runOnPart(method: nodes.Method): Iterator[DiffGraph] = {
     val cfgAdapter = new CpgCfgAdapter()
     val dominatorCalculator = new CfgDominator(cfgAdapter)
 
@@ -35,26 +33,23 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[Method](cpg) {
   }
 
   private def addDomTreeEdges(dstGraph: DiffGraph.Builder,
-                              cfgNodeToImmediateDominator: mutable.Map[Node, Node]): Unit = {
+                              cfgNodeToImmediateDominator: mutable.Map[nodes.StoredNode, nodes.StoredNode]): Unit = {
     // TODO do not iterate over potential hash map to ensure same interation order for
     // edge creation.
     cfgNodeToImmediateDominator.foreach {
       case (node, immediateDominator) =>
-        dstGraph.addEdgeInOriginal(immediateDominator.asInstanceOf[StoredNode],
-                                   node.asInstanceOf[StoredNode],
-                                   EdgeTypes.DOMINATE)
+        dstGraph.addEdgeInOriginal(immediateDominator, node, EdgeTypes.DOMINATE)
     }
   }
 
-  private def addPostDomTreeEdges(dstGraph: DiffGraph.Builder,
-                                  cfgNodeToPostImmediateDominator: mutable.Map[Node, Node]): Unit = {
+  private def addPostDomTreeEdges(
+      dstGraph: DiffGraph.Builder,
+      cfgNodeToPostImmediateDominator: mutable.Map[nodes.StoredNode, nodes.StoredNode]): Unit = {
     // TODO do not iterate over potential hash map to ensure same interation order for
     // edge creation.
     cfgNodeToPostImmediateDominator.foreach {
       case (node, immediatePostDominator) =>
-        dstGraph.addEdgeInOriginal(immediatePostDominator.asInstanceOf[StoredNode],
-                                   node.asInstanceOf[StoredNode],
-                                   EdgeTypes.POST_DOMINATE)
+        dstGraph.addEdgeInOriginal(immediatePostDominator, node, EdgeTypes.POST_DOMINATE)
     }
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.passes.cfgdominator
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.{Method, StoredNode}
 import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CpgCfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CpgCfgAdapter.scala
@@ -1,16 +1,15 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 
 import scala.jdk.CollectionConverters._
 
-class CpgCfgAdapter extends CfgAdapter[nodes.StoredNode] {
-  override def successors(node: nodes.StoredNode): IterableOnce[nodes.StoredNode] = {
+class CpgCfgAdapter extends CfgAdapter[StoredNode] {
+  override def successors(node: StoredNode): IterableOnce[StoredNode] = {
     node._cfgOut.asScala
   }
 
-  override def predecessors(node: nodes.StoredNode): IterableOnce[nodes.StoredNode] = {
+  override def predecessors(node: StoredNode): IterableOnce[StoredNode] = {
     node._cfgIn.asScala
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CpgCfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CpgCfgAdapter.scala
@@ -1,16 +1,16 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import overflowdb.Node
+import io.shiftleft.codepropertygraph.generated.nodes
 
 import scala.jdk.CollectionConverters._
 
-class CpgCfgAdapter extends CfgAdapter[Node] {
-  override def successors(node: Node): IterableOnce[Node] = {
-    node.out(EdgeTypes.CFG).asScala
+class CpgCfgAdapter extends CfgAdapter[nodes.StoredNode] {
+  override def successors(node: nodes.StoredNode): IterableOnce[nodes.StoredNode] = {
+    node._cfgOut.asScala
   }
 
-  override def predecessors(node: Node): IterableOnce[Node] = {
-    node.in(EdgeTypes.CFG).asScala
+  override def predecessors(node: nodes.StoredNode): IterableOnce[nodes.StoredNode] = {
+    node._cfgIn.asScala
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/ReverseCpgCfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/ReverseCpgCfgAdapter.scala
@@ -1,16 +1,15 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import overflowdb.Node
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
 
 import scala.jdk.CollectionConverters._
 
-class ReverseCpgCfgAdapter extends CfgAdapter[Node] {
-  override def successors(node: Node): IterableOnce[Node] = {
-    node.in(EdgeTypes.CFG).asScala
+class ReverseCpgCfgAdapter extends CfgAdapter[nodes.StoredNode] {
+  override def successors(node: nodes.StoredNode): IterableOnce[nodes.StoredNode] = {
+    node._cfgIn.asScala
   }
 
-  override def predecessors(node: Node): IterableOnce[Node] = {
-    node.out(EdgeTypes.CFG).asScala
+  override def predecessors(node: nodes.StoredNode): IterableOnce[nodes.StoredNode] = {
+    node._cfgOut.asScala
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/ReverseCpgCfgAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/ReverseCpgCfgAdapter.scala
@@ -1,15 +1,15 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, nodes}
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 
 import scala.jdk.CollectionConverters._
 
-class ReverseCpgCfgAdapter extends CfgAdapter[nodes.StoredNode] {
-  override def successors(node: nodes.StoredNode): IterableOnce[nodes.StoredNode] = {
+class ReverseCpgCfgAdapter extends CfgAdapter[StoredNode] {
+  override def successors(node: StoredNode): IterableOnce[StoredNode] = {
     node._cfgIn.asScala
   }
 
-  override def predecessors(node: nodes.StoredNode): IterableOnce[nodes.StoredNode] = {
+  override def predecessors(node: StoredNode): IterableOnce[StoredNode] = {
     node._cfgOut.asScala
   }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
@@ -3,11 +3,11 @@ package io.shiftleft.semanticcpg.passes.codepencegraph
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{
-  Literal,
   Call,
   ControlStructure,
   Identifier,
   JumpTarget,
+  Literal,
   Method,
   MethodRef,
   Unknown

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.passes.codepencegraph
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
-import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Properties}
+import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominatorFrontier, ReverseCpgCfgAdapter}
@@ -32,16 +32,15 @@ class CdgPass(cpg: Cpg) extends ParallelCpgPass[Method](cpg) {
         postDomFrontierNode match {
           case _: Literal | _: Identifier | _: Call | _: MethodRef | _: Unknown | _: ControlStructure |
               _: JumpTarget => {
-            dstGraph.addEdgeInOriginal(postDomFrontierNode.asInstanceOf[StoredNode],
-                                       node.asInstanceOf[StoredNode],
-                                       EdgeTypes.CDG)
+            dstGraph.addEdgeInOriginal(postDomFrontierNode, node, EdgeTypes.CDG)
           }
           case _ =>
-            val method = postDomFrontierNode.in(EdgeTypes.CONTAINS).next
+            val method = postDomFrontierNode._containsIn.next
             val nodeLabel = postDomFrontierNode.label
-            logger.warn(s"Found CDG edge starting at $nodeLabel node. This is most likely caused by an invalid CFG." +
-              s" Method: ${method.propertyOption(Properties.FULL_NAME)}" +
-              s" number of outgoing CFG edges from $nodeLabel node: ${postDomFrontierNode.outE(EdgeTypes.CFG).asScala.size}")
+            logger.warn(
+              s"Found CDG edge starting at $nodeLabel node. This is most likely caused by an invalid CFG." +
+                s" Method: ${method match { case m: Method => m.fullName; case other => other.label }}" +
+                s" number of outgoing CFG edges from $nodeLabel node: ${postDomFrontierNode._cfgOut.asScala.size}")
         }
     }
     Iterator(dstGraph.build())

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
@@ -2,7 +2,16 @@ package io.shiftleft.semanticcpg.passes.codepencegraph
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes._
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Literal,
+  Call,
+  ControlStructure,
+  Identifier,
+  JumpTarget,
+  Method,
+  MethodRef,
+  Unknown
+}
 import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominatorFrontier, ReverseCpgCfgAdapter}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CdgPass.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg.passes.codepencegraph
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.cfgdominator.{CfgDominatorFrontier, ReverseCpgCfgAdapter}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CpgPostDomTreeAdapter.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/codepencegraph/CpgPostDomTreeAdapter.scala
@@ -1,13 +1,12 @@
 package io.shiftleft.semanticcpg.passes.codepencegraph
 
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import io.shiftleft.semanticcpg.passes.cfgdominator.DomTreeAdapter
-import overflowdb.Node
 import overflowdb.traversal._
 
-class CpgPostDomTreeAdapter extends DomTreeAdapter[Node] {
+class CpgPostDomTreeAdapter extends DomTreeAdapter[StoredNode] {
 
-  override def immediateDominator(cfgNode: Node): Option[Node] = {
-    cfgNode.in(EdgeTypes.POST_DOMINATE).nextOption()
+  override def immediateDominator(cfgNode: StoredNode): Option[StoredNode] = {
+    cfgNode._postDominateIn.nextOption()
   }
 }


### PR DESCRIPTION
No functional changes. Avoids some casts by choosing more appropriate type bound. Uses the faster API for accessing neighbors.