### PR TITLE
drop c2cpg as a direct dependency, to simplify classpath issues

### DIFF
--- a/console/build.sbt
+++ b/console/build.sbt
@@ -4,8 +4,7 @@ enablePlugins(JavaAppPackaging)
 
 dependsOn(Projects.codepropertygraph % "compile ->compile; test -> test",
           Projects.semanticcpg,
-          Projects.macros,
-          Projects.fuzzyc2cpg)
+          Projects.macros)
 
 scalacOptions ++= Seq(
   "-deprecation",                      // Emit warning and location for usages of deprecated APIs.

--- a/console/build.sbt
+++ b/console/build.sbt
@@ -5,8 +5,7 @@ enablePlugins(JavaAppPackaging)
 dependsOn(Projects.codepropertygraph % "compile ->compile; test -> test",
           Projects.semanticcpg,
           Projects.macros,
-          Projects.fuzzyc2cpg,
-          Projects.c2cpg)
+          Projects.fuzzyc2cpg)
 
 scalacOptions ++= Seq(
   "-deprecation",                      // Emit warning and location for usages of deprecated APIs.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
@@ -1,9 +1,6 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.c2cpg.C2Cpg
-import io.shiftleft.c2cpg.C2Cpg.Config
 import io.shiftleft.console.CFrontendConfig
-
 import java.nio.file.Path
 
 /**
@@ -18,17 +15,11 @@ case class CCpgGenerator(config: CFrontendConfig, rootPath: Path) extends CpgGen
     * CPG was generated.
     **/
   override def generate(inputPath: String,
-                        outputPath: String = "cpg.bin.zip",
+                        outputPath: String = "cpg.bin",
                         namespaces: List[String] = List()): Option[String] = {
-    val c = new C2Cpg()
-    val config = Config(
-      inputPaths = Set(inputPath),
-      outputPath = outputPath,
-      sourceFileExtensions = Set(".c", ".cc", ".cpp", ".h", ".hpp")
-    )
-    val cpg = c.runAndOutput(config)
-    cpg.close()
-    Some(outputPath)
+    val command = rootPath.resolve("c2cpg.sh").toString
+    val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
+    runShellCommand(command, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = true

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.console.cpgcreation
 
 import io.shiftleft.console.CFrontendConfig
+
 import java.nio.file.Path
 
 /**


### PR DESCRIPTION
* downstream builds have very complicated and mutually
  excluding transitive dependencies already