### PR TITLE
Fullname and TypeDecl fixes

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/FileTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/FileTests.scala
@@ -41,7 +41,7 @@ class FileTests extends CCodeToCpgSuite {
   }
 
   "should allow traversing from file to its type declarations via namespace block" in {
-    cpg.file.nameNot(FileTraversal.UNKNOWN).typeDecl.name.toSet shouldBe Set("my_struct")
+    cpg.file.nameNot(FileTraversal.UNKNOWN).typeDecl.name.toSet shouldBe Set("foo", "bar", "my_struct")
   }
 
   "should allow traversing to namespaces" in {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
@@ -87,6 +87,21 @@ trait AstCreatorHelper {
     typeName
   }
 
+  private def cleanType(t: String): String = t match {
+    case ""                                        => Defines.anyTypeName
+    case t if t.contains("?")                      => Defines.anyTypeName
+    case t if t.contains("#")                      => Defines.anyTypeName
+    case t if t.startsWith("{") && t.endsWith("}") => Defines.anyTypeName
+    case t if t.contains("*")                      => "*"
+    case t if t.contains("[")                      => "[]"
+    case t if t.contains("::")                     => fixQualifiedName(t).split(".").lastOption.getOrElse(Defines.anyTypeName)
+    case someType                                  => someType
+  }
+
+  protected def typeFor(node: IASTNode): String = cleanType(ASTTypeUtil.getNodeType(node))
+
+  protected def typeFor(node: IASTTypeId): String = cleanType(ASTTypeUtil.getType(node))
+
   private def notHandledText(node: IASTNode): String =
     s"""Node '${node.getClass.getSimpleName}' not handled yet!
        |  Code: '${node.getRawSignature}'

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
@@ -136,13 +136,15 @@ trait AstCreatorHelper {
         evaluation.getBinding match {
           case f: CPPFunction if f.getDeclarations != null =>
             usingDeclarationMappings.getOrElse(
-              fixQualifiedName(d.getName.toString),
-              f.getDeclarations.headOption.map(_.getName.toString).getOrElse(f.getName))
+              fixQualifiedName(d.getName.getRawSignature),
+              f.getDeclarations.headOption.map(_.getName.getRawSignature).getOrElse(f.getName))
           case f: CPPFunction if f.getDefinition != null =>
-            usingDeclarationMappings.getOrElse(fixQualifiedName(d.getName.toString), f.getDefinition.getName.toString)
+            usingDeclarationMappings.getOrElse(fixQualifiedName(d.getName.getRawSignature),
+                                               f.getDefinition.getName.getRawSignature)
           case other => other.getName
         }
-      case alias: ICPPASTNamespaceAlias => alias.getMappingName.toString
+      case alias: ICPPASTNamespaceAlias =>
+        alias.getMappingName.getRawSignature
       case namespace: ICPPASTNamespaceDefinition if namespace.getName.getRawSignature.nonEmpty =>
         fullName(namespace.getParent) + "." + namespace.getName.getRawSignature
       case namespace: ICPPASTNamespaceDefinition if namespace.getName.getRawSignature.isEmpty =>
@@ -160,19 +162,19 @@ trait AstCreatorHelper {
         val fullname = s"${fullName(cppClass.getParent)}.$name"
         fullname
       case enum: IASTEnumerationSpecifier =>
-        fullName(enum.getParent) + "." + enum.getName.toString
-      case c: IASTCompositeTypeSpecifier => c.getName.toString
+        fullName(enum.getParent) + "." + enum.getName.getRawSignature
+      case c: IASTCompositeTypeSpecifier => c.getName.getRawSignature
       case f: IASTFunctionDeclarator =>
-        fullName(f.getParent) + "." + f.getName.toString
+        fullName(f.getParent) + "." + f.getName.getRawSignature
       case f: ICPPASTLambdaExpression =>
         fullName(f.getParent) + "."
       case f: IASTFunctionDefinition =>
-        fullName(f.getParent) + "." + f.getDeclarator.getName.toString
-      case d: IASTIdExpression    => d.getName.toString
+        fullName(f.getParent) + "." + f.getDeclarator.getName.getRawSignature
+      case d: IASTIdExpression    => d.getName.getRawSignature
       case _: IASTTranslationUnit => ""
-      case u: IASTUnaryExpression => u.getOperand.toString
+      case u: IASTUnaryExpression => u.getOperand.getRawSignature
       case e: ICPPASTElaboratedTypeSpecifier =>
-        fullName(e.getParent) + "." + e.getName.toString
+        fullName(e.getParent) + "." + e.getName.getRawSignature
       case other if other.getParent != null => fullName(other.getParent)
       case other if other != null           => notHandledYet(other, -1); ""
       case null                             => ""

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -23,11 +23,7 @@ trait AstForFunctionsCreator {
     val parentNode: NewTypeDecl = methodAstParentStack.collectFirst { case t: NewTypeDecl => t }.getOrElse {
       val astParentType = methodAstParentStack.head.label
       val astParentFullName = methodAstParentStack.head.properties("FULL_NAME").toString
-      val newTypeDeclNode = NewTypeDecl()
-        .name(methodName)
-        .fullName(methodFullName)
-        .astParentType(astParentType)
-        .astParentFullName(astParentFullName)
+      val newTypeDeclNode = newTypeDecl(methodName, methodFullName, astParentType, astParentFullName)
       Ast.storeInDiffGraph(Ast(newTypeDeclNode), diffGraph)
       newTypeDeclNode
     }
@@ -102,7 +98,7 @@ trait AstForFunctionsCreator {
     Ast.storeInDiffGraph(r, diffGraph)
     Ast.storeInDiffGraph(typeDeclAst, diffGraph)
 
-    createMethodRefNode(code, fullname, methodNode.astParentFullName, lambdaExpression)
+    newMethodRefNode(code, fullname, methodNode.astParentFullName, lambdaExpression)
   }
 
   protected def astForFunctionDeclarator(funcDecl: IASTFunctionDeclarator, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -95,8 +95,8 @@ trait AstForFunctionsCreator {
     scope.popScope()
     val typeDeclAst = createFunctionTypeAndTypeDecl(methodNode, name, fullname, signature)
 
-    Ast.storeInDiffGraph(r.withRefEdge(typeDeclAst.root.get, methodNode), diffGraph)
     Ast.storeInDiffGraph(typeDeclAst, diffGraph)
+    Ast.storeInDiffGraph(r.withRefEdge(typeDeclAst.root.get, methodNode), diffGraph)
 
     newMethodRefNode(code, fullname, methodNode.astParentFullName, lambdaExpression)
   }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -31,7 +31,7 @@ trait AstForFunctionsCreator {
     method.astParentFullName = parentNode.fullName
     method.astParentType = parentNode.label
     val functionBinding = NewBinding().name(methodName).signature(signature)
-    Ast(functionBinding).withBindsEdge(parentNode, functionBinding).withRefEdge(functionBinding, method)
+    Ast(functionBinding).withBindsEdge(parentNode, functionBinding)
   }
 
   @tailrec
@@ -95,7 +95,7 @@ trait AstForFunctionsCreator {
     scope.popScope()
     val typeDeclAst = createFunctionTypeAndTypeDecl(methodNode, name, fullname, signature)
 
-    Ast.storeInDiffGraph(r, diffGraph)
+    Ast.storeInDiffGraph(r.withRefEdge(typeDeclAst.root.get, methodNode), diffGraph)
     Ast.storeInDiffGraph(typeDeclAst, diffGraph)
 
     newMethodRefNode(code, fullname, methodNode.astParentFullName, lambdaExpression)
@@ -139,7 +139,7 @@ trait AstForFunctionsCreator {
     val typeDeclAst = createFunctionTypeAndTypeDecl(methodNode, name, fullname, signature)
     Ast.storeInDiffGraph(typeDeclAst, diffGraph)
 
-    r
+    r.withRefEdge(typeDeclAst.root.get, methodNode)
   }
 
   protected def astForFunctionDefinition(functDef: IASTFunctionDefinition, order: Int): Ast = {
@@ -183,7 +183,7 @@ trait AstForFunctionsCreator {
     val typeDeclAst = createFunctionTypeAndTypeDecl(methodNode, name, fullname, signature)
     Ast.storeInDiffGraph(typeDeclAst, diffGraph)
 
-    r
+    r.withRefEdge(typeDeclAst.root.get, methodNode)
   }
 
   private def astForParameter(parameter: IASTNode, childNum: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -31,7 +31,7 @@ trait AstForFunctionsCreator {
     method.astParentFullName = parentNode.fullName
     method.astParentType = parentNode.label
     val functionBinding = NewBinding().name(methodName).signature(signature)
-    Ast(functionBinding).withBindsEdge(parentNode, functionBinding)
+    Ast(functionBinding).withBindsEdge(parentNode, functionBinding).withRefEdge(functionBinding, method)
   }
 
   @tailrec
@@ -95,8 +95,7 @@ trait AstForFunctionsCreator {
     scope.popScope()
     val typeDeclAst = createFunctionTypeAndTypeDecl(methodNode, name, fullname, signature)
 
-    Ast.storeInDiffGraph(typeDeclAst, diffGraph)
-    Ast.storeInDiffGraph(r.withRefEdge(typeDeclAst.root.get, methodNode), diffGraph)
+    Ast.storeInDiffGraph(r.merge(typeDeclAst), diffGraph)
 
     newMethodRefNode(code, fullname, methodNode.astParentFullName, lambdaExpression)
   }
@@ -137,9 +136,8 @@ trait AstForFunctionsCreator {
     scope.popScope()
 
     val typeDeclAst = createFunctionTypeAndTypeDecl(methodNode, name, fullname, signature)
-    Ast.storeInDiffGraph(typeDeclAst, diffGraph)
 
-    r.withRefEdge(typeDeclAst.root.get, methodNode)
+    r.merge(typeDeclAst)
   }
 
   protected def astForFunctionDefinition(functDef: IASTFunctionDefinition, order: Int): Ast = {
@@ -181,9 +179,8 @@ trait AstForFunctionsCreator {
     methodAstParentStack.pop()
 
     val typeDeclAst = createFunctionTypeAndTypeDecl(methodNode, name, fullname, signature)
-    Ast.storeInDiffGraph(typeDeclAst, diffGraph)
 
-    r.withRefEdge(typeDeclAst.root.get, methodNode)
+    r.merge(typeDeclAst)
   }
 
   private def astForParameter(parameter: IASTNode, childNum: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -33,17 +33,8 @@ trait AstForPrimitivesCreator {
     }
     val variableOption = scope.lookupVariable(identifierName)
     val identifierTypeName = variableOption match {
-      case Some((_, variableTypeName)) =>
-        variableTypeName
-      case None =>
-        ASTTypeUtil.getNodeType(ident) match {
-          case t if t == "?" || t.isEmpty                => Defines.anyTypeName
-          case t if t.startsWith("{") && t.endsWith("}") => Defines.anyTypeName
-          case t if t.contains("*")                      => "*"
-          case t if t.contains("[")                      => "[]"
-          case t if t.contains("::")                     => fixQualifiedName(t).split(".").lastOption.getOrElse(Defines.anyTypeName)
-          case t                                         => t
-        }
+      case Some((_, variableTypeName)) => variableTypeName
+      case None                        => typeFor(ident)
     }
 
     val cpgIdentifier = NewIdentifier()

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -38,6 +38,7 @@ trait AstForPrimitivesCreator {
       case None if ident.getParent.isInstanceOf[IASTDeclarator] =>
         ASTTypeUtil.getNodeType(ident.getParent.asInstanceOf[IASTDeclarator]) match {
           case t if t == "?" || t.isEmpty => Defines.anyTypeName
+          case t if t.endsWith("*")       => "*"
           case t                          => t
         }
       case None =>

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -35,14 +35,15 @@ trait AstForPrimitivesCreator {
     val identifierTypeName = variableOption match {
       case Some((_, variableTypeName)) =>
         variableTypeName
-      case None if ident.getParent.isInstanceOf[IASTDeclarator] =>
-        ASTTypeUtil.getNodeType(ident.getParent.asInstanceOf[IASTDeclarator]) match {
-          case t if t == "?" || t.isEmpty => Defines.anyTypeName
-          case t if t.endsWith("*")       => "*"
-          case t                          => t
-        }
       case None =>
-        Defines.anyTypeName
+        ASTTypeUtil.getNodeType(ident) match {
+          case t if t == "?" || t.isEmpty                => Defines.anyTypeName
+          case t if t.startsWith("{") && t.endsWith("}") => Defines.anyTypeName
+          case t if t.contains("*")                      => "*"
+          case t if t.contains("[")                      => "[]"
+          case t if t.contains("::")                     => fixQualifiedName(t).split(".").lastOption.getOrElse(Defines.anyTypeName)
+          case t                                         => t
+        }
     }
 
     val cpgIdentifier = NewIdentifier()

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
@@ -282,8 +282,9 @@ trait AstForTypesCreator {
         enumeration.getBaseType.toString
       case _ =>
         ASTTypeUtil.getNodeType(enumerator) match {
-          case ""       => Defines.anyTypeName
-          case someType => someType
+          case ""                   => Defines.anyTypeName
+          case t if t.endsWith("*") => "*"
+          case someType             => someType
         }
     }
     val cpgMember = NewMember()

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
@@ -91,14 +91,7 @@ trait AstForTypesCreator {
     val name = declarator.getName.toString
     declaration match {
       case d if isTypeDef(d) =>
-        Ast(
-          NewTypeDecl()
-            .name(name)
-            .fullName(registerType(name))
-            .isExternal(false)
-            .aliasTypeFullName(Some(registerType(declTypeName)))
-            .filename(declaration.getContainingFilename)
-            .order(order))
+        Ast(newTypeDecl(name, registerType(name), alias = Some(registerType(declTypeName)), order = order))
       case d if parentIsClassDef(d) =>
         Ast(
           NewMember()
@@ -107,13 +100,7 @@ trait AstForTypesCreator {
             .typeFullName(registerType(declTypeName))
             .order(order))
       case _ if declarator.isInstanceOf[IASTArrayDeclarator] =>
-        Ast(
-          NewTypeDecl()
-            .name(name)
-            .fullName(registerType(name))
-            .isExternal(false)
-            .filename(declaration.getContainingFilename)
-            .order(order))
+        Ast(newTypeDecl(name, registerType(name), order = order))
       case _ if !scope.isEmpty =>
         val l = NewLocal()
           .code(name)
@@ -123,13 +110,7 @@ trait AstForTypesCreator {
         scope.addToScope(name, (l, declTypeName))
         Ast(l)
       case _ if scope.isEmpty =>
-        Ast(
-          NewTypeDecl()
-            .name(name)
-            .fullName(registerType(name))
-            .isExternal(false)
-            .filename(declaration.getContainingFilename)
-            .order(order))
+        Ast(newTypeDecl(name, registerType(name), order = order))
     }
   }
 
@@ -173,15 +154,13 @@ trait AstForTypesCreator {
   protected def astForAliasDeclaration(aliasDeclaration: ICPPASTAliasDeclaration, order: Int): Ast = {
     val name = aliasDeclaration.getAlias.toString
     val mappedName = ASTTypeUtil.getType(aliasDeclaration.getMappingTypeId)
-    val typeDeclNode = NewTypeDecl()
-      .name(name)
-      .fullName(registerType(name))
-      .aliasTypeFullName(Some(registerType(mappedName)))
-      .filename(filename)
-      .lineNumber(line(aliasDeclaration))
-      .columnNumber(column(aliasDeclaration))
-      .isExternal(false)
-      .order(order)
+    val typeDeclNode =
+      newTypeDecl(name,
+                  registerType(name),
+                  alias = Some(registerType(mappedName)),
+                  line = line(aliasDeclaration),
+                  column = column(aliasDeclaration),
+                  order = order)
     Ast(typeDeclNode)
   }
 
@@ -213,14 +192,7 @@ trait AstForTypesCreator {
           .isInstanceOf[ICASTTypedefNameSpecifier] =>
       val spec = declaration.getDeclSpecifier.asInstanceOf[ICASTTypedefNameSpecifier]
       val name = spec.getName.getRawSignature
-      Seq(
-        Ast(
-          NewTypeDecl()
-            .name(name)
-            .fullName(registerType(name))
-            .isExternal(false)
-            .filename(spec.getContainingFilename)
-            .order(order)))
+      Seq(Ast(newTypeDecl(name, registerType(name), order = order)))
     case declaration: IASTSimpleDeclaration if declaration.getDeclarators.nonEmpty =>
       declaration.getDeclarators.toIndexedSeq.map {
         case d: IASTFunctionDeclarator     => astForFunctionDeclarator(d, order)
@@ -265,22 +237,13 @@ trait AstForTypesCreator {
       case cppClass: ICPPASTCompositeTypeSpecifier =>
         val baseClassList = cppClass.getBaseSpecifiers.toSeq.map(_.getNameSpecifier.toString)
         baseClassList.foreach(registerType)
-        NewTypeDecl()
-          .name(name)
-          .fullName(registerType(fullname))
-          .isExternal(false)
-          .filename(typeSpecifier.getContainingFilename)
-          .inheritsFromTypeFullName(baseClassList)
-          .aliasTypeFullName(nameWithTemplateParams)
-          .order(order)
+        newTypeDecl(name,
+                    registerType(fullname),
+                    inherits = baseClassList,
+                    alias = nameWithTemplateParams,
+                    order = order)
       case _ =>
-        NewTypeDecl()
-          .name(name)
-          .fullName(registerType(fullname))
-          .isExternal(false)
-          .filename(typeSpecifier.getContainingFilename)
-          .aliasTypeFullName(nameWithTemplateParams)
-          .order(order)
+        newTypeDecl(name, registerType(fullname), alias = nameWithTemplateParams, order = order)
     }
 
     methodAstParentStack.push(typeDecl)
@@ -308,14 +271,7 @@ trait AstForTypesCreator {
     val fullname = fullName(typeSpecifier)
     val nameWithTemplateParams = templateParameters(typeSpecifier).map(fullname + _)
 
-    val typeDecl =
-      NewTypeDecl()
-        .name(name)
-        .fullName(registerType(fullname))
-        .isExternal(false)
-        .aliasTypeFullName(nameWithTemplateParams)
-        .filename(typeSpecifier.getContainingFilename)
-        .order(order)
+    val typeDecl = newTypeDecl(name, registerType(fullname), alias = nameWithTemplateParams, order = order)
 
     declAsts :+ Ast(typeDecl)
   }
@@ -360,12 +316,7 @@ trait AstForTypesCreator {
     }
 
     val (name, fullname) = uniqueName("enum", enumSpecifier.getName.toString, fullName(enumSpecifier))
-    val typeDecl = NewTypeDecl()
-      .name(name)
-      .fullName(registerType(fullname))
-      .isExternal(false)
-      .filename(enumSpecifier.getContainingFilename)
-      .order(order)
+    val typeDecl = newTypeDecl(name, registerType(fullname), order = order)
 
     methodAstParentStack.push(typeDecl)
     scope.pushNewScope(typeDecl)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
@@ -280,15 +280,7 @@ trait AstForTypesCreator {
     val tpe = enumerator.getParent match {
       case enumeration: ICPPASTEnumerationSpecifier if enumeration.getBaseType != null =>
         enumeration.getBaseType.toString
-      case _ =>
-        ASTTypeUtil.getNodeType(enumerator) match {
-          case ""                                        => Defines.anyTypeName
-          case t if t.startsWith("{") && t.endsWith("}") => Defines.anyTypeName
-          case t if t.contains("*")                      => "*"
-          case t if t.contains("[")                      => "[]"
-          case t if t.contains("::")                     => fixQualifiedName(t).split(".").lastOption.getOrElse(Defines.anyTypeName)
-          case someType                                  => someType
-        }
+      case _ => typeFor(enumerator)
     }
     val cpgMember = NewMember()
       .code(enumerator.getRawSignature)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
@@ -282,9 +282,12 @@ trait AstForTypesCreator {
         enumeration.getBaseType.toString
       case _ =>
         ASTTypeUtil.getNodeType(enumerator) match {
-          case ""                   => Defines.anyTypeName
-          case t if t.endsWith("*") => "*"
-          case someType             => someType
+          case ""                                        => Defines.anyTypeName
+          case t if t.startsWith("{") && t.endsWith("}") => Defines.anyTypeName
+          case t if t.contains("*")                      => "*"
+          case t if t.contains("[")                      => "[]"
+          case t if t.contains("::")                     => fixQualifiedName(t).split(".").lastOption.getOrElse(Defines.anyTypeName)
+          case someType                                  => someType
         }
     }
     val cpgMember = NewMember()

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstNodeBuilder.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstNodeBuilder.scala
@@ -16,10 +16,10 @@ trait AstNodeBuilder {
       .lineNumber(line(node))
       .columnNumber(column(node))
 
-  protected def createMethodRefNode(code: String,
-                                    methodFullName: String,
-                                    typeFullName: String,
-                                    node: IASTNode): NewMethodRef =
+  protected def newMethodRefNode(code: String,
+                                 methodFullName: String,
+                                 typeFullName: String,
+                                 node: IASTNode): NewMethodRef =
     NewMethodRef()
       .code(code)
       .methodFullName(methodFullName)
@@ -72,5 +72,27 @@ trait AstNodeBuilder {
       .lineNumber(line(node))
       .columnNumber(column(node))
   }
+
+  protected def newTypeDecl(name: String,
+                            fullname: String,
+                            astParentType: String = "",
+                            astParentFullName: String = "",
+                            order: Int = -1,
+                            inherits: Seq[String] = Seq.empty,
+                            alias: Option[String] = None,
+                            line: Option[Integer] = None,
+                            column: Option[Integer] = None): NewTypeDecl =
+    NewTypeDecl()
+      .name(name)
+      .fullName(fullname)
+      .isExternal(false)
+      .filename(filename)
+      .astParentType(astParentType)
+      .astParentFullName(astParentFullName)
+      .inheritsFromTypeFullName(inherits)
+      .aliasTypeFullName(alias)
+      .lineNumber(line)
+      .columnNumber(column)
+      .order(order)
 
 }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreationPass.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreationPass.scala
@@ -20,7 +20,7 @@ class AstCreationPass(filenames: List[String],
   private val global: Global = Global()
 
   def usedTypes(): List[String] =
-    global.usedTypes.keys().asScala.filterNot(_ == Defines.anyTypeName).toSet.toList
+    global.usedTypes.keys().asScala.filterNot(_ == Defines.anyTypeName).toList
 
   override def generateParts(): Array[String] = filenames.toArray
 

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/NamespaceTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/NamespaceTests.scala
@@ -34,7 +34,7 @@ class NamespaceTests extends AnyWordSpec with Matchers with Inside with Complete
         |}
         |""".stripMargin) { cpg =>
       inside(cpg.method.fullName.l) {
-        case List(h, f, m) =>
+        case List(f, h, m) =>
           // TODO: this might be a bug. h is declared inside of f but as extern.
           //  Looks like extern is not part of the Eclipse CDT AST:
           h shouldBe "Q.V.f.h"
@@ -84,7 +84,7 @@ class NamespaceTests extends AnyWordSpec with Matchers with Inside with Complete
         |{ return 0; }
         |""".stripMargin) { cpg =>
       inside(cpg.method.fullName.l) {
-        case List(m1, f1, h, f2, m2) =>
+        case List(m1, f1, f2, h, m2) =>
           // TODO: this looks strange too it first glance. But as Eclipse CDT does not provide any
           //  mapping from definitions outside of namespace into them we cant reconstruct proper full-names.
           m1 shouldBe "Q.V.C.m"

--- a/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/Ast.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/Ast.scala
@@ -68,6 +68,18 @@ case class Ast(nodes: List[NewNode],
     )
   }
 
+  def merge(other: Ast): Ast = {
+    Ast(
+      nodes ++ other.nodes,
+      edges = edges ++ other.edges,
+      conditionEdges = conditionEdges ++ other.conditionEdges,
+      argEdges = argEdges ++ other.argEdges,
+      receiverEdges = receiverEdges ++ other.receiverEdges,
+      refEdges = refEdges ++ other.refEdges,
+      bindsEdges = bindsEdges ++ other.bindsEdges
+    )
+  }
+
   /** AST that results when adding all ASTs in `asts` as children,
     * that is, connecting them to the root node of this AST.
     */


### PR DESCRIPTION
The where tons of defect fullnames and typedecl names/fullnames coming from internal CDT helper classes like ASTTypeUtils.
Had to fix them manually.