### PR TITLE
Minor fix for ghidra integration

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/GhidraCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/GhidraCpgGenerator.scala
@@ -22,5 +22,5 @@ case class GhidraCpgGenerator(config: GhidraFrontendConfig, rootPath: Path) exte
     runShellCommand(command, arguments).map(_ => outputPath)
   }
 
-  override def isAvailable: Boolean = rootPath.resolve("ghidra2cpg.sh").toFile.exists()
+  override def isAvailable: Boolean = rootPath.resolve("ghidra2cpg").toFile.exists()
 }


### PR DESCRIPTION
Availability of the ghidra module was not correctly displayed in the output of `importCode` previously because we were looking for a while called `ghidra2cpg.sh` as opposed to `ghidra2cpg`.