### PR TITLE
Added commandline argument to print preprocessor ifs/ifdefs only

### DIFF
--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
@@ -1,9 +1,9 @@
 package io.shiftleft.c2cpg.parser
 
 import io.shiftleft.c2cpg.utils.{IOUtils, TimeUtils}
-import org.eclipse.cdt.core.dom.ast.{IASTPreprocessorStatement, IASTTranslationUnit}
 import org.eclipse.cdt.core.dom.ast.gnu.c.GCCLanguage
 import org.eclipse.cdt.core.dom.ast.gnu.cpp.GPPLanguage
+import org.eclipse.cdt.core.dom.ast.{IASTPreprocessorStatement, IASTTranslationUnit}
 import org.eclipse.cdt.core.model.ILanguage
 import org.eclipse.cdt.core.parser.{DefaultLogService, ScannerInfo}
 import org.eclipse.cdt.internal.core.dom.parser.cpp.semantics.CPPVisitor

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.c2cpg.parser
 
 import io.shiftleft.c2cpg.utils.{IOUtils, TimeUtils}
-import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit
+import org.eclipse.cdt.core.dom.ast.{IASTPreprocessorStatement, IASTTranslationUnit}
 import org.eclipse.cdt.core.dom.ast.gnu.c.GCCLanguage
 import org.eclipse.cdt.core.dom.ast.gnu.cpp.GPPLanguage
 import org.eclipse.cdt.core.model.ILanguage
@@ -70,6 +70,10 @@ class CdtParser(private val parseConfig: ParseConfig) extends ParseProblemsLogge
       }
     }
     result.copy(duration = duration)
+  }
+
+  def preprocessorStatements(file: Path): Iterable[IASTPreprocessorStatement] = {
+    parse(file).map(t => preprocessorStatements(t)).getOrElse(Iterable.empty)
   }
 
   def parse(file: Path): Option[IASTTranslationUnit] = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/PreprocessorStatementsLogger.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/PreprocessorStatementsLogger.scala
@@ -36,8 +36,11 @@ trait PreprocessorStatementsLogger {
     logger.info(text + additionalInfo)
   }
 
+  protected def preprocessorStatements(translationUnit: IASTTranslationUnit): Iterable[IASTPreprocessorStatement] =
+    translationUnit.getAllPreprocessorStatements
+
   protected def logPreprocessorStatements(translationUnit: IASTTranslationUnit): Unit = {
-    translationUnit.getAllPreprocessorStatements.foreach(logPreprocessorStatement)
+    preprocessorStatements(translationUnit).foreach(logPreprocessorStatement)
   }
 
 }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/PreprocessorPass.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/PreprocessorPass.scala
@@ -1,0 +1,29 @@
+package io.shiftleft.c2cpg.passes
+
+import io.shiftleft.c2cpg.parser.{CdtParser, ParseConfig}
+import org.eclipse.cdt.core.dom.ast.{
+  IASTPreprocessorIfStatement,
+  IASTPreprocessorIfdefStatement,
+  IASTPreprocessorStatement
+}
+
+import java.nio.file.Paths
+import scala.collection.parallel.CollectionConverters.ImmutableIterableIsParallelizable
+import scala.collection.parallel.immutable.ParIterable
+
+class PreprocessorPass(filenames: List[String], parseConfig: ParseConfig) {
+
+  def run(): ParIterable[String] = filenames.par.flatMap(runOnPart)
+
+  private def preprocessorStatement2String(stmt: IASTPreprocessorStatement): Option[String] = stmt match {
+    case s: IASTPreprocessorIfStatement =>
+      Some(s.getCondition.mkString + { if (s.taken()) "=true" else "" })
+    case s: IASTPreprocessorIfdefStatement =>
+      Some(s.getCondition.mkString + { if (s.taken()) "=true" else "" })
+    case _ => None
+  }
+
+  private def runOnPart(filename: String): Iterable[String] =
+    new CdtParser(parseConfig).preprocessorStatements(Paths.get(filename)).flatMap(preprocessorStatement2String).toSet
+
+}

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/PreprocessorPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/PreprocessorPassTests.scala
@@ -1,0 +1,69 @@
+package io.shiftleft.c2cpg.passes
+
+import better.files.File
+import io.shiftleft.c2cpg.parser.ParseConfig
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class PreprocessorPassTests extends AnyWordSpec with Matchers {
+
+  "PreprocessorPass" should {
+
+    "find all ifdefs and ifs" in {
+      File.usingTemporaryDirectory("preprocessorPassTests") { dir =>
+        val code =
+          """
+            |#ifdef SYMBOL
+            | foo();
+            |#endif
+            |
+            |#define FOO
+            |#ifndef SYMBOL
+            | bar();
+            |#endif
+            |#ifdef FOO
+            | main();
+            |#endif
+            |""".stripMargin
+
+        val filename = "test.c"
+        val file = dir / filename
+        file.write(code)
+        val filePath = file.path.toAbsolutePath.toString
+
+        val stmts = new PreprocessorPass(List(filePath), ParseConfig.empty).run().toList
+        stmts shouldBe List("SYMBOL", "FOO=true")
+      }
+    }
+
+    "find all ifdefs and ifs with predefined symbols" in {
+      File.usingTemporaryDirectory("preprocessorPassTests") { dir =>
+        val code =
+          """
+            |#ifdef SYMBOL
+            | foo();
+            |#endif
+            |
+            |#define FOO
+            |#ifndef SYMBOL
+            | bar();
+            |#endif
+            |#ifdef FOO
+            | main();
+            |#endif
+            |""".stripMargin
+
+        val filename = "test.c"
+        val file = dir / filename
+        file.write(code)
+        val filePath = file.path.toAbsolutePath.toString
+
+        val parseConfig = ParseConfig(List.empty, Map("SYMBOL" -> "true"), logProblems = false, logPreprocessor = false)
+        val stmts = new PreprocessorPass(List(filePath), parseConfig).run().toList
+        stmts shouldBe List("SYMBOL=true", "FOO=true")
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
Running c2cpg with `--print-ifdef-only` will print a comma-separated list of all preprocessor ifdef and if statements. Does not create a CPG.