### PR TITLE
Allow bailing out on large ReachingDef problems

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -11,7 +11,7 @@ object OssDataFlow {
   def defaultOpts = new OssDataFlowOptions()
 }
 
-class OssDataFlowOptions(var maxNumberOfDefinitions: Int = 1024) extends LayerCreatorOptions {}
+class OssDataFlowOptions(var maxNumberOfDefinitions: Int = 4000) extends LayerCreatorOptions {}
 
 class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/layers/dataflows/OssDataFlow.scala
@@ -4,8 +4,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.dataflowengineoss.passes.reachingdef.ReachingDefPass
 import io.shiftleft.semanticcpg.layers.{LayerCreator, LayerCreatorContext, LayerCreatorOptions}
 
-import scala.annotation.nowarn
-
 object OssDataFlow {
   val overlayName: String = "dataflowOss"
   val description: String = "Layer to support the OSS lightweight data flow tracker"
@@ -13,9 +11,8 @@ object OssDataFlow {
   def defaultOpts = new OssDataFlowOptions()
 }
 
-class OssDataFlowOptions() extends LayerCreatorOptions {}
+class OssDataFlowOptions(var maxNumberOfDefinitions: Int = 1024) extends LayerCreatorOptions {}
 
-@nowarn
 class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
 
   override val overlayName: String = OssDataFlow.overlayName
@@ -23,7 +20,7 @@ class OssDataFlow(opts: OssDataFlowOptions) extends LayerCreator {
 
   override def create(context: LayerCreatorContext, storeUndoInfo: Boolean): Unit = {
     val cpg = context.cpg
-    val enhancementExecList = Iterator(new ReachingDefPass(cpg))
+    val enhancementExecList = Iterator(new ReachingDefPass(cpg, opts.maxNumberOfDefinitions))
     enhancementExecList.zipWithIndex.foreach {
       case (pass, index) =>
         runPass(pass, context, storeUndoInfo, index)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -23,7 +23,8 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 1024) extends Para
     val problem = ReachingDefProblem.create(method)
 
     if (shouldBailOut(problem)) {
-      logger.info("Bailing out.")
+      logger.warn("Bailing out.")
+      return Iterator()
     }
 
     val solution = new DataFlowSolver().calculateMopSolutionForwards(problem)
@@ -38,7 +39,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 1024) extends Para
     val numberOfDefinitions = transferFunction.gen.foldLeft(0)(_ + _._2.size)
     logger.info("Number of definitions for {}: {}", method.fullName, numberOfDefinitions)
     if (numberOfDefinitions > maxNumberOfDefinitions) {
-      logger.info("Problem has more than {} definitions", maxNumberOfDefinitions)
+      logger.warn("Problem has more than {} definitions", maxNumberOfDefinitions)
       true
     } else {
       false

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -36,6 +36,8 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 1024) extends Para
   private def shouldBailOut(problem: DataFlowProblem[mutable.Set[Definition]]): Boolean = {
     val method = problem.flowGraph.entryNode.asInstanceOf[Method]
     val transferFunction = problem.transferFunction.asInstanceOf[ReachingDefTransferFunction]
+    // For each node, the `gen` map contains the list of definitions it generates
+    // We add up the sizes of these lists to obtain the total number of definitions
     val numberOfDefinitions = transferFunction.gen.foldLeft(0)(_ + _._2.size)
     logger.info("Number of definitions for {}: {}", method.fullName, numberOfDefinitions)
     if (numberOfDefinitions > maxNumberOfDefinitions) {


### PR DESCRIPTION
If a reaching definition problem has more than `4000` definitions, do not attempt to perform reaching definition analysis. This seems to be a good tradeoff. For `php-src`, this ends up skipping the following functions:
```
2021-09-03 17:16:34.306 WARN ReachingDefPass: KeccakP1600_Permute_Nrounds has more than 4000 definitions
2021-09-03 17:16:46.196 WARN ReachingDefPass: PHP_TIGERUpdate has more than 4000 definitions
2021-09-03 17:16:46.476 WARN ReachingDefPass: TigerFinalize has more than 4000 definitions
2021-09-03 17:16:47.783 WARN ReachingDefPass: KeccakP1600_Permute_12rounds has more than 4000 definitions
2021-09-03 17:16:49.528 WARN ReachingDefPass: luaV_execute has more than 4000 definitions
2021-09-03 17:16:49.812 WARN ReachingDefPass: zend_jit_trace_build_tssa has more than 4000 definitions
2021-09-03 17:16:50.852 WARN ReachingDefPass: zend_jit_trace has more than 4000 definitions
2021-09-03 17:17:21.016 WARN ReachingDefPass: SHA1Transform has more than 4000 definitions
2021-09-03 17:17:29.491 WARN ReachingDefPass: BF_crypt has more than 4000 definitions
2021-09-03 17:17:45.351 WARN ReachingDefPass: KeccakP1600_Permute_24rounds has more than 4000 definitions
2021-09-03 17:17:51.529 WARN ReachingDefPass: KeccakF1600_FastLoop_Absorb has more than 4000 definitions
```
... and takes 15 minutes to complete. Tested with the new frontend.