### PR TITLE
Add `is` and `isNot` operators to schema

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
@@ -255,6 +255,14 @@ object Operators extends SchemaBase {
         valueType = ValueTypes.STRING,
         comment = "Checks the non-existence of a variable in a range or collection, e.g. `print(5 not in [1, 2, 3, 4])`"
       ),
+      Constant(name = "is",
+               value = "<operator>.is",
+               valueType = ValueTypes.STRING,
+               comment = "Checks whether a variable is of a given type"),
+      Constant(name = "isNot",
+               value = "<operator>.isNot",
+               valueType = ValueTypes.STRING,
+               comment = "Checks whether a variable is not of a given type"),
     )
 
   }


### PR DESCRIPTION
The `is` operator is defined in Kotlin, C#
The `isNot` operator is defined in Kotlin

e.g
```
int i = 34;
object iBoxed = i;
int? jNullable = 42;
if (iBoxed is int a && jNullable is int b)
{
    Console.WriteLine(a + b);  // output 76
}
```

```
if (obj is String) {
    print(obj.length)
}

if (obj !is String) { // same as !(obj is String)
    print("Not a String")
} else {
    print(obj.length)
}
```
