### PR TITLE
Remove frontend specific config and add additional args to importCode

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -20,7 +20,7 @@ object InstallConfig {
 }
 
 class ConsoleConfig(val install: InstallConfig = InstallConfig(),
-                    val frontend: LanguageFrontendConfig = LanguageFrontendConfig(),
+                    val frontend: FrontendConfig = FrontendConfig(),
                     val tools: ToolsConfig = ToolsConfig()) {}
 
 object ToolsConfig {
@@ -29,67 +29,8 @@ object ToolsConfig {
 
 class ToolsConfig(var imageViewer: String = "xdg-open")
 
-object LanguageFrontendConfig {
-  def apply(): LanguageFrontendConfig = new LanguageFrontendConfig()
-}
-
-class LanguageFrontendConfig(var c: CFrontendConfig = CFrontendConfig(),
-                             var csharp: CSharpFrontendConfig = CSharpFrontendConfig(),
-                             var fuzzyc: FuzzyCFrontendConfig = FuzzyCFrontendConfig(),
-                             var go: GoFrontendConfig = GoFrontendConfig(),
-                             var java: JavaFrontendConfig = JavaFrontendConfig(),
-                             var js: JsFrontendConfig = JsFrontendConfig(),
-                             var llvm: LlvmFrontendConfig = LlvmFrontendConfig(),
-                             var python: PythonFrontendConfig = PythonFrontendConfig(),
-                             var php: PhpFrontendConfig = PhpFrontendConfig(),
-                             var ghidra: GhidraFrontendConfig = GhidraFrontendConfig())
-
-class CFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class CSharpFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class FuzzyCFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class GoFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class JavaFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class JsFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class LlvmFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class PythonFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class PhpFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-class GhidraFrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer())
-
-object CFrontendConfig {
-  def apply(): CFrontendConfig = new CFrontendConfig()
-}
-object CSharpFrontendConfig {
-  def apply(): CSharpFrontendConfig = new CSharpFrontendConfig()
-}
-
-object FuzzyCFrontendConfig {
-  def apply(): FuzzyCFrontendConfig = new FuzzyCFrontendConfig()
-}
-
-object GoFrontendConfig {
-  def apply(): GoFrontendConfig = new GoFrontendConfig()
-}
-
-object JavaFrontendConfig {
-  def apply(): JavaFrontendConfig = new JavaFrontendConfig()
-}
-
-object JsFrontendConfig {
-  def apply(): JsFrontendConfig = new JsFrontendConfig()
-}
-
-object LlvmFrontendConfig {
-  def apply(): LlvmFrontendConfig = new LlvmFrontendConfig()
-}
-
-object PythonFrontendConfig {
-  def apply(): PythonFrontendConfig = new PythonFrontendConfig()
-}
-
-object PhpFrontendConfig {
-  def apply(): PhpFrontendConfig = new PhpFrontendConfig()
-}
-
-object GhidraFrontendConfig {
-  def apply(): GhidraFrontendConfig = new GhidraFrontendConfig()
+case class FrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer()) {
+  def withAdditionalArgs(additionalArgs: Iterable[String]): FrontendConfig = {
+    FrontendConfig(cmdLineParams ++ additionalArgs)
+  }
 }

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.CFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
@@ -8,7 +8,7 @@ import java.nio.file.Path
   * Fuzzy C/C++ language frontend. Translates C/C++ source files
   * into code property graphs via fuzzy parsing.
   * */
-case class CCpgGenerator(config: CFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CSharpCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CSharpCpgGenerator.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.CSharpFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
 /**
   * C# language frontend. Translates C# project files into code property graphs.
   * */
-case class CSharpCpgGenerator(config: CSharpFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class CSharpCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   private val dotnetFrameworkOpt = "--dotnet-framework"
   private val dotnetCoreOpt = "--dotnet-core"

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
@@ -19,7 +19,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     guessLanguage(inputPath)
       .flatMap { l =>
         report("Using generator for language: " + l)
-        cpgGeneratorForLanguage(l, config.frontend, config.install.rootPath.path)
+        cpgGeneratorForLanguage(l, config.frontend, config.install.rootPath.path, additionalArgs = Nil)
       }
   }
 
@@ -34,7 +34,8 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
           cpgGeneratorForLanguage(
             lang,
             config.frontend,
-            config.install.rootPath.path
+            config.install.rootPath.path,
+            additionalArgs = Nil
         ))
   }
 

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.FuzzyCFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
@@ -8,7 +8,7 @@ import java.nio.file.Path
   * Fuzzy C/C++ language frontend. Translates C/C++ source files
   * into code property graphs via fuzzy parsing.
   * */
-case class FuzzyCCpgGenerator(config: FuzzyCFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class FuzzyCCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/GhidraCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/GhidraCpgGenerator.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.GhidraFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
 /**
   * Language frontend for Ghidra - translates compiled binaries into Code Property Graphs.
   */
-case class GhidraCpgGenerator(config: GhidraFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class GhidraCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/GoCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/GoCpgGenerator.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.GoFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
 /**
   * Language frontend for Go code.  Translates Go source code into Code Property Graphs.
   */
-case class GoCpgGenerator(config: GoFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class GoCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
@@ -60,12 +60,16 @@ class ImportCode[T <: Project](console: io.shiftleft.console.Console[T]) {
 
   class Frontend(val language: String, val description: String = "") {
     def isAvailable: Boolean = {
-      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path).get.isAvailable
+      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, additionalArgs = Nil).get.isAvailable
     }
 
-    def apply(inputPath: String, projectName: String = "", namespaces: List[String] = List()): Option[Cpg] = {
-      val frontend =
-        cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path)
+    def apply(inputPath: String,
+              projectName: String = "",
+              namespaces: List[String] = List(),
+              additionalArgs: List[String] = List()): Option[Cpg] = {
+      val frontend = {
+        cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, additionalArgs)
+      }
       new ImportCode(console)(frontend.get, inputPath, projectName, namespaces)
     }
   }

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/JavaCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/JavaCpgGenerator.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.JavaFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
 /**
   * Language frontend for Java archives (JAR files). Translates Java archives into code property graphs.
   * */
-case class JavaCpgGenerator(config: JavaFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class JavaCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/JsCpgGenerator.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.JsFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
-case class JsCpgGenerator(config: JsFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/LlvmCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/LlvmCpgGenerator.scala
@@ -1,13 +1,13 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.LlvmFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
 /**
   * Language frontend for LLVM.  Translates LLVM bitcode into Code Property Graphs.
   */
-case class LlvmCpgGenerator(config: LlvmFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class LlvmCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/PhpCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/PhpCpgGenerator.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.PhpFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
-case class PhpCpgGenerator(config: PhpFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class PhpCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   override def generate(inputPath: String, outputPath: String, namespaces: List[String]): Option[String] = {
     val command = rootPath.resolve("php2cpg").toString

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/PythonCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/PythonCpgGenerator.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.PythonFrontendConfig
+import io.shiftleft.console.FrontendConfig
 
 import java.nio.file.Path
 
-case class PythonCpgGenerator(config: PythonFrontendConfig, rootPath: Path) extends CpgGenerator {
+case class PythonCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
 
   /**
     * Generate a CPG for the given input path.

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
@@ -11,19 +11,20 @@ package object cpgcreation {
     * For a given language, return CPG generator script
     * */
   def cpgGeneratorForLanguage(language: String,
-                              config: LanguageFrontendConfig,
-                              rootPath: Path): Option[CpgGenerator] = {
+                              config: FrontendConfig,
+                              rootPath: Path,
+                              additionalArgs: List[String]): Option[CpgGenerator] = {
     language match {
-      case Languages.CSHARP     => Some(CSharpCpgGenerator(config.csharp, rootPath))
-      case Languages.C          => Some(FuzzyCCpgGenerator(config.fuzzyc, rootPath))
-      case Languages.LLVM       => Some(LlvmCpgGenerator(config.llvm, rootPath))
-      case Languages.GOLANG     => Some(GoCpgGenerator(config.go, rootPath))
-      case Languages.JAVA       => Some(JavaCpgGenerator(config.java, rootPath))
-      case Languages.JAVASCRIPT => Some(JsCpgGenerator(config.js, rootPath))
-      case Languages.PYTHON     => Some(PythonCpgGenerator(config.python, rootPath))
-      case Languages.PHP        => Some(PhpCpgGenerator(config.php, rootPath))
-      case Languages.GHIDRA     => Some(GhidraCpgGenerator(config.ghidra, rootPath))
-      case Languages.NEWC       => Some(CCpgGenerator(config.c, rootPath))
+      case Languages.CSHARP     => Some(CSharpCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.C          => Some(FuzzyCCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.LLVM       => Some(LlvmCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.GOLANG     => Some(GoCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.JAVA       => Some(JavaCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.JAVASCRIPT => Some(JsCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.PYTHON     => Some(PythonCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.PHP        => Some(PhpCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.GHIDRA     => Some(GhidraCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
+      case Languages.NEWC       => Some(CCpgGenerator(config.withAdditionalArgs(additionalArgs), rootPath))
       case _                    => None
     }
   }

--- a/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
@@ -15,5 +15,22 @@ class ConsoleConfigTest extends AnyWordSpec with Matchers {
       val config = new InstallConfig(environment = Map("SHIFTLEFT_OCULAR_INSTALL_DIR" -> "/tmp"))
       config.rootPath shouldBe File("/tmp")
     }
+
+    "copy config with params correctly" in {
+      val config = new FrontendConfig()
+      val initialParamList = List("param1", "param2")
+      val additionalParamList = List("param3", "param4", "param5")
+
+      config.cmdLineParams ++= initialParamList
+      val newConfig = config.withAdditionalArgs(additionalParamList)
+
+      withClue("New config should have the full param list") {
+        newConfig.cmdLineParams shouldBe (initialParamList ++ additionalParamList)
+      }
+
+      withClue("Old config should not be mutated") {
+        config.cmdLineParams shouldBe initialParamList
+      }
+    }
   }
 }

--- a/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
@@ -68,8 +68,9 @@ class LanguageHelperTests extends AnyWordSpec with Matchers {
     "select LLVM frontend for directories containing ll files" in {
       val frontend = io.shiftleft.console.cpgcreation.cpgGeneratorForLanguage(
         Languages.LLVM,
-        new LanguageFrontendConfig(),
-        File(".").path
+        FrontendConfig(),
+        File(".").path,
+        Nil
       )
       frontend.get.isInstanceOf[LlvmCpgGenerator] shouldBe true
     }


### PR DESCRIPTION
# Notes
* Collapse frontend specific config into a single `FrontendConfig` that acts as a wrapper around the `cmdLineParams` field currently present in the frontend-specific configs
* Add an `additionalArgs` parameter to `ImportCode.Frontend.apply`. This lets you specify additional args for the cpgGenerator through joern by doing `importCode.language(src, additionalArgs = List("additional", "args"))`

# Testing
`sbt clean test` and manual testing through joern.

Edit: Formatting