### PR TITLE
Fix long standing bug in resolving of install dir

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -10,9 +10,15 @@ import scala.collection.mutable
   * @param environment A map of system environment variables.
   * */
 class InstallConfig(environment: Map[String, String] = sys.env) {
-  var rootPath: File = environment
-    .getOrElse("SHIFTLEFT_OCULAR_INSTALL_DIR", ".")
-    .toFile
+  var rootPath: File = {
+    if (environment.contains("SHIFTLEFT_OCULAR_INSTALL_DIR")) {
+      environment("SHIFTLEFT_OCULAR_INSTALL_DIR").toFile
+    } else {
+      val uriToLibDir = classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
+      val pathToLibDir = new java.io.File(uriToLibDir).toPath
+      pathToLibDir.getParent.getParent.toFile.toScala
+    }
+  }
 }
 
 object InstallConfig {

--- a/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
@@ -1,14 +1,16 @@
 package io.shiftleft.console
 
-import better.files.File
+import better.files.{File, FileExtensions}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class ConsoleConfigTest extends AnyWordSpec with Matchers {
   "An InstallConfig" should {
-    "set the rootPath to the current working directory by default" in {
+    "set the rootPath to parent of directory containing jar by default" in {
       val config = new InstallConfig(environment = Map.empty)
-      config.rootPath shouldBe File(".")
+      val uriToLibDir = classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
+      val pathToLibDir = new java.io.File(uriToLibDir).toPath
+      config.rootPath shouldBe pathToLibDir.getParent.getParent.toFile.toScala
     }
 
     "set the rootPath to SHIFTLEFT_OCULAR_INSTALL_DIR if it is defined" in {


### PR DESCRIPTION
Previously, unless the environment variable `SHIFTLEFT_OCULAR_INSTALL_DIR` was set, we would assume that the installation directory was the current working directory. In particular when installing via `joern-install.sh` and then accessing `joern` via the symlink in `/usr/local/bin`, this isn't the case. Fortunately, we know that when running `joern/ocular` that the install dir is in fact the parent directory of the directory containing the jar, so, let's use that instead.
