### PR TITLE
fix search for root directory: start with lib dir, not the jar itself

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -15,7 +15,7 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
       environment("SHIFTLEFT_OCULAR_INSTALL_DIR").toFile
     } else {
       val uriToLibDir = classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
-      val pathToLibDir = File(uriToLibDir)
+      val pathToLibDir = File(uriToLibDir).parent
       findRootDirectory(pathToLibDir).getOrElse(throw new AssertionError(s"""unable to find root installation directory
            | context: tried to find marker file `$rootDirectoryMarkerFilename`
            | started search in $pathToLibDir and searched $maxSearchDepth directories upwards""".stripMargin))


### PR DESCRIPTION
the previous version only worked with classes dir, but broke at runtime
in joern/ocular when jars were used