### PR TITLE
detect installation root dir via marker file

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/ProjectRoot.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/ProjectRoot.scala
@@ -28,4 +28,7 @@ object ProjectRoot {
     else ???
   }
 
+  def find: File =
+    File(findRelativePath)
+
 }

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -25,7 +25,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
   def console: Console[T] = this
 
   protected var workspaceManager: WorkspaceManager[T] = _
-  switchWorkspace(config.install.rootPath.path.resolve("workspace").toString)
+  switchWorkspace(File.currentWorkingDirectory.path.resolve("workspace").toString)
   protected def workspacePathName: String = workspaceManager.getPath
 
   private val nameOfCpgInProject = "cpg.bin"

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -16,7 +16,10 @@ import overflowdb.traversal.help.Doc
 import scala.sys.process.Process
 import scala.util.{Failure, Success, Try}
 
-class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[T]) extends ScriptManager(executor) {
+class Console[T <: Project](executor: AmmoniteExecutor,
+                            loader: WorkspaceLoader[T],
+                            baseDir: File = File.currentWorkingDirectory)
+    extends ScriptManager(executor) {
 
   import Console._
 
@@ -25,7 +28,7 @@ class Console[T <: Project](executor: AmmoniteExecutor, loader: WorkspaceLoader[
   def console: Console[T] = this
 
   protected var workspaceManager: WorkspaceManager[T] = _
-  switchWorkspace(File.currentWorkingDirectory.path.resolve("workspace").toString)
+  switchWorkspace(baseDir.path.resolve("workspace").toString)
   protected def workspacePathName: String = workspaceManager.getPath
 
   private val nameOfCpgInProject = "cpg.bin"

--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -16,8 +16,7 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
     } else {
       val uriToLibDir = classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
       val pathToLibDir = File(uriToLibDir)
-      findRootDirectory(pathToLibDir).getOrElse(throw new AssertionError(
-        s"""unable to find root installation directory
+      findRootDirectory(pathToLibDir).getOrElse(throw new AssertionError(s"""unable to find root installation directory
            | context: tried to find marker file `$rootDirectoryMarkerFilename`
            | started search in $pathToLibDir and searched $maxSearchDepth directories upwards""".stripMargin))
     }

--- a/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/ConsoleConfigTest.scala
@@ -1,16 +1,15 @@
 package io.shiftleft.console
 
-import better.files.{File, FileExtensions}
+import better.files.File
+import io.shiftleft.utils.ProjectRoot
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class ConsoleConfigTest extends AnyWordSpec with Matchers {
   "An InstallConfig" should {
-    "set the rootPath to parent of directory containing jar by default" in {
+    "set the rootPath to directory containing `.installation_root` by default" in {
       val config = new InstallConfig(environment = Map.empty)
-      val uriToLibDir = classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
-      val pathToLibDir = new java.io.File(uriToLibDir).toPath
-      config.rootPath shouldBe pathToLibDir.getParent.getParent.toFile.toScala
+      config.rootPath shouldBe ProjectRoot.find
     }
 
     "set the rootPath to SHIFTLEFT_OCULAR_INSTALL_DIR if it is defined" in {

--- a/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
+++ b/console/src/test/scala/io/shiftleft/console/testing/ConsoleFixture.scala
@@ -32,7 +32,8 @@ object TestWorkspaceLoader extends WorkspaceLoader[Project] {
   override def createProject(projectFile: ProjectFile, path: Path): Project = Project(projectFile, path)
 }
 
-class TestConsole(workspaceDir: String) extends Console[Project](DefaultAmmoniteExecutor, TestWorkspaceLoader) {
+class TestConsole(workspaceDir: String)
+    extends Console[Project](DefaultAmmoniteExecutor, TestWorkspaceLoader, File(workspaceDir)) {
   override def config = new ConsoleConfig(
     install = new InstallConfig(Map("SHIFTLEFT_OCULAR_INSTALL_DIR" -> workspaceDir))
   )


### PR DESCRIPTION
https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1387 introduced
the assumption that the root directory is always two levels up from the lib
dir. That's not true for ocular, and a little brittle anyway. This PR
changes the behaviour to instead search for a marker file.