### PR TITLE
Bring in hidden schema elements

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -102,6 +102,17 @@ object Base extends SchemaBase {
       .mandatory(PropertyDefaults.String)
       .protoId(8)
 
+    val content = builder
+      .addProperty(
+        name = "CONTENT",
+        valueType = ValueType.String,
+        comment = """Certain files, e.g., configuration files, may be included in the CPG as-is.
+            |For such files, the `CONTENT` field contains the files content.
+            |""".stripMargin
+      )
+      .mandatory(CpgSchema.PropertyDefaults.String)
+      .protoId(20)
+
     // The following fields are used to create edges between nodes in later processing stages.
 
     val astParentType = builder

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Binding.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Binding.scala
@@ -7,7 +7,7 @@ object Binding extends SchemaBase {
   def apply(builder: SchemaBuilder, base: Base.Schema, typeSchema: Type.Schema, methodSchema: Method.Schema) =
     new Schema(builder, base, typeSchema, methodSchema)
 
-  override def index: Int = 18
+  override def index: Int = 19
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Configuration.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Configuration.scala
@@ -1,0 +1,38 @@
+package io.shiftleft.codepropertygraph.schema
+
+import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
+
+object Configuration extends SchemaBase {
+
+  override def index: Int = 18
+
+  override def description: String =
+    """
+      |The code property graph specification currently does not contain
+      |schema elements for the representation of configuration files in
+      |a structured format, however, it does allow configuration files
+      |to be included verbatim in the graph to enable language-/framework-
+      |specific passes to access them. This layer provides the necessary
+      |schema elements for this basic support of configuration files.
+      |""".stripMargin
+
+  def apply(builder: SchemaBuilder, base: Base.Schema) = new Schema(builder, base)
+
+  class Schema(builder: SchemaBuilder, base: Base.Schema) {
+    import base._
+
+    implicit private val schemaInfo = SchemaInfo.forClass(getClass)
+
+    val configFile: NodeType = builder
+      .addNodeType(
+        name = "CONFIG_FILE",
+        comment = """This node type represent a configuration file, where `NAME` is the name
+                    |of the file and `content` is its content. The exact representation of the
+                    |name is left undefined and can be chosen as required by consumers of
+                    |the corresponding configuration files.
+                    |""".stripMargin
+      )
+      .protoId(50)
+      .addProperties(name, content)
+  }
+}

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
@@ -9,6 +9,7 @@ class CpgSchema(builder: SchemaBuilder) {
   val namespaces = Namespace(builder, base, fs)
 
   val operators = Operators(builder)
+  val configuration = Configuration(builder, base)
   val metaData = MetaData(builder, base)
 
   val typeSchema = Type(builder, base, fs)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
@@ -26,6 +26,7 @@ class CpgSchema(builder: SchemaBuilder) {
   val tagsAndLocation = TagsAndLocation(builder, base, typeSchema, method, ast, fs, callGraph)
   val binding = Binding(builder, base, typeSchema, method)
   val finding = Finding(builder, base)
+  val hidden = Hidden(builder, base, method, ast, callGraph)
   val protoSerialize = ProtoSerialize(builder, ast)
 }
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -1,0 +1,96 @@
+package io.shiftleft.codepropertygraph.schema
+
+import overflowdb.schema.Property.ValueType
+import overflowdb.schema.{EdgeType, NodeType, SchemaBuilder, SchemaInfo}
+
+object Hidden extends SchemaBase {
+  override def index: Int = -1
+
+  override def description: String =
+    """
+      |The schema elements defined here are NOT included on the schema website.
+      |These are schema elements that we are using but would like to rework
+      |in the future and not make part of the standard.
+      |""".stripMargin
+
+  def apply(builder: SchemaBuilder,
+            base: Base.Schema,
+            methodSchema: Method.Schema,
+            ast: Ast.Schema,
+            callGraph: CallGraph.Schema) = new Schema(builder, base, methodSchema, ast, callGraph)
+
+  class Schema(builder: SchemaBuilder,
+               base: Base.Schema,
+               methodSchema: Method.Schema,
+               ast: Ast.Schema,
+               callGraph: CallGraph.Schema) {
+
+    import base._
+    import methodSchema._
+    import ast._
+    import callGraph._
+
+    implicit private val schemaInfo = SchemaInfo.forClass(getClass)
+
+    // node properties
+
+    val closureBindingId = builder
+      .addProperty(
+        name = "CLOSURE_BINDING_ID",
+        valueType = ValueType.String,
+        comment =
+          "Identifier which uniquely describes a CLOSURE_BINDING. This property is used to match captured LOCAL nodes with the corresponding CLOSURE_BINDING nodes"
+      )
+      .protoId(50)
+
+    val closureOriginalName = builder
+      .addProperty(
+        name = "CLOSURE_ORIGINAL_NAME",
+        valueType = ValueType.String,
+        comment = "The original name of the (potentially mangled) captured variable"
+      )
+      .protoId(159)
+
+    // edge types
+    val capture = builder
+      .addEdgeType(
+        name = "CAPTURE",
+        comment = "Represents the capturing of a variable into a closure"
+      )
+      .protoId(40)
+
+    // node types
+    local.addProperties(closureBindingId)
+
+    val closureBinding: NodeType = builder
+      .addNodeType(
+        name = "CLOSURE_BINDING",
+        comment = "Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method"
+      )
+      .protoId(334)
+      .addProperties(closureBindingId, evaluationStrategy, closureOriginalName)
+
+    val capturedBy = builder
+      .addEdgeType(
+        name = "CAPTURED_BY",
+        comment = "Connection between a captured LOCAL and the corresponding CLOSURE_BINDING"
+      )
+      .protoId(41)
+
+    // node relations
+    local.addOutEdge(edge = capturedBy, inNode = closureBinding)
+
+    methodRef
+      .addOutEdge(edge = capture, inNode = closureBinding)
+
+    typeRef
+      .addOutEdge(edge = capture, inNode = closureBinding)
+
+    closureBinding
+      .addOutEdge(edge = ref, inNode = local, cardinalityOut = EdgeType.Cardinality.One)
+      .addOutEdge(edge = ref, inNode = methodParameterIn)
+    // constants
+
+  }
+
+}

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -32,7 +32,9 @@ object Hidden extends SchemaBase {
 
     implicit private val schemaInfo = SchemaInfo.forClass(getClass)
 
-    // node properties
+    /*
+     * Closure bindings
+     * */
 
     val closureBindingId = builder
       .addProperty(
@@ -89,7 +91,35 @@ object Hidden extends SchemaBase {
     closureBinding
       .addOutEdge(edge = ref, inNode = local, cardinalityOut = EdgeType.Cardinality.One)
       .addOutEdge(edge = ref, inNode = methodParameterIn)
-    // constants
+
+    /*
+     * Dependencies
+     * */
+
+    val dependencyGroupId = builder
+      .addProperty(
+        name = "DEPENDENCY_GROUP_ID",
+        valueType = ValueType.String,
+        comment = "The group ID for a dependency"
+      )
+      .protoId(58)
+
+    val usedIn = builder
+      .addProperty(
+        name = "USED_IN",
+        valueType = ValueType.String,
+        comment = "The name of the file for which this include is valid"
+      )
+      .protoId(22919)
+
+    // node types
+    val dependency: NodeType = builder
+      .addNodeType(
+        name = "DEPENDENCY",
+        comment = "This node represents a dependency"
+      )
+      .protoId(35)
+      .addProperties(version, name, dependencyGroupId, usedIn)
 
   }
 

--- a/schema2json/src/main/scala/Schema2Json.scala
+++ b/schema2json/src/main/scala/Schema2Json.scala
@@ -26,7 +26,7 @@ object Schema2Json extends App {
   private def schemaName(nodeType: AbstractNodeType): String =
     schemaName(nodeType.schemaInfo)
 
-  private def schemaName(schemaInfo: SchemaInfo) =
+  private def schemaName(schemaInfo: SchemaInfo): String =
     schemaInfo.definedIn.map(_.getDeclaringClass.getSimpleName).getOrElse("unknown")
 
   private def schemaIndex(nodeType: AbstractNodeType): Int =
@@ -37,8 +37,12 @@ object Schema2Json extends App {
       .map(_.getDeclaringClass.getDeclaredMethod("index").invoke(null).asInstanceOf[Int])
       .getOrElse(Int.MaxValue)
 
+  private def isSchemaHidden(schemaInfo: SchemaInfo) =
+    schemaName(schemaInfo) == "Hidden"
+
   private def schemaSummary = {
     (schema.nodeTypes.map(_.schemaInfo) ++ schema.edgeTypes.map(_.schemaInfo))
+      .filterNot(isSchemaHidden)
       .sortBy(schemaIndex)
       .flatMap(_.definedIn)
       .distinct
@@ -55,11 +59,13 @@ object Schema2Json extends App {
 
   private def nodeTypesAsJson = {
     (schema.nodeTypes ++ schema.nodeBaseTypes)
+      .filterNot(x => isSchemaHidden(x.schemaInfo))
       .sortBy(x => (schemaIndex(x), x.name))
       .flatMap { nodeType =>
         val baseTypeNames = nodeType.extendz.map(_.name)
-        val allPropertyNames = nodeType.properties.map(_.name)
-        val cardinalities = nodeType.properties.map(p => name(p.cardinality))
+        val allPropertyNames = nodeType.properties.filterNot(x => isSchemaHidden(x.schemaInfo)).map(_.name)
+        val cardinalities =
+          nodeType.properties.filterNot(x => isSchemaHidden(x.schemaInfo)).map(p => name(p.cardinality))
         val schName = schemaName(nodeType)
 
         val inheritedProperties = nodeType.extendz
@@ -74,7 +80,7 @@ object Schema2Json extends App {
         val nonInheritedProperties = allPropertyNames.filterNot(x => inheritedPropertyNames.contains(x))
 
         val containedNodes = nodeType match {
-          case nt: NodeType =>
+          case nt: NodeType if !isSchemaHidden(nt.schemaInfo) =>
             nt.containedNodes.map { n =>
               Map("name" -> n.localName, "type" -> n.nodeType.name, "cardinality" -> name(n.cardinality))
             }
@@ -96,19 +102,23 @@ object Schema2Json extends App {
   }
 
   private def edgeTypesAsJson = {
-    schema.edgeTypes.sortBy(_.name).flatMap { edge =>
-      val schName = schemaName(edge.schemaInfo)
-      Some(
-        ("name" -> edge.name) ~
-          ("comment" -> edge.comment) ~
-          ("schema" -> schName)
-      )
-    }
+    schema.edgeTypes
+      .sortBy(_.name)
+      .filterNot(x => isSchemaHidden(x.schemaInfo))
+      .flatMap { edge =>
+        val schName = schemaName(edge.schemaInfo)
+        Some(
+          ("name" -> edge.name) ~
+            ("comment" -> edge.comment) ~
+            ("schema" -> schName)
+        )
+      }
   }
 
   private def propertiesAsJson = {
     schema.properties
       .sortBy(_.name)
+      .filterNot(x => isSchemaHidden(x.schemaInfo))
       .flatMap { prop =>
         val schName = schemaName(prop.schemaInfo)
         Some(


### PR DESCRIPTION
To allow open-sourcing of a few frontends, we need to bring in further node types but we do not want to make these node types part of the standard because we would rather like to redesign these aspects of the CPG at a later point in time. This PR therefore brings in a schema file for hidden schema elements. These are part of the schema like all other schema elements, but when creating the json for the CPG website, they are filtered.
