### PR TITLE
Improved Macro Handling for new C/C++ frontend

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/dotgenerator/DotDdgGeneratorTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/dotgenerator/DotDdgGeneratorTests.scala
@@ -25,7 +25,7 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
       implicit val s: Semantics = semantics
       val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
       lines.head.startsWith("digraph foo") shouldBe true
-      lines.count(x => x.contains("->")) shouldBe 35
+      lines.count(x => x.contains("->")) shouldBe 32
       lines.last.startsWith("}") shouldBe true
     }
   }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
@@ -222,8 +222,8 @@ class MacroHandlingTests2 extends CCodeToCpgSuite {
   "should correctly expand macro inside macro" in {
     val List(x: Call) = cpg.method("foo").call.nameExact(Operators.assignment).l
     x.code shouldBe "y = (y + 1)"
-    val List(id: Identifier, call2: Call) = x.astChildren.l.sortBy(_.order)
-    id.name shouldBe "y"
+    val List(identifier: Identifier, call2: Call) = x.astChildren.l.sortBy(_.order)
+    identifier.code shouldBe "y"
     call2.code shouldBe "y + 1"
     val List(arg1: Identifier, arg2: Literal) = call2.argument.l.sortBy(_.argumentIndex)
     arg1.name shouldBe "y"
@@ -280,7 +280,7 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
        }
     """.stripMargin
 
-  "should correctly expand macro inside macro" in {
+  "should correctly include calls to macros" in {
     val List(call1: Call) = cpg.method("foo").call.nameExact("A_MACRO").l
     call1.code shouldBe "A_MACRO(dst, ptr, 1)"
     call1.name shouldBe "A_MACRO"
@@ -301,5 +301,22 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     call2.columnNumber shouldBe Some(8)
     call2.typeFullName shouldBe "ANY"
     call2.argument.l.sortBy(_.order).size shouldBe 0
+  }
+}
+
+class MacroHandlingTests5 extends CCodeToCpgSuite {
+  override val code: String =
+    """
+       #define A_MACRO (1)
+       int foo() {
+        return A_MACRO;
+       }
+    """.stripMargin
+
+  "should correctly include call to macro that is only a constant in a return" in {
+    val List(call: Call) = cpg.method("foo").call.l
+    call.name shouldBe "A_MACRO"
+    call.code shouldBe "A_MACRO"
+    call.argument.size shouldBe 0
   }
 }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
@@ -249,3 +249,42 @@ class MacroHandlingTests3 extends CCodeToCpgSuite {
     arg.name shouldBe "y"
   }
 }
+
+class MacroHandlingTests4 extends CCodeToCpgSuite {
+  override val code: String =
+    """
+       #define A_MACRO(dst, code, size)\
+     do \
+    { \
+        if( (i_read) >= (size) ) \
+        { \
+            dst = (code); \
+            p_peek += (size); \
+            i_read -= (size); \
+        } \
+        else \
+        { \
+            dst = 0; \
+            i_read = 0; \
+        } \
+    } while(0)
+
+    #define A_MACRO_2() (dst++)
+
+    int foo() {
+        char * dst, ptr;
+        A_MACRO(dst, ptr, 1);
+        dst++;
+        A_MACRO_2();
+        return 10 * y;
+       }
+    """.stripMargin
+
+  "should correctly expand macro inside macro" in {
+//    implicit val viewer: ImageViewer = (pathStr: String) =>
+//      Try {
+//        Process(Seq("xdg-open", pathStr)).!!
+//    }
+//    cpg.method("foo").plotDotAst
+  }
+}

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
@@ -288,13 +288,18 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     call1.lineNumber shouldBe Some(22)
     call1.columnNumber shouldBe Some(8)
     call1.typeFullName shouldBe "ANY"
+    val List(arg1, arg2, arg3) = call1.argument.l.sortBy(_.order)
+    arg1.code shouldBe "dst"
+    arg2.code shouldBe "ptr"
+    arg3.code shouldBe "1"
 
-//    implicit val viewer: ImageViewer = (pathStr: String) =>
-//      Try {
-//        Process(Seq("xdg-open", pathStr)).!!
-//      }
-//
-//    cpg.method("foo").plotDotAst
-
+    val List(call2: Call) = cpg.method("foo").call.nameExact("A_MACRO_2").l
+    call2.code shouldBe "A_MACRO_2()"
+    call2.name shouldBe "A_MACRO_2"
+    call2.methodFullName shouldBe "A_MACRO_2"
+    call2.lineNumber shouldBe Some(24)
+    call2.columnNumber shouldBe Some(8)
+    call2.typeFullName shouldBe "ANY"
+    call2.argument.l.sortBy(_.order).size shouldBe 0
   }
 }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
@@ -4,6 +4,10 @@ import io.shiftleft.c2cpg.testfixtures.CCodeToCpgSuite
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
+
+import scala.sys.process.Process
+import scala.util.Try
 
 class CAstTests extends CCodeToCpgSuite {
 
@@ -285,5 +289,16 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     call1.code shouldBe "A_MACRO(dst, ptr, 1)"
     call1.name shouldBe "A_MACRO"
     call1.methodFullName shouldBe "A_MACRO"
+    call1.lineNumber shouldBe Some(22)
+    call1.columnNumber shouldBe Some(8)
+    call1.typeFullName shouldBe "ANY"
+
+    implicit val viewer: ImageViewer = (pathStr: String) =>
+      Try {
+        Process(Seq("xdg-open", pathStr)).!!
+      }
+
+    cpg.method("foo").plotDotAst
+
   }
 }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
@@ -4,10 +4,6 @@ import io.shiftleft.c2cpg.testfixtures.CCodeToCpgSuite
 import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.dotextension.ImageViewer
-
-import scala.sys.process.Process
-import scala.util.Try
 
 class CAstTests extends CCodeToCpgSuite {
 
@@ -293,12 +289,12 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     call1.columnNumber shouldBe Some(8)
     call1.typeFullName shouldBe "ANY"
 
-    implicit val viewer: ImageViewer = (pathStr: String) =>
-      Try {
-        Process(Seq("xdg-open", pathStr)).!!
-      }
-
-    cpg.method("foo").plotDotAst
+//    implicit val viewer: ImageViewer = (pathStr: String) =>
+//      Try {
+//        Process(Seq("xdg-open", pathStr)).!!
+//      }
+//
+//    cpg.method("foo").plotDotAst
 
   }
 }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.c2cpg.querying
 
 import io.shiftleft.c2cpg.testfixtures.CCodeToCpgSuite
-import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.semanticcpg.language._
 
 class CAstTests extends CCodeToCpgSuite {
@@ -201,6 +201,7 @@ class MacroHandlingTests1 extends CCodeToCpgSuite {
   "should correctly expand macro" in {
     val List(x: Call) = cpg.method("foo").call.nameExact(Operators.assignment).l
     x.code shouldBe "y = 10"
+    x.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
     val List(l: Identifier, r: Literal) = x.astMinusRoot.l.sortBy(_.order)
     l.name shouldBe "y"
     r.code shouldBe "10"
@@ -288,6 +289,7 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     call1.lineNumber shouldBe Some(22)
     call1.columnNumber shouldBe Some(8)
     call1.typeFullName shouldBe "ANY"
+    call1.dispatchType shouldBe DispatchTypes.INLINED
     val List(arg1, arg2, arg3) = call1.argument.l.sortBy(_.order)
     arg1.code shouldBe "dst"
     arg2.code shouldBe "ptr"
@@ -301,6 +303,7 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     call2.columnNumber shouldBe Some(8)
     call2.typeFullName shouldBe "ANY"
     call2.argument.l.sortBy(_.order).size shouldBe 0
+    call2.dispatchType shouldBe DispatchTypes.INLINED
   }
 }
 

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/AstTests.scala
@@ -281,10 +281,9 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     """.stripMargin
 
   "should correctly expand macro inside macro" in {
-//    implicit val viewer: ImageViewer = (pathStr: String) =>
-//      Try {
-//        Process(Seq("xdg-open", pathStr)).!!
-//    }
-//    cpg.method("foo").plotDotAst
+    val List(call1: Call) = cpg.method("foo").call.nameExact("A_MACRO").l
+    call1.code shouldBe "A_MACRO(dst, ptr, 1)"
+    call1.name shouldBe "A_MACRO"
+    call1.methodFullName shouldBe "A_MACRO"
   }
 }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/CDataFlowTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/CDataFlowTests.scala
@@ -1,7 +1,8 @@
 package io.shiftleft.c2cpg.querying
 
 import io.shiftleft.c2cpg.testfixtures.DataFlowCodeToCpgSuite
-import io.shiftleft.codepropertygraph.generated.EdgeTypes
+import io.shiftleft.codepropertygraph.generated.nodes.Call
+import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes}
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
@@ -977,5 +978,43 @@ class CDataFlowTests32 extends DataFlowCodeToCpgSuite {
     sink.size shouldBe 2
     source.size shouldBe 2
     sink.reachableBy(source).size shouldBe 4
+  }
+}
+
+class CfgMacroTests extends DataFlowCodeToCpgSuite {
+  override val code: String =
+    """
+       #define MP4_GET4BYTES( dst ) MP4_GETX_PRIVATE( dst, GetDWBE(p_peek), 4 )
+       #define MP4_GETX_PRIVATE(dst, code, size) \
+    do \
+    { \
+        if( (i_read) >= (size) ) \
+        { \
+            dst = (code); \
+            p_peek += (size); \
+            i_read -= (size); \
+        } \
+        else \
+        { \
+            dst = 0; \
+            i_read = 0; \
+        } \
+    } while(0)
+
+    int foo() {
+       unsigned int x;
+       MP4_GET4BYTES(x);
+       sink(x);
+    }
+
+    """.stripMargin
+
+  "should create correct CFG for macro expansion and find data flow" in {
+    val List(callToMacro: Call) = cpg.method("foo").call.dispatchType(DispatchTypes.INLINED).l
+    callToMacro.argument.code.l shouldBe List("x")
+    callToMacro.cfgNext.code.toSet shouldBe Set("x", "i_read")
+    val source = cpg.method("foo").call.name("MP4_GET4BYTES").argument(1).l
+    val sink = cpg.method("foo").call.name("sink").argument(1).l
+    sink.reachableByFlows(source).l.foreach(println)
   }
 }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/CfgTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/CfgTests.scala
@@ -1,6 +1,8 @@
 package io.shiftleft.c2cpg.querying
 
 import io.shiftleft.c2cpg.testfixtures.CCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier}
 import io.shiftleft.semanticcpg.language._
 
 class CfgTests extends CCodeToCpgSuite {
@@ -43,7 +45,6 @@ class CfgTests extends CCodeToCpgSuite {
   "should find that method does not post dominate anything" in {
     cpg.method("foo").postDominates.l.size shouldBe 0
   }
-
 }
 
 class CfgMacroTests extends CCodeToCpgSuite {
@@ -74,12 +75,10 @@ class CfgMacroTests extends CCodeToCpgSuite {
 
     """.stripMargin
 
-  "foo" in {
-//    implicit val viewer: ImageViewer = (pathStr: String) =>
-//      Try {
-//        Process(Seq("xdg-open", pathStr)).!!
-//    }
-//    cpg.method("foo").plotDotCfg
+  "should create correct CFG for macro expansion" in {
+    val List(callToMacro: Call) = cpg.method("foo").call.dispatchType(DispatchTypes.INLINED).l
+    val l = callToMacro.cfgNext.collect { case x: Identifier => x }.name.l.sorted
+    l shouldBe List("i_read", "sink")
   }
 
 }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/CfgTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/CfgTests.scala
@@ -45,3 +45,41 @@ class CfgTests extends CCodeToCpgSuite {
   }
 
 }
+
+class CfgMacroTests extends CCodeToCpgSuite {
+  override val code: String =
+    """
+       #define MP4_GET4BYTES( dst ) MP4_GETX_PRIVATE( dst, GetDWBE(p_peek), 4 )
+       #define MP4_GETX_PRIVATE(dst, code, size) \
+    do \
+    { \
+        if( (i_read) >= (size) ) \
+        { \
+            dst = (code); \
+            p_peek += (size); \
+            i_read -= (size); \
+        } \
+        else \
+        { \
+            dst = 0; \
+            i_read = 0; \
+        } \
+    } while(0)
+
+    int foo() {
+       unsigned int x;
+       MP4_GET4BYTES(x);
+       sink(x);
+    }
+
+    """.stripMargin
+
+  "foo" in {
+//    implicit val viewer: ImageViewer = (pathStr: String) =>
+//      Try {
+//        Process(Seq("xdg-open", pathStr)).!!
+//    }
+//    cpg.method("foo").plotDotCfg
+  }
+
+}

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/CfgTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/CfgTests.scala
@@ -1,9 +1,6 @@
 package io.shiftleft.c2cpg.querying
 
-import io.shiftleft.c2cpg.testfixtures.{CCodeToCpgSuite, DataFlowCodeToCpgSuite}
-import io.shiftleft.codepropertygraph.generated.DispatchTypes
-import io.shiftleft.codepropertygraph.generated.nodes.Call
-import io.shiftleft.dataflowengineoss.language.toExtendedCfgNode
+import io.shiftleft.c2cpg.testfixtures.CCodeToCpgSuite
 import io.shiftleft.semanticcpg.language._
 
 class CfgTests extends CCodeToCpgSuite {
@@ -45,43 +42,5 @@ class CfgTests extends CCodeToCpgSuite {
 
   "should find that method does not post dominate anything" in {
     cpg.method("foo").postDominates.l.size shouldBe 0
-  }
-}
-
-class CfgMacroTests extends DataFlowCodeToCpgSuite {
-  override val code: String =
-    """
-       #define MP4_GET4BYTES( dst ) MP4_GETX_PRIVATE( dst, GetDWBE(p_peek), 4 )
-       #define MP4_GETX_PRIVATE(dst, code, size) \
-    do \
-    { \
-        if( (i_read) >= (size) ) \
-        { \
-            dst = (code); \
-            p_peek += (size); \
-            i_read -= (size); \
-        } \
-        else \
-        { \
-            dst = 0; \
-            i_read = 0; \
-        } \
-    } while(0)
-
-    int foo() {
-       unsigned int x;
-       MP4_GET4BYTES(x);
-       sink(x);
-    }
-
-    """.stripMargin
-
-  "should create correct CFG for macro expansion and find data flow" in {
-    val List(callToMacro: Call) = cpg.method("foo").call.dispatchType(DispatchTypes.INLINED).l
-    callToMacro.argument.code.l shouldBe List("x")
-    callToMacro.cfgNext.code.toSet shouldBe Set("x", "i_read")
-    val source = cpg.method("foo").call.name("MP4_GET4BYTES").argument(1).l
-    val sink = cpg.method("foo").call.name("sink").argument(1).l
-    sink.reachableByFlows(source).l.foreach(println)
   }
 }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/NodeTypeStartersTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/NodeTypeStartersTests.scala
@@ -15,7 +15,7 @@ class NodeTypeStartersTests extends CCodeToCpgSuite {
   override val code = """
        /* A C comment */
        // A C++ comment
-       int main(int argc, char **argv) { int mylocal; libfunc(1); }
+       int main(int argc, char **argv) { int mylocal; libfunc(1, argc); }
        struct foo { int x; };
     """
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreator.scala
@@ -19,14 +19,15 @@ class AstCreator(val filename: String,
                  val global: Global,
                  val config: C2Cpg.Config,
                  val diffGraph: DiffGraph.Builder,
-                 parserResult: IASTTranslationUnit)
+                 val parserResult: IASTTranslationUnit)
     extends AstForTypesCreator
     with AstForFunctionsCreator
     with AstForPrimitivesCreator
     with AstForStatementsCreator
     with AstForExpressionsCreator
     with AstNodeBuilder
-    with AstCreatorHelper {
+    with AstCreatorHelper
+    with MacroHandler {
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])
 
@@ -40,8 +41,6 @@ class AstCreator(val filename: String,
   // where the respective nodes are defined. Instead we put them under the parent TYPE_DECL in which they are defined.
   // To achieve this we need this extra stack.
   protected val methodAstParentStack: Stack[NewNode] = new Stack()
-
-  protected val macroHandler = new MacroHandler(parserResult)
 
   def createAst(): Unit =
     Ast.storeInDiffGraph(astForFile(parserResult), diffGraph)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
@@ -119,7 +119,7 @@ trait AstCreatorHelper {
   }
 
   protected def nullSafeCode(node: IASTNode): String = {
-    Option(node).map(macroHandler.nodeSignature).getOrElse("")
+    Option(node).map(nodeSignature).getOrElse("")
   }
 
   protected def nullSafeAst(node: IASTExpression, order: Int): Ast = {
@@ -152,46 +152,46 @@ trait AstCreatorHelper {
         evaluation.getBinding match {
           case f: CPPFunction if f.getDeclarations != null =>
             usingDeclarationMappings.getOrElse(
-              fixQualifiedName(macroHandler.nodeSignature(d.getName)),
-              f.getDeclarations.headOption.map(x => macroHandler.nodeSignature(x.getName)).getOrElse(f.getName)
+              fixQualifiedName(nodeSignature(d.getName)),
+              f.getDeclarations.headOption.map(x => nodeSignature(x.getName)).getOrElse(f.getName)
             )
           case f: CPPFunction if f.getDefinition != null =>
-            usingDeclarationMappings.getOrElse(fixQualifiedName(macroHandler.nodeSignature(d.getName)),
-                                               macroHandler.nodeSignature(f.getDefinition.getName))
+            usingDeclarationMappings.getOrElse(fixQualifiedName(nodeSignature(d.getName)),
+                                               nodeSignature(f.getDefinition.getName))
           case other => other.getName
         }
       case alias: ICPPASTNamespaceAlias =>
-        macroHandler.nodeSignature(alias.getMappingName)
-      case namespace: ICPPASTNamespaceDefinition if macroHandler.nodeSignature(namespace.getName).nonEmpty =>
-        fullName(namespace.getParent) + "." + macroHandler.nodeSignature(namespace.getName)
-      case namespace: ICPPASTNamespaceDefinition if macroHandler.nodeSignature(namespace.getName).isEmpty =>
+        nodeSignature(alias.getMappingName)
+      case namespace: ICPPASTNamespaceDefinition if nodeSignature(namespace.getName).nonEmpty =>
+        fullName(namespace.getParent) + "." + nodeSignature(namespace.getName)
+      case namespace: ICPPASTNamespaceDefinition if nodeSignature(namespace.getName).isEmpty =>
         fullName(namespace.getParent) + "." + uniqueName("namespace", "", "")._1
-      case cppClass: ICPPASTCompositeTypeSpecifier if macroHandler.nodeSignature(cppClass.getName).nonEmpty =>
+      case cppClass: ICPPASTCompositeTypeSpecifier if nodeSignature(cppClass.getName).nonEmpty =>
         fullName(cppClass.getParent) + "." + cppClass.getName.toString
-      case cppClass: ICPPASTCompositeTypeSpecifier if macroHandler.nodeSignature(cppClass.getName).isEmpty =>
+      case cppClass: ICPPASTCompositeTypeSpecifier if nodeSignature(cppClass.getName).isEmpty =>
         val name = cppClass.getParent match {
           case decl: IASTSimpleDeclaration =>
             decl.getDeclarators.headOption
-              .map(x => macroHandler.nodeSignature(x.getName))
+              .map(x => nodeSignature(x.getName))
               .getOrElse(uniqueName("composite_type", "", "")._1)
           case _ => uniqueName("composite_type", "", "")._1
         }
         val fullname = s"${fullName(cppClass.getParent)}.$name"
         fullname
       case enum: IASTEnumerationSpecifier =>
-        fullName(enum.getParent) + "." + macroHandler.nodeSignature(enum.getName)
-      case c: IASTCompositeTypeSpecifier => macroHandler.nodeSignature(c.getName)
+        fullName(enum.getParent) + "." + nodeSignature(enum.getName)
+      case c: IASTCompositeTypeSpecifier => nodeSignature(c.getName)
       case f: IASTFunctionDeclarator =>
-        fullName(f.getParent) + "." + macroHandler.nodeSignature(f.getName)
+        fullName(f.getParent) + "." + nodeSignature(f.getName)
       case f: ICPPASTLambdaExpression =>
         fullName(f.getParent) + "."
       case f: IASTFunctionDefinition =>
-        fullName(f.getParent) + "." + macroHandler.nodeSignature(f.getDeclarator.getName)
-      case d: IASTIdExpression    => macroHandler.nodeSignature(d.getName)
+        fullName(f.getParent) + "." + nodeSignature(f.getDeclarator.getName)
+      case d: IASTIdExpression    => nodeSignature(d.getName)
       case _: IASTTranslationUnit => ""
-      case u: IASTUnaryExpression => macroHandler.nodeSignature(u.getOperand)
+      case u: IASTUnaryExpression => nodeSignature(u.getOperand)
       case e: ICPPASTElaboratedTypeSpecifier =>
-        fullName(e.getParent) + "." + macroHandler.nodeSignature(e.getName)
+        fullName(e.getParent) + "." + nodeSignature(e.getName)
       case other if other.getParent != null => fullName(other.getParent)
       case other if other != null           => notHandledYet(other, -1); ""
       case null                             => ""

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -98,7 +98,7 @@ trait AstForExpressionsCreator {
       case _ if rec.root.exists(_.isInstanceOf[NewIdentifier]) =>
         (DispatchTypes.STATIC_DISPATCH, rec.root.get.asInstanceOf[NewIdentifier].name)
       case reference: IASTIdExpression =>
-        (DispatchTypes.STATIC_DISPATCH, macroHandler.nodeSignature(reference))
+        (DispatchTypes.STATIC_DISPATCH, nodeSignature(reference))
       case _ =>
         (DispatchTypes.STATIC_DISPATCH, "")
     }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -107,7 +107,6 @@ trait AstForExpressionsCreator {
     val args = withOrder(call.getArguments) { case (a, o)     => astForNode(a, o) }
     val validArgs = args.collect { case a if a.root.isDefined => a.root.get }
 
-    println(rec.root)
     rec.root match {
       // Optimization: do not include the receiver if the receiver is just the function name,
       // e.g., for `f(x)`, don't include an `f` identifier node as a first child. Since we
@@ -332,7 +331,7 @@ trait AstForExpressionsCreator {
         astForPackExpansionExpression(packExpansionExpression, order)
       case _ => notHandledYet(expression, order)
     }
-    asChildOfMacroCall(expression, r)
+    asChildOfMacroCall(expression, r, order)
   }
 
   protected def astForStaticAssert(a: ICPPASTStaticAssertDeclaration, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -98,7 +98,7 @@ trait AstForExpressionsCreator {
       case _ if rec.root.exists(_.isInstanceOf[NewIdentifier]) =>
         (DispatchTypes.STATIC_DISPATCH, rec.root.get.asInstanceOf[NewIdentifier].name)
       case reference: IASTIdExpression =>
-        (DispatchTypes.STATIC_DISPATCH, AstCreator.nodeSignature(reference))
+        (DispatchTypes.STATIC_DISPATCH, macroHandler.nodeSignature(reference))
       case _ =>
         (DispatchTypes.STATIC_DISPATCH, "")
     }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -294,30 +294,33 @@ trait AstForExpressionsCreator {
   private def astForPackExpansionExpression(packExpansionExpression: ICPPASTPackExpansionExpression, order: Int): Ast =
     astForExpression(packExpansionExpression.getPattern, order)
 
-  protected def astForExpression(expression: IASTExpression, order: Int): Ast = expression match {
-    case lit: IASTLiteralExpression   => astForLiteral(lit, order)
-    case un: IASTUnaryExpression      => astForUnaryExpression(un, order)
-    case bin: IASTBinaryExpression    => astForBinaryExpression(bin, order)
-    case exprList: IASTExpressionList => astForExpressionList(exprList, order)
-    case qualId: IASTIdExpression if qualId.getName.isInstanceOf[CPPASTQualifiedName] =>
-      astForQualifiedName(qualId.getName.asInstanceOf[CPPASTQualifiedName], order)
-    case ident: IASTIdExpression                            => astForIdentifier(ident, order)
-    case call: IASTFunctionCallExpression                   => astForCallExpression(call, order)
-    case typeId: IASTTypeIdExpression                       => astForTypeIdExpression(typeId, order)
-    case fieldRef: IASTFieldReference                       => astForFieldReference(fieldRef, order)
-    case expr: IASTConditionalExpression                    => astForConditionalExpression(expr, order)
-    case arrayIndexExpression: IASTArraySubscriptExpression => astForArrayIndexExpression(arrayIndexExpression, order)
-    case castExpression: IASTCastExpression                 => astForCastExpression(castExpression, order)
-    case newExpression: ICPPASTNewExpression                => astForNewExpression(newExpression, order)
-    case delExpression: ICPPASTDeleteExpression             => astForDeleteExpression(delExpression, order)
-    case typeIdInit: IASTTypeIdInitializerExpression        => astForTypeIdInitExpression(typeIdInit, order)
-    case c: ICPPASTSimpleTypeConstructorExpression          => astForConstructorExpression(c, order)
-    case lambdaExpression: ICPPASTLambdaExpression          => Ast(methodRefForLambda(lambdaExpression))
-    case compoundExpression: IGNUASTCompoundStatementExpression =>
-      astForCompoundStatementExpression(compoundExpression, order)
-    case packExpansionExpression: ICPPASTPackExpansionExpression =>
-      astForPackExpansionExpression(packExpansionExpression, order)
-    case _ => notHandledYet(expression, order)
+  protected def astForExpression(expression: IASTExpression, order: Int): Ast = {
+    val r = expression match {
+      case lit: IASTLiteralExpression   => astForLiteral(lit, order)
+      case un: IASTUnaryExpression      => astForUnaryExpression(un, order)
+      case bin: IASTBinaryExpression    => astForBinaryExpression(bin, order)
+      case exprList: IASTExpressionList => astForExpressionList(exprList, order)
+      case qualId: IASTIdExpression if qualId.getName.isInstanceOf[CPPASTQualifiedName] =>
+        astForQualifiedName(qualId.getName.asInstanceOf[CPPASTQualifiedName], order)
+      case ident: IASTIdExpression                            => astForIdentifier(ident, order)
+      case call: IASTFunctionCallExpression                   => astForCallExpression(call, order)
+      case typeId: IASTTypeIdExpression                       => astForTypeIdExpression(typeId, order)
+      case fieldRef: IASTFieldReference                       => astForFieldReference(fieldRef, order)
+      case expr: IASTConditionalExpression                    => astForConditionalExpression(expr, order)
+      case arrayIndexExpression: IASTArraySubscriptExpression => astForArrayIndexExpression(arrayIndexExpression, order)
+      case castExpression: IASTCastExpression                 => astForCastExpression(castExpression, order)
+      case newExpression: ICPPASTNewExpression                => astForNewExpression(newExpression, order)
+      case delExpression: ICPPASTDeleteExpression             => astForDeleteExpression(delExpression, order)
+      case typeIdInit: IASTTypeIdInitializerExpression        => astForTypeIdInitExpression(typeIdInit, order)
+      case c: ICPPASTSimpleTypeConstructorExpression          => astForConstructorExpression(c, order)
+      case lambdaExpression: ICPPASTLambdaExpression          => Ast(methodRefForLambda(lambdaExpression))
+      case compoundExpression: IGNUASTCompoundStatementExpression =>
+        astForCompoundStatementExpression(compoundExpression, order)
+      case packExpansionExpression: ICPPASTPackExpansionExpression =>
+        astForPackExpansionExpression(packExpansionExpression, order)
+      case _ => notHandledYet(expression, order)
+    }
+    asChildOfMacroCall(expression, r)
   }
 
   protected def astForStaticAssert(a: ICPPASTStaticAssertDeclaration, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -61,7 +61,7 @@ trait AstForFunctionsCreator {
         case p: IASTParameterDeclaration => typeForDeclSpecifier(p.getDeclSpecifier)
         case other                       => typeForDeclSpecifier(other)
       } else {
-        parameters(func).map(p => macroHandler.nodeSignature(p))
+        parameters(func).map(p => nodeSignature(p))
       }
     s"(${elements.mkString(",")}$variadic)"
   }
@@ -217,24 +217,21 @@ trait AstForFunctionsCreator {
   private def astForParameter(parameter: IASTNode, childNum: Int): Ast = {
     val (name, code, tpe, variadic) = parameter match {
       case p: CASTParameterDeclaration =>
-        (macroHandler.nodeSignature(p.getDeclarator.getName),
-         macroHandler.nodeSignature(p),
-         typeForDeclSpecifier(p.getDeclSpecifier),
-         false)
+        (nodeSignature(p.getDeclarator.getName), nodeSignature(p), typeForDeclSpecifier(p.getDeclSpecifier), false)
       case p: CPPASTParameterDeclaration =>
-        (macroHandler.nodeSignature(p.getDeclarator.getName),
-         macroHandler.nodeSignature(p),
+        (nodeSignature(p.getDeclarator.getName),
+         nodeSignature(p),
          typeForDeclSpecifier(p.getDeclSpecifier),
          p.getDeclarator.declaresParameterPack())
       case s: IASTSimpleDeclaration =>
         (s.getDeclarators.headOption
-           .map(x => macroHandler.nodeSignature(x.getName))
+           .map(x => nodeSignature(x.getName))
            .getOrElse(uniqueName("parameter", "", "")._1),
-         macroHandler.nodeSignature(s),
+         nodeSignature(s),
          typeForDeclSpecifier(s),
          false)
       case other =>
-        (macroHandler.nodeSignature(other), macroHandler.nodeSignature(other), typeForDeclSpecifier(other), false)
+        (nodeSignature(other), nodeSignature(other), typeForDeclSpecifier(other), false)
     }
 
     val parameterNode = NewMethodParameterIn()

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -61,7 +61,7 @@ trait AstForFunctionsCreator {
         case p: IASTParameterDeclaration => typeForDeclSpecifier(p.getDeclSpecifier)
         case other                       => typeForDeclSpecifier(other)
       } else {
-        parameters(func).map(p => AstCreator.nodeSignature(p))
+        parameters(func).map(p => macroHandler.nodeSignature(p))
       }
     s"(${elements.mkString(",")}$variadic)"
   }
@@ -217,24 +217,24 @@ trait AstForFunctionsCreator {
   private def astForParameter(parameter: IASTNode, childNum: Int): Ast = {
     val (name, code, tpe, variadic) = parameter match {
       case p: CASTParameterDeclaration =>
-        (AstCreator.nodeSignature(p.getDeclarator.getName),
-         AstCreator.nodeSignature(p),
+        (macroHandler.nodeSignature(p.getDeclarator.getName),
+         macroHandler.nodeSignature(p),
          typeForDeclSpecifier(p.getDeclSpecifier),
          false)
       case p: CPPASTParameterDeclaration =>
-        (AstCreator.nodeSignature(p.getDeclarator.getName),
-         AstCreator.nodeSignature(p),
+        (macroHandler.nodeSignature(p.getDeclarator.getName),
+         macroHandler.nodeSignature(p),
          typeForDeclSpecifier(p.getDeclSpecifier),
          p.getDeclarator.declaresParameterPack())
       case s: IASTSimpleDeclaration =>
         (s.getDeclarators.headOption
-           .map(x => AstCreator.nodeSignature(x.getName))
+           .map(x => macroHandler.nodeSignature(x.getName))
            .getOrElse(uniqueName("parameter", "", "")._1),
-         AstCreator.nodeSignature(s),
+         macroHandler.nodeSignature(s),
          typeForDeclSpecifier(s),
          false)
       case other =>
-        (AstCreator.nodeSignature(other), AstCreator.nodeSignature(other), typeForDeclSpecifier(other), false)
+        (macroHandler.nodeSignature(other), macroHandler.nodeSignature(other), typeForDeclSpecifier(other), false)
     }
 
     val parameterNode = NewMethodParameterIn()

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -12,13 +12,13 @@ trait AstForPrimitivesCreator {
   this: AstCreator =>
 
   protected def astForComment(comment: IASTComment): Ast =
-    Ast(NewComment().code(macroHandler.nodeSignature(comment)).filename(filename).lineNumber(line(comment)))
+    Ast(NewComment().code(nodeSignature(comment)).filename(filename).lineNumber(line(comment)))
 
   protected def astForLiteral(lit: IASTLiteralExpression, order: Int): Ast = {
     val tpe = ASTTypeUtil.getType(lit.getExpressionType)
     val litNode = NewLiteral()
       .typeFullName(registerType(tpe))
-      .code(macroHandler.nodeSignature(lit))
+      .code(nodeSignature(lit))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(lit))
@@ -40,7 +40,7 @@ trait AstForPrimitivesCreator {
     val cpgIdentifier = NewIdentifier()
       .name(identifierName)
       .typeFullName(registerType(identifierTypeName))
-      .code(macroHandler.nodeSignature(ident))
+      .code(nodeSignature(ident))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(ident))

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -12,13 +12,13 @@ trait AstForPrimitivesCreator {
   this: AstCreator =>
 
   protected def astForComment(comment: IASTComment): Ast =
-    Ast(NewComment().code(AstCreator.nodeSignature(comment)).filename(filename).lineNumber(line(comment)))
+    Ast(NewComment().code(macroHandler.nodeSignature(comment)).filename(filename).lineNumber(line(comment)))
 
   protected def astForLiteral(lit: IASTLiteralExpression, order: Int): Ast = {
     val tpe = ASTTypeUtil.getType(lit.getExpressionType)
     val litNode = NewLiteral()
       .typeFullName(registerType(tpe))
-      .code(AstCreator.nodeSignature(lit))
+      .code(macroHandler.nodeSignature(lit))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(lit))
@@ -40,7 +40,7 @@ trait AstForPrimitivesCreator {
     val cpgIdentifier = NewIdentifier()
       .name(identifierName)
       .typeFullName(registerType(identifierTypeName))
-      .code(AstCreator.nodeSignature(ident))
+      .code(macroHandler.nodeSignature(ident))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(ident))

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -168,7 +168,7 @@ trait AstForStatementsCreator {
   }
 
   protected def astsForStatement(statement: IASTStatement, order: Int): Seq[Ast] = {
-    statement match {
+    val r = statement match {
       case expr: IASTExpressionStatement          => Seq(astForExpression(expr.getExpression, order))
       case block: IASTCompoundStatement           => Seq(astForBlockStatement(block, order))
       case ifStmt: IASTIfStatement                => Seq(astForIf(ifStmt, order))
@@ -190,6 +190,7 @@ trait AstForStatementsCreator {
       case _: IASTNullStatement                   => Seq.empty
       case _                                      => Seq(astForNode(statement, order))
     }
+    r.map(x => asChildOfMacroCall(statement, x))
   }
 
   private def astForFor(forStmt: IASTForStatement, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -64,7 +64,7 @@ trait AstForStatementsCreator {
 
   private def astForReturnStatement(ret: IASTReturnStatement, order: Int): Ast = {
     val cpgReturn = NewReturn()
-      .code(macroHandler.nodeSignature(ret))
+      .code(nodeSignature(ret))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(ret))
@@ -78,11 +78,11 @@ trait AstForStatementsCreator {
   }
 
   private def astForBreakStatement(br: IASTBreakStatement, order: Int): Ast = {
-    Ast(newControlStructureNode(br, ControlStructureTypes.BREAK, macroHandler.nodeSignature(br), order))
+    Ast(newControlStructureNode(br, ControlStructureTypes.BREAK, nodeSignature(br), order))
   }
 
   private def astForContinueStatement(cont: IASTContinueStatement, order: Int): Ast = {
-    Ast(newControlStructureNode(cont, ControlStructureTypes.CONTINUE, macroHandler.nodeSignature(cont), order))
+    Ast(newControlStructureNode(cont, ControlStructureTypes.CONTINUE, nodeSignature(cont), order))
   }
 
   private def astForGotoStatement(goto: IASTGotoStatement, order: Int): Ast = {
@@ -108,7 +108,7 @@ trait AstForStatementsCreator {
   }
 
   private def astForDoStatement(doStmt: IASTDoStatement, order: Int): Ast = {
-    val code = macroHandler.nodeSignature(doStmt)
+    val code = nodeSignature(doStmt)
 
     val doNode = newControlStructureNode(doStmt, ControlStructureTypes.DO, code, order)
 
@@ -125,7 +125,7 @@ trait AstForStatementsCreator {
       case None =>
         ast
     }
-    macroHandler.asChildOfMacroCall(doStmt, r)
+    asChildOfMacroCall(doStmt, r)
   }
 
   private def astForSwitchStatement(switchStmt: IASTSwitchStatement, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -119,13 +119,12 @@ trait AstForStatementsCreator {
       .withChild(conditionAst)
       .withChildren(stmtAsts)
 
-    val r = conditionAst.root match {
+    conditionAst.root match {
       case Some(r) =>
         ast.withConditionEdge(doNode, r)
       case None =>
         ast
     }
-    asChildOfMacroCall(doStmt, r)
   }
 
   private def astForSwitchStatement(switchStmt: IASTSwitchStatement, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -12,29 +12,6 @@ trait AstForStatementsCreator {
 
   this: AstCreator =>
 
-  /**
-    * For the given node, determine if it is expanded from a macro, and if so, find the first
-    * matching (offset, macro) pair in nodeOffsetMacroPairs, removing none matching elements
-    * from the start of nodeOffsetMacroPairs. Returns (Some(macroDefinition)) if a macro
-    * definition matches and None otherwise.
-    * */
-  def extractMatchingMacro(node: IASTNode): Option[IASTPreprocessorFunctionStyleMacroDefinition] = {
-    AstCreator.expandedFromMacro(node).foreach { expandedFrom =>
-      val nodeOffset = node.getFileLocation.getNodeOffset
-      val macroName = expandedFrom.getExpansion.getMacroDefinition.getName.toString
-      while (nodeOffsetMacroPairs.headOption.exists(
-               x => x._1 <= nodeOffset && x._2.isInstanceOf[IASTPreprocessorFunctionStyleMacroDefinition])) {
-        val (_, macroDefinition: IASTPreprocessorFunctionStyleMacroDefinition) = nodeOffsetMacroPairs.head
-        nodeOffsetMacroPairs.remove(0)
-        val name = macroDefinition.getName.toString
-        if (macroName == name) {
-          return Some(macroDefinition)
-        }
-      }
-    }
-    None
-  }
-
   protected def astForBlockStatement(blockStmt: IASTCompoundStatement, order: Int): Ast = {
     val cpgBlock = NewBlock()
       .order(order)
@@ -128,15 +105,6 @@ trait AstForStatementsCreator {
     val cpgLabel = newJumpTarget(label, order)
     val nestedStmts = nullSafeAst(label.getNestedStatement, order + 1)
     Ast(cpgLabel) +: nestedStmts
-  }
-
-  private def asChildOfMacroCall(node: IASTNode, ast: Ast): Ast = {
-    val macroCallAst = extractMatchingMacro(node).map(createMacroCall(node, _))
-    if (macroCallAst.isDefined) {
-      macroCallAst.get.withChild(ast)
-    } else {
-      ast
-    }
   }
 
   private def astForDoStatement(doStmt: IASTDoStatement, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -189,7 +189,7 @@ trait AstForStatementsCreator {
       case _: IASTNullStatement                   => Seq.empty
       case _                                      => Seq(astForNode(statement, order))
     }
-    r.map(x => asChildOfMacroCall(statement, x))
+    r.map(x => asChildOfMacroCall(statement, x, order))
   }
 
   private def astForFor(forStmt: IASTForStatement, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForStatementsCreator.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.c2cpg.astcreation
 
 import io.shiftleft.codepropertygraph.generated.ControlStructureTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewCall, NewReturn}
+import io.shiftleft.codepropertygraph.generated.nodes.{NewBlock, NewReturn}
 import io.shiftleft.x2cpg.Ast
 import org.eclipse.cdt.core.dom.ast._
 import org.eclipse.cdt.core.dom.ast.cpp._
@@ -64,7 +64,7 @@ trait AstForStatementsCreator {
 
   private def astForReturnStatement(ret: IASTReturnStatement, order: Int): Ast = {
     val cpgReturn = NewReturn()
-      .code(AstCreator.nodeSignature(ret))
+      .code(macroHandler.nodeSignature(ret))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(ret))
@@ -78,11 +78,11 @@ trait AstForStatementsCreator {
   }
 
   private def astForBreakStatement(br: IASTBreakStatement, order: Int): Ast = {
-    Ast(newControlStructureNode(br, ControlStructureTypes.BREAK, AstCreator.nodeSignature(br), order))
+    Ast(newControlStructureNode(br, ControlStructureTypes.BREAK, macroHandler.nodeSignature(br), order))
   }
 
   private def astForContinueStatement(cont: IASTContinueStatement, order: Int): Ast = {
-    Ast(newControlStructureNode(cont, ControlStructureTypes.CONTINUE, AstCreator.nodeSignature(cont), order))
+    Ast(newControlStructureNode(cont, ControlStructureTypes.CONTINUE, macroHandler.nodeSignature(cont), order))
   }
 
   private def astForGotoStatement(goto: IASTGotoStatement, order: Int): Ast = {
@@ -108,7 +108,7 @@ trait AstForStatementsCreator {
   }
 
   private def astForDoStatement(doStmt: IASTDoStatement, order: Int): Ast = {
-    val code = AstCreator.nodeSignature(doStmt)
+    val code = macroHandler.nodeSignature(doStmt)
 
     val doNode = newControlStructureNode(doStmt, ControlStructureTypes.DO, code, order)
 
@@ -125,7 +125,7 @@ trait AstForStatementsCreator {
       case None =>
         ast
     }
-    asChildOfMacroCall(doStmt, r)
+    macroHandler.asChildOfMacroCall(doStmt, r)
   }
 
   private def astForSwitchStatement(switchStmt: IASTSwitchStatement, order: Int): Ast = {
@@ -255,16 +255,6 @@ trait AstForStatementsCreator {
       case None =>
         ast
     }
-  }
-
-  def createMacroCall(node: IASTNode, m: IASTPreprocessorFunctionStyleMacroDefinition): Ast = {
-    val name = m.getName.toString
-    val code = node.getRawSignature
-    val callNode = NewCall()
-      .name(name)
-      .methodFullName(name)
-      .code(code)
-    Ast(callNode)
   }
 
   private def astForIf(ifStmt: IASTIfStatement, order: Int): Ast = {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
@@ -19,7 +19,7 @@ trait AstForTypesCreator {
   }
 
   private def isTypeDef(decl: IASTSimpleDeclaration): Boolean =
-    macroHandler.nodeSignature(decl).startsWith("typedef") ||
+    nodeSignature(decl).startsWith("typedef") ||
       decl.getDeclSpecifier.isInstanceOf[IASTCompositeTypeSpecifier] ||
       decl.getDeclSpecifier.isInstanceOf[IASTEnumerationSpecifier]
 
@@ -94,7 +94,7 @@ trait AstForTypesCreator {
       case d if parentIsClassDef(d) =>
         Ast(
           NewMember()
-            .code(macroHandler.nodeSignature(declarator))
+            .code(nodeSignature(declarator))
             .name(name)
             .typeFullName(registerType(declTypeName))
             .order(order))
@@ -212,7 +212,7 @@ trait AstForTypesCreator {
         if declaration.getDeclSpecifier != null && declaration.getDeclSpecifier
           .isInstanceOf[IASTNamedTypeSpecifier] && declaration.getDeclarators.isEmpty =>
       val spec = declaration.getDeclSpecifier.asInstanceOf[IASTNamedTypeSpecifier]
-      val name = macroHandler.nodeSignature(spec.getName)
+      val name = nodeSignature(spec.getName)
       Seq(Ast(newTypeDecl(name, registerType(name), alias = Some(name), order = order)))
     case declaration: IASTSimpleDeclaration if declaration.getDeclarators.nonEmpty =>
       declaration.getDeclarators.toIndexedSeq.map {
@@ -228,12 +228,12 @@ trait AstForTypesCreator {
       Seq.empty
     case _: ICPPASTUsingDirective =>
       Seq.empty
-    case _: ICPPASTExplicitTemplateInstantiation                          => Seq.empty
-    case s: IASTSimpleDeclaration if macroHandler.nodeSignature(s) == ";" => Seq.empty
-    case l: ICPPASTLinkageSpecification                                   => astsForLinkageSpecification(l)
-    case t: ICPPASTTemplateDeclaration                                    => astsForDeclaration(t.getDeclaration, order)
-    case a: ICPPASTStaticAssertDeclaration                                => Seq(astForStaticAssert(a, order))
-    case asm: IASTASMDeclaration                                          => Seq(astForASMDeclaration(asm, order))
+    case _: ICPPASTExplicitTemplateInstantiation             => Seq.empty
+    case s: IASTSimpleDeclaration if nodeSignature(s) == ";" => Seq.empty
+    case l: ICPPASTLinkageSpecification                      => astsForLinkageSpecification(l)
+    case t: ICPPASTTemplateDeclaration                       => astsForDeclaration(t.getDeclaration, order)
+    case a: ICPPASTStaticAssertDeclaration                   => Seq(astForStaticAssert(a, order))
+    case asm: IASTASMDeclaration                             => Seq(astForASMDeclaration(asm, order))
     case structuredBindingDeclaration: ICPPASTStructuredBindingDeclaration =>
       Seq(astForStructuredBindingDeclaration(structuredBindingDeclaration, order))
     case _ => Seq(astForNode(decl, order))
@@ -307,7 +307,7 @@ trait AstForTypesCreator {
       case _ => typeFor(enumerator)
     }
     val cpgMember = NewMember()
-      .code(macroHandler.nodeSignature(enumerator))
+      .code(nodeSignature(enumerator))
       .name(enumerator.getName.toString)
       .typeFullName(registerType(tpe))
       .order(order)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForTypesCreator.scala
@@ -19,7 +19,7 @@ trait AstForTypesCreator {
   }
 
   private def isTypeDef(decl: IASTSimpleDeclaration): Boolean =
-    AstCreator.nodeSignature(decl).startsWith("typedef") ||
+    macroHandler.nodeSignature(decl).startsWith("typedef") ||
       decl.getDeclSpecifier.isInstanceOf[IASTCompositeTypeSpecifier] ||
       decl.getDeclSpecifier.isInstanceOf[IASTEnumerationSpecifier]
 
@@ -94,7 +94,7 @@ trait AstForTypesCreator {
       case d if parentIsClassDef(d) =>
         Ast(
           NewMember()
-            .code(AstCreator.nodeSignature(declarator))
+            .code(macroHandler.nodeSignature(declarator))
             .name(name)
             .typeFullName(registerType(declTypeName))
             .order(order))
@@ -212,7 +212,7 @@ trait AstForTypesCreator {
         if declaration.getDeclSpecifier != null && declaration.getDeclSpecifier
           .isInstanceOf[IASTNamedTypeSpecifier] && declaration.getDeclarators.isEmpty =>
       val spec = declaration.getDeclSpecifier.asInstanceOf[IASTNamedTypeSpecifier]
-      val name = AstCreator.nodeSignature(spec.getName)
+      val name = macroHandler.nodeSignature(spec.getName)
       Seq(Ast(newTypeDecl(name, registerType(name), alias = Some(name), order = order)))
     case declaration: IASTSimpleDeclaration if declaration.getDeclarators.nonEmpty =>
       declaration.getDeclarators.toIndexedSeq.map {
@@ -228,12 +228,12 @@ trait AstForTypesCreator {
       Seq.empty
     case _: ICPPASTUsingDirective =>
       Seq.empty
-    case _: ICPPASTExplicitTemplateInstantiation                        => Seq.empty
-    case s: IASTSimpleDeclaration if AstCreator.nodeSignature(s) == ";" => Seq.empty
-    case l: ICPPASTLinkageSpecification                                 => astsForLinkageSpecification(l)
-    case t: ICPPASTTemplateDeclaration                                  => astsForDeclaration(t.getDeclaration, order)
-    case a: ICPPASTStaticAssertDeclaration                              => Seq(astForStaticAssert(a, order))
-    case asm: IASTASMDeclaration                                        => Seq(astForASMDeclaration(asm, order))
+    case _: ICPPASTExplicitTemplateInstantiation                          => Seq.empty
+    case s: IASTSimpleDeclaration if macroHandler.nodeSignature(s) == ";" => Seq.empty
+    case l: ICPPASTLinkageSpecification                                   => astsForLinkageSpecification(l)
+    case t: ICPPASTTemplateDeclaration                                    => astsForDeclaration(t.getDeclaration, order)
+    case a: ICPPASTStaticAssertDeclaration                                => Seq(astForStaticAssert(a, order))
+    case asm: IASTASMDeclaration                                          => Seq(astForASMDeclaration(asm, order))
     case structuredBindingDeclaration: ICPPASTStructuredBindingDeclaration =>
       Seq(astForStructuredBindingDeclaration(structuredBindingDeclaration, order))
     case _ => Seq(astForNode(decl, order))
@@ -307,7 +307,7 @@ trait AstForTypesCreator {
       case _ => typeFor(enumerator)
     }
     val cpgMember = NewMember()
-      .code(AstCreator.nodeSignature(enumerator))
+      .code(macroHandler.nodeSignature(enumerator))
       .name(enumerator.getName.toString)
       .typeFullName(registerType(tpe))
       .order(order)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstNodeBuilder.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstNodeBuilder.scala
@@ -10,7 +10,7 @@ trait AstNodeBuilder {
   protected def newUnknown(node: IASTNode, order: Int): NewUnknown =
     NewUnknown()
       .parserTypeName(node.getClass.getSimpleName)
-      .code(macroHandler.nodeSignature(node))
+      .code(nodeSignature(node))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(node))
@@ -37,7 +37,7 @@ trait AstNodeBuilder {
       .dispatchType(dispatchType)
       .signature("TODO")
       .methodFullName(fullname)
-      .code(macroHandler.nodeSignature(astNode))
+      .code(nodeSignature(astNode))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(astNode))
@@ -58,7 +58,7 @@ trait AstNodeBuilder {
       .columnNumber(column(node))
 
   protected def newJumpTarget(node: IASTNode, order: Int): NewJumpTarget = {
-    val code = macroHandler.nodeSignature(node)
+    val code = nodeSignature(node)
     val name = node match {
       case label: IASTLabelStatement    => label.getName.toString
       case _ if code.startsWith("case") => "case"

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstNodeBuilder.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstNodeBuilder.scala
@@ -10,7 +10,7 @@ trait AstNodeBuilder {
   protected def newUnknown(node: IASTNode, order: Int): NewUnknown =
     NewUnknown()
       .parserTypeName(node.getClass.getSimpleName)
-      .code(AstCreator.nodeSignature(node))
+      .code(macroHandler.nodeSignature(node))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(node))
@@ -37,7 +37,7 @@ trait AstNodeBuilder {
       .dispatchType(dispatchType)
       .signature("TODO")
       .methodFullName(fullname)
-      .code(AstCreator.nodeSignature(astNode))
+      .code(macroHandler.nodeSignature(astNode))
       .order(order)
       .argumentIndex(order)
       .lineNumber(line(astNode))
@@ -58,7 +58,7 @@ trait AstNodeBuilder {
       .columnNumber(column(node))
 
   protected def newJumpTarget(node: IASTNode, order: Int): NewJumpTarget = {
-    val code = AstCreator.nodeSignature(node)
+    val code = macroHandler.nodeSignature(node)
     val name = node match {
       case label: IASTLabelStatement    => label.getName.toString
       case _ if code.startsWith("case") => "case"

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -93,7 +93,7 @@ trait MacroHandler {
 
     val argAsts = arguments.zipWithIndex.map {
       case (arg, i) =>
-        Ast(NewIdentifier(code = arg, order = i + 1))
+        Ast(NewIdentifier(name = arg, code = arg, order = i + 1, argumentIndex = i + 1))
     }
 
     Ast(callNode)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -3,7 +3,13 @@ package io.shiftleft.c2cpg.astcreation
 import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.nodes.NewCall
 import io.shiftleft.x2cpg.Ast
-import org.eclipse.cdt.core.dom.ast.{IASTMacroExpansionLocation, IASTNode, IASTPreprocessorFunctionStyleMacroDefinition, IASTPreprocessorMacroDefinition}
+import org.eclipse.cdt.core.dom.ast.{
+  IASTMacroExpansionLocation,
+  IASTNode,
+  IASTPreprocessorFunctionStyleMacroDefinition,
+  IASTPreprocessorMacroDefinition
+}
+import org.eclipse.cdt.internal.core.parser.scanner.C2CpgMacroExplorer
 
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -34,9 +40,7 @@ trait MacroHandler {
     * */
   private def extractMatchingMacro(node: IASTNode): Option[IASTPreprocessorFunctionStyleMacroDefinition] = {
     expandedFromMacro(node).foreach { expandedFrom =>
-
-      // val explorer = C2CpgMacroExplorer(parserResult, node.getFileLocation)
-      // println(explorer.getExpansionStep(0))
+      new C2CpgMacroExplorer(parserResult, node.getFileLocation)
 
       val nodeOffset = node.getFileLocation.getNodeOffset
       val macroName = expandedFrom.getExpansion.getMacroDefinition.getName.toString

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -18,15 +18,17 @@ trait MacroHandler {
     * create a Call node to represent the macro invocation and attach `ast`
     * as its child.
     * */
-  def asChildOfMacroCall(node: IASTNode, ast: Ast): Ast = {
+  def asChildOfMacroCall(node: IASTNode, ast: Ast, order: Int): Ast = {
     val macroCallAst = extractMatchingMacro(node).map {
       case (mac, args) =>
         createMacroCallAst( // ast,
                            node,
                            mac,
-                           args)
+                           args,
+                           order)
     }
     if (macroCallAst.isDefined) {
+      // TODO order/argument_index of `ast`'s root needs to be set to 1
       macroCallAst.get.withChild(ast)
     } else {
       ast
@@ -71,7 +73,8 @@ trait MacroHandler {
   private def createMacroCallAst( // ast: Ast,
                                  node: IASTNode,
                                  macroDef: IASTPreprocessorMacroDefinition,
-                                 arguments: List[String]): Ast = {
+                                 arguments: List[String],
+                                 order: Int): Ast = {
     val name = macroDef.getName.toString
     val code = node.getRawSignature.replaceAll(";$", "")
     val callNode = NewCall()
@@ -82,6 +85,8 @@ trait MacroHandler {
       .columnNumber(column(node))
       .typeFullName(typeFor(node))
       .dispatchType(DispatchTypes.INLINED)
+      .order(order)
+      .argumentIndex(order)
 
     // TODO We want to clone the ASTS of arguments here
     // and then attach those ASTS to the AST we return

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -1,13 +1,9 @@
 package io.shiftleft.c2cpg.astcreation
 
+import io.shiftleft.codepropertygraph.generated.DispatchTypes
 import io.shiftleft.codepropertygraph.generated.nodes.NewCall
 import io.shiftleft.x2cpg.Ast
-import org.eclipse.cdt.core.dom.ast.{
-  IASTMacroExpansionLocation,
-  IASTNode,
-  IASTPreprocessorFunctionStyleMacroDefinition,
-  IASTPreprocessorMacroDefinition
-}
+import org.eclipse.cdt.core.dom.ast.{IASTMacroExpansionLocation, IASTNode, IASTPreprocessorFunctionStyleMacroDefinition, IASTPreprocessorMacroDefinition}
 
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -38,6 +34,10 @@ trait MacroHandler {
     * */
   private def extractMatchingMacro(node: IASTNode): Option[IASTPreprocessorFunctionStyleMacroDefinition] = {
     expandedFromMacro(node).foreach { expandedFrom =>
+
+      // val explorer = C2CpgMacroExplorer(parserResult, node.getFileLocation)
+      // println(explorer.getExpansionStep(0))
+
       val nodeOffset = node.getFileLocation.getNodeOffset
       val macroName = expandedFrom.getExpansion.getMacroDefinition.getName.toString
       while (nodeOffsetMacroPairs.headOption.exists(
@@ -66,6 +66,9 @@ trait MacroHandler {
       .methodFullName(name)
       .code(code)
       .lineNumber(line(node))
+      .columnNumber(column(node))
+      .typeFullName(typeFor(node))
+      .dispatchType(DispatchTypes.STATIC_DISPATCH)
     Ast(callNode)
   }
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -9,7 +9,7 @@ import org.eclipse.cdt.core.dom.ast.{
   IASTPreprocessorFunctionStyleMacroDefinition,
   IASTPreprocessorMacroDefinition
 }
-import org.eclipse.cdt.internal.core.parser.scanner.C2CpgMacroExplorer
+import org.eclipse.cdt.internal.core.parser.scanner.MacroArgumentExtractor
 
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -49,7 +49,7 @@ trait MacroHandler {
         nodeOffsetMacroPairs.remove(0)
         val name = macroDefinition.getName.toString
         if (macroName == name) {
-          val arguments = new C2CpgMacroExplorer(parserResult, node.getFileLocation).getArguments
+          val arguments = new MacroArgumentExtractor(parserResult, node.getFileLocation).getArguments
           return Some((macroDefinition, arguments))
         }
       }

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -6,14 +6,15 @@ import org.eclipse.cdt.core.dom.ast.{
   IASTMacroExpansionLocation,
   IASTNode,
   IASTPreprocessorFunctionStyleMacroDefinition,
-  IASTPreprocessorMacroDefinition,
-  IASTTranslationUnit
+  IASTPreprocessorMacroDefinition
 }
 
 import scala.annotation.nowarn
 import scala.collection.mutable
 
-class MacroHandler(parserResult: IASTTranslationUnit) {
+trait MacroHandler {
+
+  this: AstCreator =>
 
   /**
     * For the given node, determine if it is expanded from a macro, and if so,
@@ -59,11 +60,12 @@ class MacroHandler(parserResult: IASTTranslationUnit) {
     * */
   private def createMacroCall(node: IASTNode, macroDef: IASTPreprocessorFunctionStyleMacroDefinition): Ast = {
     val name = macroDef.getName.toString
-    val code = node.getRawSignature
+    val code = node.getRawSignature.replaceAll(";$", "")
     val callNode = NewCall()
       .name(name)
       .methodFullName(name)
       .code(code)
+      .lineNumber(line(node))
     Ast(callNode)
   }
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -1,0 +1,106 @@
+package io.shiftleft.c2cpg.astcreation
+
+import io.shiftleft.codepropertygraph.generated.nodes.NewCall
+import io.shiftleft.x2cpg.Ast
+import org.eclipse.cdt.core.dom.ast.{
+  IASTMacroExpansionLocation,
+  IASTNode,
+  IASTPreprocessorFunctionStyleMacroDefinition,
+  IASTPreprocessorMacroDefinition,
+  IASTTranslationUnit
+}
+
+import scala.annotation.nowarn
+import scala.collection.mutable
+
+class MacroHandler(parserResult: IASTTranslationUnit) {
+
+  /**
+    * For the given node, determine if it is expanded from a macro, and if so,
+    * create a Call node to represent the macro invocation and attach `ast`
+    * as its child.
+    * */
+  def asChildOfMacroCall(node: IASTNode, ast: Ast): Ast = {
+    val macroCallAst = extractMatchingMacro(node).map(createMacroCall(node, _))
+    if (macroCallAst.isDefined) {
+      macroCallAst.get.withChild(ast)
+    } else {
+      ast
+    }
+  }
+
+  /**
+    * For the given node, determine if it is expanded from a macro, and if so, find the first
+    * matching (offset, macro) pair in nodeOffsetMacroPairs, removing none matching elements
+    * from the start of nodeOffsetMacroPairs. Returns (Some(macroDefinition)) if a macro
+    * definition matches and None otherwise.
+    * */
+  private def extractMatchingMacro(node: IASTNode): Option[IASTPreprocessorFunctionStyleMacroDefinition] = {
+    expandedFromMacro(node).foreach { expandedFrom =>
+      val nodeOffset = node.getFileLocation.getNodeOffset
+      val macroName = expandedFrom.getExpansion.getMacroDefinition.getName.toString
+      while (nodeOffsetMacroPairs.headOption.exists(
+               x => x._1 <= nodeOffset && x._2.isInstanceOf[IASTPreprocessorFunctionStyleMacroDefinition])) {
+        val (_, macroDefinition: IASTPreprocessorFunctionStyleMacroDefinition) = nodeOffsetMacroPairs.head
+        nodeOffsetMacroPairs.remove(0)
+        val name = macroDefinition.getName.toString
+        if (macroName == name) {
+          return Some(macroDefinition)
+        }
+      }
+    }
+    None
+  }
+
+  /**
+    * Create a CALL node that represents the macro invocation where
+    * `node` is the node is the root node of the expansion and
+    * `macroDef` is the macro definition.
+    * */
+  private def createMacroCall(node: IASTNode, macroDef: IASTPreprocessorFunctionStyleMacroDefinition): Ast = {
+    val name = macroDef.getName.toString
+    val code = node.getRawSignature
+    val callNode = NewCall()
+      .name(name)
+      .methodFullName(name)
+      .code(code)
+    Ast(callNode)
+  }
+
+  private val nodeOffsetMacroPairs: mutable.Buffer[(Int, IASTPreprocessorMacroDefinition)] = {
+    parserResult.getNodeLocations.toList
+      .collect {
+        case exp: IASTMacroExpansionLocation =>
+          (exp.asFileLocation().getNodeOffset, exp.getExpansion.getMacroDefinition)
+      }
+      .sortBy(_._1)
+      .toBuffer
+  }
+
+  /** The CDT utility method is unfortunately in a class that is marked as deprecated, however,
+    * this is because the CDT team would like to discourage its use but at the same time does
+    * not plan to remove this code.
+    */
+  @nowarn
+  def nodeSignature(node: IASTNode): String = {
+    import org.eclipse.cdt.core.dom.ast.ASTSignatureUtil.getNodeSignature
+    if (isExpandedFromMacro(node)) {
+      getNodeSignature(node)
+    } else {
+      node.getRawSignature
+    }
+  }
+
+  def isExpandedFromMacro(node: IASTNode): Boolean =
+    expandedFromMacro(node).nonEmpty
+
+  def expandedFromMacro(node: IASTNode): Option[IASTMacroExpansionLocation] = {
+    val locations = node.getNodeLocations
+    if (locations.nonEmpty) {
+      node.getNodeLocations.headOption.collect { case x: IASTMacroExpansionLocation => x }
+    } else {
+      None
+    }
+  }
+
+}

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -81,7 +81,7 @@ trait MacroHandler {
       .lineNumber(line(node))
       .columnNumber(column(node))
       .typeFullName(typeFor(node))
-      .dispatchType(DispatchTypes.STATIC_DISPATCH)
+      .dispatchType(DispatchTypes.INLINED)
 
     // TODO We want to clone the ASTS of arguments here
     // and then attach those ASTS to the AST we return

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreationPass.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/passes/AstCreationPass.scala
@@ -25,9 +25,9 @@ class AstCreationPass(filenames: List[String],
   override def generateParts(): Array[String] = filenames.toArray
 
   override def runOnPart(diffGraph: DiffGraph.Builder, filename: String): Unit =
-    new CdtParser(parseConfig).parse(Paths.get(filename)).foreach { ast =>
+    new CdtParser(parseConfig).parse(Paths.get(filename)).foreach { parserResult =>
       val localDiff = DiffGraph.newBuilder
-      new AstCreator(filename, global, config, localDiff).createAst(ast)
+      new AstCreator(filename, global, config, localDiff, parserResult).createAst()
       diffGraph.moveFrom(localDiff)
     }
 

--- a/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/C2CpgMacroExplorer.scala
+++ b/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/C2CpgMacroExplorer.scala
@@ -1,0 +1,44 @@
+package org.eclipse.cdt.internal.core.parser.scanner
+
+import org.eclipse.cdt.core.dom.ast.{IASTFileLocation, IASTName, IASTPreprocessorElifStatement, IASTPreprocessorIfStatement, IASTTranslationUnit}
+import org.eclipse.cdt.core.parser.util.CharArrayMap
+import org.eclipse.cdt.internal.core.parser.scanner.Lexer.LexerOptions
+
+class C2CpgMacroExplorer(tu : IASTTranslationUnit,  loc : IASTFileLocation) {
+
+  private val resolver = tu.getAdapter(classOf[ILocationResolver])
+  private val expansion = resolver.getMacroExpansions(loc).headOption
+  private val dictionary : CharArrayMap[PreprocessorMacro] = createDictionary()
+  private val lexerOptions = tu.getAdapter(classOf[LexerOptions])
+  private val expander = new MacroExpander(ILexerLog.NULL, dictionary, null, lexerOptions)
+  private val tracker : MacroExpansionTracker  = new MacroExpansionTracker(Integer.MAX_VALUE)
+
+  val source : String = resolver.getUnpreprocessedSignature(loc).mkString("")
+  expansion.foreach{ exp =>
+    val refLoc = exp.getFileLocation
+    val from = refLoc.getNodeOffset
+    val to = from + refLoc.getNodeLength
+    val input = source.substring(from, to - from)
+    val enclosing = tu.getNodeSelector(null).findEnclosingNode(from -1, 2)
+    val isPPCondition = enclosing.isInstanceOf[IASTPreprocessorIfStatement] || enclosing.isInstanceOf[IASTPreprocessorElifStatement]
+    expander.expand(input, tracker, tu.getFilePath, refLoc.getStartingLineNumber, isPPCondition);
+  }
+
+  def createDictionary() : CharArrayMap[PreprocessorMacro] = {
+    val refs : Array[IASTName] = expansion.map(_.getMacroReference).toList.toArray
+    val map = new CharArrayMap[PreprocessorMacro](refs.length);
+    refs.foreach(name => addMacroDefinition(map, name))
+    map
+  }
+
+  private def addMacroDefinition(map : CharArrayMap[PreprocessorMacro], name : IASTName) : Unit = {
+    val binding = name.getBinding
+    binding match {
+      case preprocessorMacro: PreprocessorMacro =>
+        map.put(name.getSimpleID, preprocessorMacro);
+      case _ =>
+    }
+  }
+
+
+}

--- a/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/C2CpgMacroExplorer.scala
+++ b/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/C2CpgMacroExplorer.scala
@@ -1,37 +1,47 @@
 package org.eclipse.cdt.internal.core.parser.scanner
 
-import org.eclipse.cdt.core.dom.ast.{IASTFileLocation, IASTName, IASTPreprocessorElifStatement, IASTPreprocessorIfStatement, IASTTranslationUnit}
+import org.eclipse.cdt.core.dom.ast.{
+  IASTFileLocation,
+  IASTName,
+  IASTPreprocessorElifStatement,
+  IASTPreprocessorIfStatement,
+  IASTTranslationUnit
+}
 import org.eclipse.cdt.core.parser.util.CharArrayMap
 import org.eclipse.cdt.internal.core.parser.scanner.Lexer.LexerOptions
 
-class C2CpgMacroExplorer(tu : IASTTranslationUnit,  loc : IASTFileLocation) {
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+class C2CpgMacroExplorer(tu: IASTTranslationUnit, loc: IASTFileLocation) {
 
   private val resolver = tu.getAdapter(classOf[ILocationResolver])
   private val expansion = resolver.getMacroExpansions(loc).headOption
-  private val dictionary : CharArrayMap[PreprocessorMacro] = createDictionary()
+  private val dictionary: CharArrayMap[PreprocessorMacro] = createDictionary()
   private val lexerOptions = tu.getAdapter(classOf[LexerOptions])
   private val expander = new MacroExpander(ILexerLog.NULL, dictionary, null, lexerOptions)
-  private val tracker : MacroExpansionTracker  = new MacroExpansionTracker(Integer.MAX_VALUE)
+  private val tracker: MacroExpansionTracker = new C2CpgMacroExpansionTracker(Integer.MAX_VALUE)
 
-  val source : String = resolver.getUnpreprocessedSignature(loc).mkString("")
-  expansion.foreach{ exp =>
+  val source: String = resolver.getUnpreprocessedSignature(loc).mkString("")
+  expansion.foreach { exp =>
     val refLoc = exp.getFileLocation
-    val from = refLoc.getNodeOffset
+    val from = 0
     val to = from + refLoc.getNodeLength
     val input = source.substring(from, to - from)
-    val enclosing = tu.getNodeSelector(null).findEnclosingNode(from -1, 2)
-    val isPPCondition = enclosing.isInstanceOf[IASTPreprocessorIfStatement] || enclosing.isInstanceOf[IASTPreprocessorElifStatement]
-    expander.expand(input, tracker, tu.getFilePath, refLoc.getStartingLineNumber, isPPCondition);
+    val enclosing = tu.getNodeSelector(null).findEnclosingNode(from - 1, 2)
+    val isPPCondition = enclosing.isInstanceOf[IASTPreprocessorIfStatement] || enclosing
+      .isInstanceOf[IASTPreprocessorElifStatement]
+    expander.expand(input, tracker, tu.getFilePath, refLoc.getStartingLineNumber, isPPCondition)
+    println(tracker)
   }
 
-  def createDictionary() : CharArrayMap[PreprocessorMacro] = {
-    val refs : Array[IASTName] = expansion.map(_.getMacroReference).toList.toArray
+  def createDictionary(): CharArrayMap[PreprocessorMacro] = {
+    val refs: Array[IASTName] = expansion.map(_.getMacroReference).toList.toArray
     val map = new CharArrayMap[PreprocessorMacro](refs.length);
     refs.foreach(name => addMacroDefinition(map, name))
     map
   }
 
-  private def addMacroDefinition(map : CharArrayMap[PreprocessorMacro], name : IASTName) : Unit = {
+  private def addMacroDefinition(map: CharArrayMap[PreprocessorMacro], name: IASTName): Unit = {
     val binding = name.getBinding
     binding match {
       case preprocessorMacro: PreprocessorMacro =>
@@ -40,5 +50,33 @@ class C2CpgMacroExplorer(tu : IASTTranslationUnit,  loc : IASTFileLocation) {
     }
   }
 
+}
 
+class C2CpgMacroExpansionTracker(stepToTrack: Int) extends MacroExpansionTracker(stepToTrack) {
+
+  override def endFunctionStyleMacro(): Unit = {
+    val field = classOf[MacroExpansionTracker].getDeclaredField("fMacroStack")
+    field.setAccessible(true)
+    val list = field.get(this).asInstanceOf[java.util.List[MacroInfo]].asScala
+    list.headOption.foreach { macroInfo =>
+      val field = classOf[MacroInfo].getDeclaredField("fArguments")
+      field.setAccessible(true)
+      val arguments = field.get(macroInfo).asInstanceOf[java.util.ArrayList[TokenList]].asScala.toList
+      arguments.foreach { argTokenList =>
+        var arg = ""
+        var done = false
+        while (!done) {
+          val next = argTokenList.removeFirst()
+          if (next == null) {
+            done = true
+          } else {
+            arg += next.toString + " "
+          }
+        }
+        arg = arg.trim
+        println(arg)
+      }
+    }
+    println("HOOKED")
+  }
 }

--- a/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
+++ b/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
@@ -14,7 +14,11 @@ import org.eclipse.cdt.internal.core.parser.scanner.Lexer.LexerOptions
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-class C2CpgMacroExplorer(tu: IASTTranslationUnit, loc: IASTFileLocation) {
+/**
+  * Utility class that obtains the arguments of the macro at `loc`
+  * of the translation unit `tu`.
+  * */
+class MacroArgumentExtractor(tu: IASTTranslationUnit, loc: IASTFileLocation) {
 
   def getArguments: List[String] = {
     val resolver = tu.getAdapter(classOf[ILocationResolver])
@@ -57,6 +61,11 @@ class C2CpgMacroExpansionTracker(stepToTrack: Int) extends MacroExpansionTracker
 
   val arguments: mutable.Buffer[String] = mutable.Buffer()
 
+  /**
+    * This function is called as part of the expansion process. Unfortunately, its
+    * default implementation in `MacroExpansionTracker` destroys the calculated
+    * arguments, so, we override this method to instead store them in `arguments`.
+    * */
   override def endFunctionStyleMacro(): Unit = {
     val macroStackField = classOf[MacroExpansionTracker].getDeclaredField("fMacroStack")
     macroStackField.setAccessible(true)

--- a/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
+++ b/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
@@ -74,7 +74,11 @@ class C2CpgMacroExpansionTracker(stepToTrack: Int) extends MacroExpansionTracker
 
   @nowarn
   override def setExpandedMacroArgument(tokenList: TokenList): Unit = {
-    arguments.addOne(tokenListToString(tokenList))
+    if (tokenList != null) {
+      arguments.addOne(tokenListToString(tokenList))
+    } else {
+      arguments.addOne("")
+    }
   }
 
   private def tokenListToString(tokenList: TokenList): String = {

--- a/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
+++ b/c2cpg/src/main/scala/org/eclipse/cdt/internal/core/parser/scanner/MacroArgumentExtractor.scala
@@ -43,7 +43,7 @@ class MacroArgumentExtractor(tu: IASTTranslationUnit, loc: IASTFileLocation) {
       val tracker = new C2CpgMacroExpansionTracker(Integer.MAX_VALUE)
       val source: String = resolver.getUnpreprocessedSignature(loc).mkString("")
       val refLoc = exp.getFileLocation
-      val input = source.substring(0, refLoc.getNodeLength)
+      val input = source.slice(0, refLoc.getNodeLength)
       val enclosing = tu.getNodeSelector(null).findEnclosingNode(-1, 2)
       val isPPCondition = enclosing.isInstanceOf[IASTPreprocessorIfStatement] || enclosing
         .isInstanceOf[IASTPreprocessorElifStatement]
@@ -74,13 +74,17 @@ class C2CpgMacroExpansionTracker(stepToTrack: Int) extends MacroExpansionTracker
 
   @nowarn
   override def setExpandedMacroArgument(tokenList: TokenList): Unit = {
+    arguments.addOne(tokenListToString(tokenList))
+  }
+
+  private def tokenListToString(tokenList: TokenList): String = {
     var tok: IToken = tokenList.first()
     var arg = ""
     while (tok != null) {
       arg += tok.toString + " "
       tok = tok.getNext
     }
-    arguments.addOne(arg.trim)
+    arg.trim
   }
 
 }

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
@@ -331,8 +331,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
           lambda1call.methodFullName shouldBe "x"
           lambda1call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
           lambda1call.astChildren.l match {
-            case List(id: Identifier, lit: Literal) =>
-              id.name shouldBe "x"
+            case List(lit: Literal) =>
               lit.code shouldBe "10"
             case _ => fail()
           }
@@ -342,9 +341,8 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
             case _ => fail()
           }
           lambda1call.receiver.l match {
-            case List(id: Identifier) =>
-              id.name shouldBe "x"
-            case _ => fail()
+            case List() =>
+            case _      => fail()
           }
         case _ => fail()
       }
@@ -881,8 +879,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
           call.code shouldBe "foo(x)"
           call.dispatchType shouldBe DispatchTypes.STATIC_DISPATCH
           val rec = call.receiver.l
-          rec.length shouldBe 1
-          rec.head.code shouldBe "foo"
+          rec.length shouldBe 0
           call.argument(1).code shouldBe "x"
         case _ => fail()
       }
@@ -1635,12 +1632,12 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
        |int c = 0;
        |}
       """.stripMargin) { cpg =>
+      val x = cpg.identifier.l
+      x.foreach(println)
       cpg.identifier.l match {
-        case List(a, st, b, c) =>
+        case List(a, b, c) =>
           a.lineNumber shouldBe Some(3)
           a.columnNumber shouldBe Some(4)
-          st.lineNumber shouldBe Some(4)
-          st.columnNumber shouldBe Some(0)
           b.lineNumber shouldBe Some(5)
           b.columnNumber shouldBe Some(4)
           c.lineNumber shouldBe Some(6)

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/CfgCreationPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/CfgCreationPassTests.scala
@@ -50,8 +50,7 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
     }
 
     "be correct for call expression" in new CpgCfgFixture("foo(a + 1, b);") {
-      succOf("RET func ()") shouldBe expected(("foo", AlwaysEdge))
-      succOf("foo") shouldBe expected(("a", AlwaysEdge))
+      succOf("RET func ()") shouldBe expected(("a", AlwaysEdge))
       succOf("a") shouldBe expected(("1", AlwaysEdge))
       succOf("1") shouldBe expected(("a + 1", AlwaysEdge))
       succOf("a + 1") shouldBe expected(("b", AlwaysEdge))
@@ -277,10 +276,9 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
     }
 
     "be correct with function call condition with empty block" in new CpgCfgFixture("for (; x(1);) ;") {
-      succOf("RET func ()") shouldBe expected(("x", AlwaysEdge))
-      succOf("x") shouldBe expected(("1", AlwaysEdge))
+      succOf("RET func ()") shouldBe expected(("1", AlwaysEdge))
       succOf("1") shouldBe expected(("x(1)", AlwaysEdge))
-      succOf("x(1)") shouldBe expected(("x", TrueEdge), ("RET", FalseEdge))
+      succOf("x(1)") shouldBe expected(("1", TrueEdge), ("RET", FalseEdge))
     }
   }
 
@@ -304,10 +302,8 @@ class CfgCreationPassTests extends AnyWordSpec with Matchers {
       succOf("foo") shouldBe expected(("&&foo", AlwaysEdge))
       succOf("*ptr = &&foo") shouldBe expected(("goto *;", AlwaysEdge))
       succOf("goto *;") shouldBe expected(("foo: someCall();", AlwaysEdge))
-      succOf("foo: someCall();") shouldBe expected(("someCall", AlwaysEdge))
-      succOf("otherCall") shouldBe expected(("otherCall()", AlwaysEdge))
+      succOf("foo: someCall();") shouldBe expected(("someCall()", AlwaysEdge))
       succOf("otherCall()") shouldBe expected(("foo: someCall();", AlwaysEdge))
-      succOf("someCall") shouldBe expected(("someCall()", AlwaysEdge))
       succOf("someCall()") shouldBe expected(("RET", AlwaysEdge))
     }
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CallGraph.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CallGraph.scala
@@ -175,6 +175,12 @@ object CallGraph extends SchemaBase {
         valueType = ValueTypes.STRING,
         comment = "For dynamically dispatched calls the target is determined during runtime"
       ).protoId(2),
+      Constant(
+        name = "INLINED",
+        value = "INLINED",
+        valueType = ValueTypes.STRING,
+        comment = "For macro expansions, code is inlined."
+      ).protoId(3),
     )
 
     callNode

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgcreation/CfgCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgcreation/CfgCreator.scala
@@ -310,7 +310,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraph.Builder) {
       .reduceOption((x, y) => x ++ y)
       .getOrElse(Cfg.empty) ++ cfgForSingleNode(call)
     val cfgForExpansion = call.astChildren.lastOption.map(cfgFor).getOrElse(Cfg.empty)
-    Cfg
+    val cfg = Cfg
       .from(cfgForMacroCall, cfgForExpansion)
       .copy(
         entryNode = cfgForMacroCall.entryNode,
@@ -318,6 +318,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraph.Builder) {
           singleEdge(call, x)),
         fringe = cfgForMacroCall.fringe ++ cfgForExpansion.fringe
       )
+    cfg
   }
 
   /**


### PR DESCRIPTION
At construction time of the AST, we now determine sub trees that are created via macro expansion and introduce a CALL node that represents the reference to the macro. Since this isn't really a call but an inlining of code, I introduced a new dispatch type called `INLINED` for these calls. The expansion sub tree is included as a child of this call node. Moreover, for each macro argument, we include an Identifier node where the `CODE` field contains the argument as a string. In a second iteration, we would like to instead include the arguments as sub trees rather than strings, however, this is currently blocked on a missing feature in overflowdb (cloning of NewNodes).

So, why a CALL for macro expansions? Because a macro expansion looks like a call to the person reading the code and I can already see them scratching their head when no calls come back for the name they just saw in the code. At the same time, leaving the macro unexpanded makes our analysis much more precise than in fuzzyc times.

Changes in detail:
- Introduced MacroArgumentExtractor, which extracts arguments of macros via CDT voodoo.
- Concentrated all handling of macros done in the AST construction stage into `MacroHandler`, which is now a mixin trait just like `AstCreatorHelper`.
- The CFG creator now picks up calls with dispatch type `INLINED` and represents them as calls to the macro followed by optional evaluation of the inlined code.
- I noticed that for simple `f(x)` calls, we included a receiver of `f`. Two things that come to mind: we end up with many rather redundant identifier nodes that simply contain `f` although `f` is already in the `NAME` field of the call. Given that the CPG mainly consists of call sites, this seems significant. The second reason I think it makes sense to remove these nodes is that the data flow calculation will then track `f`, which slows it down considerably.

Some known/intended limitations:
- If there is a macro used in a macro, we don't see that in the AST of the callee, we simply see the entire expansion. This seems alright though because the whole reason for making available the call to the macro is that this call is something the auditor looking at the code sees and if they only have the expansion they may be confused about that. The fact that the expansion is actually created via multiple expansions seems less relevant.
- AST rewriting is pretty hard without the copy method for `NewNode` classes, so, currently, the order/argument_index field of expanded nodes inserted below artificial call nodes is possibly wrong. I added a TODO.