### PR TITLE
Do not attempt to redirect stderr/turn some warns into infos

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -7,7 +7,7 @@ import io.shiftleft.console.cpgqlserver.CPGQLServer
 import io.shiftleft.console.embammonite.EmbeddedAmmonite
 import io.shiftleft.console.qdbwserver.QDBWServer
 
-import java.io.{FileOutputStream, IOException, PrintStream}
+import java.io.IOException
 
 case class Config(
     scriptFile: Option[Path] = None,
@@ -232,16 +232,9 @@ trait BridgeBase {
         | $storeCode
         |""".stripMargin
 
-    val logFileName = "/tmp/" + productName + "-scan-log.txt"
-    println(s"Detailed logs at: $logFileName")
-    val file = new java.io.File(logFileName);
-    val fos = new FileOutputStream(file);
-    val ps = new PrintStream(fos);
-    System.setErr(ps)
     withTemporaryScript(code, productName) { file =>
       runScript(os.Path(file.path.toString), config)
     }
-    ps.close()
   }
 
   private def startInteractiveShell(config: Config, slProduct: SLProduct) = {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/memberaccesslinker/MemberAccessLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/linking/memberaccesslinker/MemberAccessLinker.scala
@@ -39,7 +39,7 @@ class MemberAccessLinker(cpg: Cpg) extends CpgPass(cpg) {
                       cache: collection.mutable.Map[(Type, String), Member],
                       call: Call): Unit = {
     if (call._refOut.hasNext && !loggedDeprecationWarning) {
-      logger.warn(
+      logger.info(
         s"Using deprecated CPG format with already existing REF edge between" +
           s" a member access node and a member.")
       loggedDeprecationWarning = true
@@ -80,7 +80,7 @@ class MemberAccessLinker(cpg: Cpg) extends CpgPass(cpg) {
       }
     } catch {
       case exception: Exception =>
-        logger.warn(
+        logger.info(
           s"Error while obtaining IDENTIFIER associated to member access at ${call}" +
             s" Reason: ${exception.getMessage}")
     }
@@ -91,7 +91,7 @@ class MemberAccessLinker(cpg: Cpg) extends CpgPass(cpg) {
                         name: String,
                         depth: Int): Member = {
     if (depth > 100) {
-      logger.warn(
+      logger.info(
         "Maximum depth for member access resolution exceeded on type=${typ.fullName}, member=$name. Recursive inheritance?")
       return null
     }
@@ -115,7 +115,7 @@ class MemberAccessLinker(cpg: Cpg) extends CpgPass(cpg) {
           } else null
         }
         if (depth == 0 && res == null) {
-          logger.warn(s"Could not find type member. type=${typ.fullName}, member=$name")
+          logger.info(s"Could not find type member. type=${typ.fullName}, member=$name")
         }
         res
       }


### PR DESCRIPTION
Previously, when running a plugin, we would attempt to redirect STDERR to a file. Unfortunately, this doesn't work well with log4j, which - if initialized first - seems to just ignore this redirect. I'm taking out the redirection code and instead, the shell script that calls `(joern|ocular)-scan.sh` will simply perform the redirection - which the logger can't escape, it seems. While I'm at it, the `MemberAccessLinker` has been reporting warnings which I have degraded to infos. Warnings are displayed to the user on the shell, and these messages seem to neither be particularly relevant to most users, nor are they actionable.