### PR TITLE
Add  language option to test new C frontend

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -5,7 +5,8 @@ enablePlugins(JavaAppPackaging)
 dependsOn(Projects.codepropertygraph % "compile ->compile; test -> test",
           Projects.semanticcpg,
           Projects.macros,
-          Projects.fuzzyc2cpg)
+          Projects.fuzzyc2cpg,
+          Projects.c2cpg)
 
 scalacOptions ++= Seq(
   "-deprecation",                      // Emit warning and location for usages of deprecated APIs.

--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -33,7 +33,8 @@ object LanguageFrontendConfig {
   def apply(): LanguageFrontendConfig = new LanguageFrontendConfig()
 }
 
-class LanguageFrontendConfig(var csharp: CSharpFrontendConfig = CSharpFrontendConfig(),
+class LanguageFrontendConfig(var c: CFrontendConfig = CFrontendConfig(),
+                             var csharp: CSharpFrontendConfig = CSharpFrontendConfig(),
                              var fuzzyc: FuzzyCFrontendConfig = FuzzyCFrontendConfig(),
                              var go: GoFrontendConfig = GoFrontendConfig(),
                              var java: JavaFrontendConfig = JavaFrontendConfig(),
@@ -43,6 +44,7 @@ class LanguageFrontendConfig(var csharp: CSharpFrontendConfig = CSharpFrontendCo
                              var php: PhpFrontendConfig = PhpFrontendConfig(),
                              var ghidra: GhidraFrontendConfig = GhidraFrontendConfig())
 
+class CFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
 class CSharpFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
 class FuzzyCFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
 class GoFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
@@ -53,6 +55,9 @@ class PythonFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer(
 class PhpFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
 class GhidraFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
 
+object CFrontendConfig {
+  def apply(): CFrontendConfig = new CFrontendConfig()
+}
 object CSharpFrontendConfig {
   def apply(): CSharpFrontendConfig = new CSharpFrontendConfig()
 }

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
@@ -1,0 +1,35 @@
+package io.shiftleft.console.cpgcreation
+
+import io.shiftleft.console.CFrontendConfig
+import io.shiftleft.c2cpg.C2Cpg
+import io.shiftleft.c2cpg.C2Cpg.Config
+
+import java.nio.file.Path
+
+/**
+  * Fuzzy C/C++ language frontend. Translates C/C++ source files
+  * into code property graphs via fuzzy parsing.
+  * */
+case class CCpgGenerator(config: CFrontendConfig, rootPath: Path) extends CpgGenerator {
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    **/
+  override def generate(inputPath: String,
+                        outputPath: String = "cpg.bin.zip",
+                        namespaces: List[String] = List()): Option[String] = {
+    val c = new C2Cpg()
+    val config = Config(
+      inputPaths = Set(inputPath),
+      outputPath = outputPath,
+      sourceFileExtensions = Set(".c", ".cc", ".cpp", ".h", ".hpp")
+    )
+    val cpg = c.runAndOutput(config)
+    cpg.close()
+    Some(outputPath)
+  }
+
+  override def isAvailable: Boolean = true
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.CFrontendConfig
 import io.shiftleft.c2cpg.C2Cpg
 import io.shiftleft.c2cpg.C2Cpg.Config
+import io.shiftleft.console.CFrontendConfig
 
 import java.nio.file.Path
 

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
@@ -49,7 +49,8 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
       Languages.FUZZY_TEST_LANG,
       Languages.LLVM,
       Languages.PHP,
-      Languages.KOTLIN
+      Languages.KOTLIN,
+      Languages.NEWC
     ).contains(language)
   }
 

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
@@ -70,7 +70,8 @@ class ImportCode[T <: Project](console: io.shiftleft.console.Console[T]) {
     }
   }
 
-  class CFrontend(language: String = Languages.C, description: String = "Fuzzy Parser for C/C++") extends Frontend(language, description) {
+  class CFrontend(language: String = Languages.C, description: String = "Fuzzy Parser for C/C++")
+      extends Frontend(language, description) {
     def fromString(str: String): Option[Cpg] = {
       withCodeInTmpFile(str, "tmp.c") { dir =>
         apply(dir.path.toString)

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
@@ -48,6 +48,7 @@ class ImportCode[T <: Project](console: io.shiftleft.console.Console[T]) {
   }
 
   def c: CFrontend = new CFrontend()
+  def newc: CFrontend = new CFrontend(Languages.NEWC, "Eclipse CDT Based Frontend for C/C++")
   def llvm: Frontend = new Frontend(Languages.LLVM, "LLVM Bitcode Frontend")
   def java: Frontend = new Frontend(Languages.JAVA, "Java/Dalvik Bytecode Frontend")
   def golang: Frontend = new Frontend(Languages.GOLANG, "Golang Source Frontend")
@@ -69,7 +70,7 @@ class ImportCode[T <: Project](console: io.shiftleft.console.Console[T]) {
     }
   }
 
-  class CFrontend extends Frontend(Languages.C, "Fuzzy Parser for C/C++") {
+  class CFrontend(language: String = Languages.C, description: String = "Fuzzy Parser for C/C++") extends Frontend(language, description) {
     def fromString(str: String): Option[Cpg] = {
       withCodeInTmpFile(str, "tmp.c") { dir =>
         apply(dir.path.toString)

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
@@ -23,6 +23,7 @@ package object cpgcreation {
       case Languages.PYTHON     => Some(PythonCpgGenerator(config.python, rootPath))
       case Languages.PHP        => Some(PhpCpgGenerator(config.php, rootPath))
       case Languages.GHIDRA     => Some(GhidraCpgGenerator(config.ghidra, rootPath))
+      case Languages.NEWC       => Some(CCpgGenerator(config.c, rootPath))
       case _                    => None
     }
   }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -84,7 +84,7 @@ object MetaData extends SchemaBase {
                valueType = ValueTypes.STRING,
                comment = "generic reverse engineering framework").protoId(10),
       Constant(name = "KOTLIN", value = "KOTLIN", valueType = ValueTypes.STRING, comment = "").protoId(11),
-      Constant(name = "NEWC", value = "NEWC", valueType = ValueTypes.STRING, comment = "Eclipse CDT based parser for C/C++")
+      Constant(name = "NEWC", value = "NEWC", valueType = ValueTypes.STRING, comment = "Eclipse CDT based parser for C/C++").protoId(12)
     )
 
   }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -84,7 +84,10 @@ object MetaData extends SchemaBase {
                valueType = ValueTypes.STRING,
                comment = "generic reverse engineering framework").protoId(10),
       Constant(name = "KOTLIN", value = "KOTLIN", valueType = ValueTypes.STRING, comment = "").protoId(11),
-      Constant(name = "NEWC", value = "NEWC", valueType = ValueTypes.STRING, comment = "Eclipse CDT based parser for C/C++").protoId(12)
+      Constant(name = "NEWC",
+               value = "NEWC",
+               valueType = ValueTypes.STRING,
+               comment = "Eclipse CDT based parser for C/C++").protoId(12)
     )
 
   }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -83,7 +83,8 @@ object MetaData extends SchemaBase {
                value = "GHIDRA",
                valueType = ValueTypes.STRING,
                comment = "generic reverse engineering framework").protoId(10),
-      Constant(name = "KOTLIN", value = "KOTLIN", valueType = ValueTypes.STRING, comment = "").protoId(11)
+      Constant(name = "KOTLIN", value = "KOTLIN", valueType = ValueTypes.STRING, comment = "").protoId(11),
+      Constant(name = "NEWC", value = "NEWC", valueType = ValueTypes.STRING, comment = "Eclipse CDT based parser for C/C++")
     )
 
   }


### PR DESCRIPTION
# Notes
This PR adds a temporary `newc` language that we can use to test the new C/C++ frontend in joern/joern-scan.
# Testing
* `sbt clean test`
* In Joern:
```
joern>  importCode.newc("/home/johannes/code/examples-joern/too_many_loops.c")  
Creating project `too_many_loops.c` for code at `/home/johannes/code/examples-joern/too_many_loops.c`
...
Code successfully imported. You can now query it using `cpg`.
...

joern> cpg.controlStructure.map(_.parserTypeName).l 
res1: List[String] = List(
  "CASTWhileStatement", <- confirms new frontend is being used
  ...
)
```