### PR TITLE
Add the cpg generators dir to InstallConfig to not require front-end scripts in project root

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -13,6 +13,18 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
   var rootPath: File = environment
     .getOrElse("SHIFTLEFT_OCULAR_INSTALL_DIR", ".")
     .toFile
+
+  var cpgGeneratorsDir: String = ""
+
+  def withCpgGeneratorsDir(cpgGeneratorsDir: String): InstallConfig = {
+    this.cpgGeneratorsDir = cpgGeneratorsDir
+    this
+  }
+
+  def withRootPath(rootPath: String): InstallConfig = {
+    this.rootPath = File(rootPath)
+    this
+  }
 }
 
 object InstallConfig {

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CCpgGenerator.scala
@@ -1,14 +1,20 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.FrontendConfig
+import io.shiftleft.console.{FrontendConfig, InstallConfig}
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 /**
   * Fuzzy C/C++ language frontend. Translates C/C++ source files
   * into code property graphs via fuzzy parsing.
   * */
-case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+case class CCpgGenerator(config: FrontendConfig, installConfig: InstallConfig) extends CpgGenerator {
+
+  val binaryPath: Path = {
+    val rootPath = installConfig.rootPath.path
+    val relativeBinPath = Paths.get(installConfig.cpgGeneratorsDir, "c2cpg.sh")
+    rootPath.resolve(relativeBinPath)
+  }
 
   /**
     * Generate a CPG for the given input path.
@@ -18,9 +24,9 @@ case class CCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGene
   override def generate(inputPath: String,
                         outputPath: String = "cpg.bin",
                         namespaces: List[String] = List()): Option[String] = {
-    val command = rootPath.resolve("c2cpg.sh").toString
+
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command, arguments).map(_ => outputPath)
+    runShellCommand(binaryPath.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = true

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGenerator.scala
@@ -1,7 +1,9 @@
 package io.shiftleft.console.cpgcreation
 
 import better.files.File
+import io.shiftleft.console.{FrontendConfig, InstallConfig}
 
+import java.nio.file.{Path, Paths}
 import scala.sys.process._
 
 /**

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
@@ -19,7 +19,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
     guessLanguage(inputPath)
       .flatMap { l =>
         report("Using generator for language: " + l)
-        cpgGeneratorForLanguage(l, config.frontend, config.install.rootPath.path, args = Nil)
+        cpgGeneratorForLanguage(l, config.frontend, config.install, args = Nil)
       }
   }
 
@@ -34,7 +34,7 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
           cpgGeneratorForLanguage(
             lang,
             config.frontend,
-            config.install.rootPath.path,
+            config.install,
             args = Nil
         ))
   }

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/FuzzyCCpgGenerator.scala
@@ -1,14 +1,20 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.FrontendConfig
+import io.shiftleft.console.{FrontendConfig, InstallConfig}
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 /**
   * Fuzzy C/C++ language frontend. Translates C/C++ source files
   * into code property graphs via fuzzy parsing.
   * */
-case class FuzzyCCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+case class FuzzyCCpgGenerator(config: FrontendConfig, installConfig: InstallConfig) extends CpgGenerator {
+
+  val binaryPath: Path = {
+    val rootPath = installConfig.rootPath.path
+    val relativeBinPath = Paths.get(installConfig.cpgGeneratorsDir, "fuzzyc2cpg.sh")
+    rootPath.resolve(relativeBinPath)
+  }
 
   /**
     * Generate a CPG for the given input path.
@@ -18,9 +24,8 @@ case class FuzzyCCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
   override def generate(inputPath: String,
                         outputPath: String = "cpg.bin",
                         namespaces: List[String] = List()): Option[String] = {
-    val command = rootPath.resolve("fuzzyc2cpg.sh").toString
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command, arguments).map(_ => outputPath)
+    runShellCommand(binaryPath.toString, arguments).map(_ => outputPath)
   }
 
   override def isAvailable: Boolean = true

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/GhidraCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/GhidraCpgGenerator.scala
@@ -1,13 +1,19 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.FrontendConfig
+import io.shiftleft.console.{FrontendConfig, InstallConfig}
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 /**
   * Language frontend for Ghidra - translates compiled binaries into Code Property Graphs.
   */
-case class GhidraCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+case class GhidraCpgGenerator(config: FrontendConfig, installConfig: InstallConfig) extends CpgGenerator {
+
+  val binaryPath: Path = {
+    val rootPath = installConfig.rootPath.path
+    val relativeBinPath = Paths.get(installConfig.cpgGeneratorsDir, "ghidra2cpg")
+    rootPath.resolve(relativeBinPath)
+  }
 
   /**
     * Generate a CPG for the given input path.
@@ -17,10 +23,9 @@ case class GhidraCpgGenerator(config: FrontendConfig, rootPath: Path) extends Cp
   override def generate(inputPath: String,
                         outputPath: String = "cpg.bin",
                         namespaces: List[String] = List()): Option[String] = {
-    val command = rootPath.resolve("ghidra2cpg").toString
     val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
-    runShellCommand(command, arguments).map(_ => outputPath)
+    runShellCommand(binaryPath.toString, arguments).map(_ => outputPath)
   }
 
-  override def isAvailable: Boolean = rootPath.resolve("ghidra2cpg").toFile.exists()
+  override def isAvailable: Boolean = binaryPath.toFile.exists()
 }

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
@@ -60,7 +60,7 @@ class ImportCode[T <: Project](console: io.shiftleft.console.Console[T]) {
 
   class Frontend(val language: String, val description: String = "") {
     def isAvailable: Boolean = {
-      cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args = Nil).get.isAvailable
+      cpgGeneratorForLanguage(language, config.frontend, config.install, args = Nil).get.isAvailable
     }
 
     def apply(inputPath: String,
@@ -68,7 +68,7 @@ class ImportCode[T <: Project](console: io.shiftleft.console.Console[T]) {
               namespaces: List[String] = List(),
               args: List[String] = List()): Option[Cpg] = {
       val frontend = {
-        cpgGeneratorForLanguage(language, config.frontend, config.install.rootPath.path, args)
+        cpgGeneratorForLanguage(language, config.frontend, config.install, args)
       }
       new ImportCode(console)(frontend.get, inputPath, projectName, namespaces)
     }

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/JsCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/JsCpgGenerator.scala
@@ -1,10 +1,16 @@
 package io.shiftleft.console.cpgcreation
 
-import io.shiftleft.console.FrontendConfig
+import io.shiftleft.console.{FrontendConfig, InstallConfig}
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
-case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+case class JsCpgGenerator(config: FrontendConfig, installConfig: InstallConfig) extends CpgGenerator {
+
+  val binaryPath: Path = {
+    val rootPath = installConfig.rootPath.path
+    val relativeBinPath = Paths.get(installConfig.cpgGeneratorsDir, "js2cpg.sh")
+    rootPath.resolve(relativeBinPath)
+  }
 
   /**
     * Generate a CPG for the given input path.
@@ -14,10 +20,10 @@ case class JsCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGen
   override def generate(inputPath: String,
                         outputPath: String = "cpg.bin.zip",
                         namespaces: List[String] = List()): Option[String] = {
-    val js2cpgsh = rootPath.resolve("js2cpg.sh").toString
+    val js2cpgsh = binaryPath.toString
     val arguments = Seq(inputPath, "--output", outputPath) ++ config.cmdLineParams
     runShellCommand(js2cpgsh, arguments).map(_ => outputPath)
   }
 
-  override def isAvailable: Boolean = rootPath.resolve("js2cpg.sh").toFile.exists()
+  override def isAvailable: Boolean = binaryPath.toFile.exists()
 }

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
@@ -12,19 +12,22 @@ package object cpgcreation {
     * */
   def cpgGeneratorForLanguage(language: String,
                               config: FrontendConfig,
-                              rootPath: Path,
+                              installConfig: InstallConfig,
                               args: List[String]): Option[CpgGenerator] = {
+
+    val rootPath = installConfig.rootPath.path
+
     language match {
       case Languages.CSHARP     => Some(CSharpCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.C          => Some(FuzzyCCpgGenerator(config.withArgs(args), rootPath))
+      case Languages.C          => Some(FuzzyCCpgGenerator(config.withArgs(args), installConfig))
       case Languages.LLVM       => Some(LlvmCpgGenerator(config.withArgs(args), rootPath))
       case Languages.GOLANG     => Some(GoCpgGenerator(config.withArgs(args), rootPath))
       case Languages.JAVA       => Some(JavaCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.JAVASCRIPT => Some(JsCpgGenerator(config.withArgs(args), rootPath))
+      case Languages.JAVASCRIPT => Some(JsCpgGenerator(config.withArgs(args), installConfig))
       case Languages.PYTHON     => Some(PythonCpgGenerator(config.withArgs(args), rootPath))
       case Languages.PHP        => Some(PhpCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.GHIDRA     => Some(GhidraCpgGenerator(config.withArgs(args), rootPath))
-      case Languages.NEWC       => Some(CCpgGenerator(config.withArgs(args), rootPath))
+      case Languages.GHIDRA     => Some(GhidraCpgGenerator(config.withArgs(args), installConfig))
+      case Languages.NEWC       => Some(CCpgGenerator(config.withArgs(args), installConfig))
       case _                    => None
     }
   }

--- a/console/src/test/scala/io/shiftleft/console/CpgGeneratorTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/CpgGeneratorTests.scala
@@ -1,0 +1,42 @@
+package io.shiftleft.console
+
+import io.shiftleft.console.cpgcreation.{CCpgGenerator, CSharpCpgGenerator, FuzzyCCpgGenerator, GhidraCpgGenerator, JsCpgGenerator}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.{Path, Paths}
+
+class CpgGeneratorTests extends AnyWordSpec with Matchers with BeforeAndAfterEach {
+  private val rootPath = "/proj/root"
+  private val frontendConfig = FrontendConfig()
+  private var installConfig = InstallConfig().withRootPath(rootPath)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    installConfig = InstallConfig().withRootPath(rootPath)
+  }
+
+  "XCpgGenerator" should {
+    "use the project root as the binary dir if none is specified" in {
+
+      CCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe s"$rootPath/c2cpg.sh"
+      FuzzyCCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe s"$rootPath/fuzzyc2cpg.sh"
+      GhidraCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe s"$rootPath/ghidra2cpg"
+      JsCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe s"$rootPath/js2cpg.sh"
+    }
+
+    "correctly insert the cpg generators directory into the binary path" in {
+      val genPath = "cpg/generators"
+      installConfig.cpgGeneratorsDir = genPath
+      CCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe s"$rootPath/$genPath/c2cpg.sh"
+      FuzzyCCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe s"$rootPath/$genPath/fuzzyc2cpg.sh"
+      GhidraCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe s"$rootPath/$genPath/ghidra2cpg"
+      JsCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe s"$rootPath/$genPath/js2cpg.sh"
+
+      installConfig.cpgGeneratorsDir = ""
+      CCpgGenerator(frontendConfig, installConfig).binaryPath.toString shouldBe "/proj/root/c2cpg.sh"
+    }
+  }
+
+}

--- a/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
+++ b/console/src/test/scala/io/shiftleft/console/LanguageHelperTests.scala
@@ -69,7 +69,7 @@ class LanguageHelperTests extends AnyWordSpec with Matchers {
       val frontend = io.shiftleft.console.cpgcreation.cpgGeneratorForLanguage(
         Languages.LLVM,
         FrontendConfig(),
-        File(".").path,
+        InstallConfig().withRootPath("."),
         Nil
       )
       frontend.get.isInstanceOf[LlvmCpgGenerator] shouldBe true

--- a/console/src/test/scala/io/shiftleft/console/project/build.properties
+++ b/console/src/test/scala/io/shiftleft/console/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.5


### PR DESCRIPTION
# Notes
This PR adds an optional `cpgGeneratorsDir` to `InstallConfig` and uses that field when determining the front-end executable path for `c2cpg`, `fuzzyc2cpg`, `ghidra2cpg`, and `js2cpg` (so effectively the front-ends available through Joern). This can easily be extended to most of the rest of the front-ends, but some thought is needed for Go and C#, since they have Windows options as well.

# Testing
`sbt clean test`, along with manual verification that these scripts no longer need to appear in the Joern project root  for it to function (follow-up PR coming)