### PR TITLE
Add binary test fixture and update c2cpg fixture 

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/testfixtures/DataFlowCodeToCpgSuite.scala
@@ -17,7 +17,7 @@ import scala.util.Try
 
 class DataFlowCodeToCpgSuite extends CCodeToCpgSuite {
 
-  private val semanticsFilename = ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
+  var semanticsFilename = ProjectRoot.relativise("dataflowengineoss/src/test/resources/default.semantics")
   var semantics: Semantics = _
   implicit var context: EngineContext = _
 

--- a/domainClasses/project/build.properties
+++ b/domainClasses/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.5

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/BinToCpgFixture.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/testfixtures/BinToCpgFixture.scala
@@ -1,0 +1,37 @@
+package io.shiftleft.semanticcpg.testfixtures
+
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.semanticcpg.layers.{LayerCreatorContext, Scpg}
+import io.shiftleft.utils.ProjectRoot
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.File
+
+class BinToCpgFixture(val frontend: LanguageFrontend) extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  var cpg: Cpg = Cpg.emptyCpg
+  val binDirectory = ProjectRoot.relativise("src/test/resources/testbinaries/")
+  def passes(cpg: Cpg): Unit = createEnhancements(cpg)
+
+  def createEnhancements(cpg: Cpg): Unit = {
+    val context = new LayerCreatorContext(cpg)
+    new Scpg().run(context)
+  }
+
+  def buildCpgForBin(binName: String): Unit = {
+    if (!cpg.graph.isClosed) {
+      cpg.close()
+    }
+    val bin = new File(binDirectory, binName)
+    cpg = frontend.execute(bin)
+    passes(cpg)
+  }
+
+  override def afterAll(): Unit = {
+    if (!cpg.graph.isClosed) {
+      cpg.close()
+    }
+  }
+}


### PR DESCRIPTION
# Notes
* Change the `c2cpg` `semanticsFilename` to a var for consistency with `fuzzyc2cpg` and to allow a swap between the two in the `query-database`
* Add an initial `BinToCpgFixture` to use for Ghidra query testing (which uses binaries).
# Testing
`sbt test`