### PR TITLE
Optimizations for OSS data flow tracker

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -16,12 +16,9 @@ class ReachingDefPass(cpg: Cpg) extends ParallelCpgPass[Method](cpg) {
   override def partIterator: Iterator[Method] = cpg.method.iterator
 
   override def runOnPart(method: Method): Iterator[DiffGraph] = {
-    println("Begin: " + method.name)
     val problem = ReachingDefProblem.create(method)
-    println("Created: " + method.name)
     val solution = new DataFlowSolver().calculateMopSolutionForwards(problem)
     val dstGraph = addReachingDefEdges(method, solution)
-    println("End: " + method.name)
     Iterator(dstGraph.build())
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -154,6 +154,7 @@ class ReachingDefTransferFunction(method: Method) extends TransferFunction[mutab
     * and `kill(n)`.
     * */
   override def apply(n: StoredNode, x: mutable.Set[Definition]): mutable.Set[Definition] = {
+    println(method.name)
     gen(n).union(x.diff(kill(n)))
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -154,7 +154,6 @@ class ReachingDefTransferFunction(method: Method) extends TransferFunction[mutab
     * and `kill(n)`.
     * */
   override def apply(n: StoredNode, x: mutable.Set[Definition]): mutable.Set[Definition] = {
-    println(method.name)
     gen(n).union(x.diff(kill(n)))
   }
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -196,27 +196,26 @@ class ReachingDefTransferFunction(method: Method) extends TransferFunction[mutab
   private def killsForGens(genOfCall: Set[Definition],
                            allIdentifiers: Map[String, List[Identifier]],
                            allCalls: Map[String, List[Call]]): Set[Definition] = {
-    genOfCall.flatMap { definition =>
-      definitionsOfSameVariable(definition, allIdentifiers, allCalls)
-    }
-  }
 
-  private def definitionsOfSameVariable(definition: Definition,
-                                        allIdentifiers: Map[String, List[Identifier]],
-                                        allCalls: Map[String, List[Call]]): Set[Definition] = {
-    val definedNodes = definition.node match {
-      case param: MethodParameterIn =>
-        allIdentifiers(param.name)
-          .filter(x => x.id != param.id)
-      case identifier: Identifier =>
-        allIdentifiers(identifier.name)
-          .filter(x => x.id != identifier.id)
-      case call: Call =>
-        allCalls(call.code)
-          .filter(x => x.id != call.id)
-      case _ => Set()
+    def definitionsOfSameVariable(definition: Definition): Set[Definition] = {
+      val definedNodes = definition.node match {
+        case param: MethodParameterIn =>
+          allIdentifiers(param.name)
+            .filter(x => x.id != param.id)
+        case identifier: Identifier =>
+          allIdentifiers(identifier.name)
+            .filter(x => x.id != identifier.id)
+        case call: Call =>
+          allCalls(call.code)
+            .filter(x => x.id != call.id)
+        case _ => Set()
+      }
+      definedNodes.map(Definition.fromNode).toSet
     }
-    definedNodes.map(Definition.fromNode).toSet
+
+    genOfCall.flatMap { definition =>
+      definitionsOfSameVariable(definition)
+    }
   }
 
 }


### PR DESCRIPTION
* Bring in a logical optimization for lone identifiers (see comments)
* Use mutable sets as opposed to immutable sets in fixed point algorithm
* Optimize initialization of kill sets