### PR TITLE
Make frontend config buffer immutable

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -29,8 +29,6 @@ object ToolsConfig {
 
 class ToolsConfig(var imageViewer: String = "xdg-open")
 
-case class FrontendConfig(var cmdLineParams: Iterable[String] = mutable.Buffer()) {
-  def withAdditionalArgs(additionalArgs: Iterable[String]): FrontendConfig = {
-    FrontendConfig(cmdLineParams ++ additionalArgs)
-  }
+case class FrontendConfig(cmdLineParams: Iterable[String] = Nil) {
+  def withAdditionalArgs(additionalArgs: Iterable[String]) = copy(cmdLineParams ++ additionalArgs)
 }

--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -2,8 +2,6 @@ package io.shiftleft.console
 
 import better.files._
 
-import scala.collection.mutable
-
 /**
   * Installation configuration of Console
   *

--- a/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
@@ -17,11 +17,10 @@ class ConsoleConfigTest extends AnyWordSpec with Matchers {
     }
 
     "copy config with params correctly" in {
-      val config = new FrontendConfig()
       val initialParamList = List("param1", "param2")
       val additionalParamList = List("param3", "param4", "param5")
 
-      config.cmdLineParams ++= initialParamList
+      val config = FrontendConfig(initialParamList)
       val newConfig = config.withAdditionalArgs(additionalParamList)
 
       withClue("New config should have the full param list") {


### PR DESCRIPTION
# Notes
* Make cmdLineParams immutable in FrontendConfig
* I'm keeping the `withAdditionalArgs` method as it's not quite a straight-forward copy (since we want to append the additional args to the existing ones). I did modify the implementation to use copy to make this more explicit, however.
# Testing
`sbt clean test`