### PR TITLE
Add Java Source language for javasrc2cpg

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/CpgGeneratorFactory.scala
@@ -51,7 +51,8 @@ class CpgGeneratorFactory(config: ConsoleConfig) {
       Languages.LLVM,
       Languages.PHP,
       Languages.KOTLIN,
-      Languages.NEWC
+      Languages.NEWC,
+      Languages.JAVASRC
     ).contains(language)
   }
 

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/ImportCode.scala
@@ -51,6 +51,7 @@ class ImportCode[T <: Project](console: io.shiftleft.console.Console[T]) {
   def newc: CFrontend = new CFrontend(Languages.NEWC, "Eclipse CDT Based Frontend for C/C++")
   def llvm: Frontend = new Frontend(Languages.LLVM, "LLVM Bitcode Frontend")
   def java: Frontend = new Frontend(Languages.JAVA, "Java/Dalvik Bytecode Frontend")
+  def javasrc: Frontend = new Frontend(Languages.JAVASRC, "Java Source Frontend")
   def golang: Frontend = new Frontend(Languages.GOLANG, "Golang Source Frontend")
   def javascript: Frontend = new Frontend(Languages.JAVASCRIPT, "Javascript Source Frontend")
   def csharp: Frontend = new Frontend(Languages.CSHARP, "C# Source Frontend (Roslyn)")

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/JavaSrcCpgGenerator.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/JavaSrcCpgGenerator.scala
@@ -1,0 +1,26 @@
+package io.shiftleft.console.cpgcreation
+
+import io.shiftleft.console.FrontendConfig
+
+import java.nio.file.Path
+
+/**
+  * Source-based front-end for Java
+  */
+case class JavaSrcCpgGenerator(config: FrontendConfig, rootPath: Path) extends CpgGenerator {
+
+  /**
+    * Generate a CPG for the given input path.
+    * Returns the output path, or None, if no
+    * CPG was generated.
+    **/
+  override def generate(inputPath: String,
+                        outputPath: String = "cpg.bin",
+                        namespaces: List[String] = List()): Option[String] = {
+    val command = rootPath.resolve("javasrc2cpg").toString
+    val arguments = config.cmdLineParams.toSeq ++ Seq(inputPath, "--output", outputPath)
+    runShellCommand(command, arguments).map(_ => outputPath)
+  }
+
+  override def isAvailable: Boolean = rootPath.resolve("javasrc2cpg").toFile.exists()
+}

--- a/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
+++ b/console/src/main/scala/io/shiftleft/console/cpgcreation/package.scala
@@ -20,6 +20,7 @@ package object cpgcreation {
       case Languages.LLVM       => Some(LlvmCpgGenerator(config.withArgs(args), rootPath))
       case Languages.GOLANG     => Some(GoCpgGenerator(config.withArgs(args), rootPath))
       case Languages.JAVA       => Some(JavaCpgGenerator(config.withArgs(args), rootPath))
+      case Languages.JAVASRC    => Some(JavaSrcCpgGenerator(config.withArgs(args), rootPath))
       case Languages.JAVASCRIPT => Some(JsCpgGenerator(config.withArgs(args), rootPath))
       case Languages.PYTHON     => Some(PythonCpgGenerator(config.withArgs(args), rootPath))
       case Languages.PHP        => Some(PhpCpgGenerator(config.withArgs(args), rootPath))

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -87,7 +87,11 @@ object MetaData extends SchemaBase {
       Constant(name = "NEWC",
                value = "NEWC",
                valueType = ValueTypes.STRING,
-               comment = "Eclipse CDT based parser for C/C++").protoId(12)
+               comment = "Eclipse CDT based parser for C/C++").protoId(12),
+      Constant(name = "JAVASRC",
+               value = "JAVASRC",
+               valueType = ValueTypes.STRING,
+               comment = "Source-based front-end for Java").protoId(13)
     )
 
   }


### PR DESCRIPTION
# Notes
Add a new `JAVASRC` language which will be used to invoke the `javasrc2cpg` front-end.
# Testing
`sbt clean test`