### PR TITLE
Check for set equality not size equality

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -26,9 +26,9 @@ class DataFlowSolver {
           .reduceOption((x, y) => problem.meet(x, y))
           .getOrElse(problem.empty)
         in += n -> inSet
-        val oldSize = out(n).size
+        val old = out(n)
         out += n -> problem.transferFunction(n, inSet)
-        if (oldSize != out(n).size)
+        if (old != out(n))
           problem.flowGraph.succ(n)
         else
           List()
@@ -59,9 +59,9 @@ class DataFlowSolver {
           .reduceOption((x, y) => problem.meet(x, y))
           .getOrElse(problem.empty)
         out += n -> outSet
-        val oldSize = in(n).size
+        val old = in(n)
         in += n -> problem.transferFunction(n, outSet)
-        if (oldSize != in(n).size)
+        if (old != in(n))
           problem.flowGraph.pred(n)
         else
           List()


### PR DESCRIPTION
Not sure how this came to be, but there was a (I believe valid) optimization in the data flow solver. Instead of checking whether sets are changing during fix point calculation, we checked whether the size of the sets were changing. That's quicker and probably OK for reaching defs as only the IN[n] set grows, but I'm not sure this is valid in general. For now, I'm taking it out. Did a bit of performance testing on this and the performance hit is insignificant.
