### PR TITLE
invoke fuzzyc2cpg via shell command rather than in running jvm - to avoid memory leak

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.console.cpgcreation
 
 import io.shiftleft.console.FuzzyCFrontendConfig
-import io.shiftleft.fuzzyc2cpg.FuzzyC2Cpg
 
 import java.nio.file.Path
 

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -17,12 +17,11 @@ case class FuzzyCCpgGenerator(config: FuzzyCFrontendConfig, rootPath: Path) exte
     * CPG was generated.
     **/
   override def generate(inputPath: String,
-                        outputPath: String = "cpg.bin.zip",
+                        outputPath: String = "cpg.bin",
                         namespaces: List[String] = List()): Option[String] = {
-    val fuzzyc = new FuzzyC2Cpg()
-    val cpg = fuzzyc.runAndOutput(Set(inputPath), Set(".c", ".cc", ".cpp", ".h", ".hpp"), Some(outputPath))
-    cpg.close()
-    Some(outputPath)
+    val command = rootPath.resolve("fuzzyc2cpg.sh").toString
+    val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
+    runShellCommand(command, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = true


### PR DESCRIPTION
I noticed that when analysing medium sized codebases (e.g.
`linux-4.1.16/drivers/staging` which is 13M), after running
`importCode`, there was still a large `io.shiftleft.fuzzyc2cpg.FunctionParser`
instance, allocating 330M on heap. I'll attach a screenshot from
the profiler which also shows the path to GC.
The class is generated via antlr and it wasn't immediately clear how to
avoid this memory leak.

Since the cpg was closed and reopened before as well, this change shouldn't
have much of a time/efficiency effect.


![yourkit-joern-fuzzyc-heap](https://user-images.githubusercontent.com/506752/130051231-02c6df29-ab88-48f9-9eb4-199bbd1dcaa8.png)
