### PR TITLE
upload c2cpg/fuzzyc2cpg as downloadable release assets

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -145,3 +145,23 @@ jobs:
           asset_path: ./fuzzyppcli-win.zip
           asset_name: fuzzyppcli-win.zip
           asset_content_type: application/zip
+      - name: Package frontends for release
+        run: sbt clean Universal/c2cpg/packageBin Universal/fuzzyc2cpg/packageBin
+      - name: Upload fuzzyc2cpg to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: fuzzyc2cpg/target/universal/*.zip
+          asset_name: fuzzy2cpg.zip.zip
+          asset_content_type: application/zip
+      - name: Upload c2cpg to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: c2cpg/target/universal/*.zip
+          asset_name: c2cpg.zip.zip
+          asset_content_type: application/zip

--- a/build.sbt
+++ b/build.sbt
@@ -105,3 +105,6 @@ Global / onLoad := {
   assert(GitLFSUtils.isGitLFSEnabled(), "You need to install git-lfs and run 'git lfs pull'")
   (Global / onLoad).value
 }
+
+// no top level directory in Universal/packageXyz
+ThisBuild/topLevelDirectory := None


### PR DESCRIPTION
note: this is using an unmaintained version of the github release plugin,
we'd better migrate the entire action, but I wasn't sure how the
fuzzycpp-windows build would affect that.

I hope this works, we can only test on master I guess.