### PR TITLE
Make data flow code easier to understand

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -27,10 +27,12 @@ class DataFlowSolver {
           .getOrElse(problem.empty)
         in += n -> inSet
         val old = out(n)
-        out += n -> problem.transferFunction(n, inSet)
-        if (old != out(n))
+        val newSet = problem.transferFunction(n, inSet)
+        val changed = !old.equals(newSet)
+        out += n -> newSet
+        if (changed) {
           problem.flowGraph.succ(n)
-        else
+        } else
           List()
       }
       workList.clear()
@@ -60,8 +62,10 @@ class DataFlowSolver {
           .getOrElse(problem.empty)
         out += n -> outSet
         val old = in(n)
-        in += n -> problem.transferFunction(n, outSet)
-        if (old != in(n))
+        val newSet = problem.transferFunction(n, outSet)
+        val changed = !old.equals(newSet)
+        in += n -> newSet
+        if (changed)
           problem.flowGraph.pred(n)
         else
           List()


### PR DESCRIPTION
I was having trouble figuring out whether the recent set equality change I made to the OSS data flow tracker was actually correct because it depended on whether or not a copy was made. It's still a bit non-obvious to me, so I rewrote it to be obvious.