### PR TITLE
Fixed types for identifiers

### DIFF
--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
@@ -93,10 +93,10 @@ trait AstCreatorHelper {
     case t if t.contains("?")                      => Defines.anyTypeName
     case t if t.contains("#")                      => Defines.anyTypeName
     case t if t.startsWith("{") && t.endsWith("}") => Defines.anyTypeName
+    case t if t.startsWith("[") && t.endsWith("]") => "[]"
     case t if t.contains("*")                      => "*"
-    case t if t.contains("[")                      => "[]"
     case t if t.contains("::")                     => fixQualifiedName(t).split(".").lastOption.getOrElse(Defines.anyTypeName)
-    case someType                                  => someType
+    case someType                                  => someType.replace(" ", "")
   }
 
   protected def typeFor(node: IASTNode): String = cleanType(ASTTypeUtil.getNodeType(node))

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
@@ -1449,6 +1449,18 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
       cpg.call.name("<operator>.new").code("new int\\[n\\]").argument.code("int").size shouldBe 1
     }
 
+    "be correct for array init" in TestAstOnlyFixture("""
+        |int x[] = {0, 1, 2, 3};
+        |""".stripMargin) { cpg =>
+      cpg.assignment.ast.l match {
+        case List(_, ident: Identifier, unknown: Unknown) =>
+          ident.typeFullName shouldBe "int[]"
+          // TODO: arrayInitializers
+          unknown.code shouldBe "{0, 1, 2, 3}"
+        case _ => fail()
+      }
+    }
+
     "be correct for 'new' object" in TestAstOnlyFixture(
       """
         |Foo* alloc(int n) {


### PR DESCRIPTION
This fixes the type calculation for types like in:
```
int x[] = {0, 1, 2, 3};
```

The `typeFullName` was previously `[]` which is incorrect.
Now its `int[]` like expected.