### PR TITLE
use current working dir for workspace

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -25,7 +25,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
   def console: Console[T] = this
 
   protected var workspaceManager: WorkspaceManager[T] = _
-  switchWorkspace(config.install.rootPath.path.resolve("workspace").toString)
+  switchWorkspace(File.currentWorkingDirectory.path.resolve("workspace").toString)
   protected def workspacePathName: String = workspaceManager.getPath
 
   private val nameOfCpgInProject = "cpg.bin"

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -16,7 +16,10 @@ import overflowdb.traversal.help.Doc
 import scala.sys.process.Process
 import scala.util.{Failure, Success, Try}
 
-class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[T]) extends ScriptManager(executor) {
+class Console[T <: Project](executor: AmmoniteExecutor,
+                            loader: WorkspaceLoader[T],
+                            baseDir: File = File.currentWorkingDirectory)
+    extends ScriptManager(executor) {
 
   import Console._
 
@@ -25,7 +28,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
   def console: Console[T] = this
 
   protected var workspaceManager: WorkspaceManager[T] = _
-  switchWorkspace(File.currentWorkingDirectory.path.resolve("workspace").toString)
+  switchWorkspace(baseDir.path.resolve("workspace").toString)
   protected def workspacePathName: String = workspaceManager.getPath
 
   private val nameOfCpgInProject = "cpg.bin"

--- a/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
@@ -32,7 +32,8 @@ object TestWorkspaceLoader extends WorkspaceLoader[Project] {
   override def createProject(projectFile: ProjectFile, path: Path): Project = Project(projectFile, path)
 }
 
-class TestConsole(workspaceDir: String) extends Console[Project](DefaultAmmoniteExecutor, TestWorkspaceLoader) {
+class TestConsole(workspaceDir: String)
+    extends Console[Project](DefaultAmmoniteExecutor, TestWorkspaceLoader, File(workspaceDir)) {
   override def config = new ConsoleConfig(
     install = new InstallConfig(Map("SHIFTLEFT_OCULAR_INSTALL_DIR" -> workspaceDir))
   )


### PR DESCRIPTION
some users may want to install joern/ocular system-wide in a read-only
directory, and have their workspace e.g. in their user home
re https://discord.com/channels/832209896089976854/832214243230744626/887106423341875200

This brings us back to the original behaviour, after it was changed in https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1387