### PR TITLE
also use current working dir in search for installation root

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -14,11 +14,14 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
     if (environment.contains("SHIFTLEFT_OCULAR_INSTALL_DIR")) {
       environment("SHIFTLEFT_OCULAR_INSTALL_DIR").toFile
     } else {
-      val uriToLibDir = classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
-      val pathToLibDir = File(uriToLibDir).parent
-      findRootDirectory(pathToLibDir).getOrElse(throw new AssertionError(s"""unable to find root installation directory
-           | context: tried to find marker file `$rootDirectoryMarkerFilename`
-           | started search in $pathToLibDir and searched $maxSearchDepth directories upwards""".stripMargin))
+      findRootDirectory(File.currentWorkingDirectory).getOrElse {
+        val uriToLibDir = classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
+        val pathToLibDir = File(uriToLibDir).parent
+        findRootDirectory(pathToLibDir).getOrElse(
+          throw new AssertionError(s"""unable to find root installation directory
+                                   | context: tried to find marker file `$rootDirectoryMarkerFilename`
+                                   | started search in $pathToLibDir and searched $maxSearchDepth directories upwards""".stripMargin))
+      }
     }
   }
 

--- a/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
+++ b/console/src/main/scala/io/shiftleft/console/ConsoleConfig.scala
@@ -15,7 +15,8 @@ class InstallConfig(environment: Map[String, String] = sys.env) {
       environment("SHIFTLEFT_OCULAR_INSTALL_DIR").toFile
     } else {
       findRootDirectory(File.currentWorkingDirectory).getOrElse {
-        val uriToLibDir = classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
+        val uriToLibDir =
+          classOf[io.shiftleft.console.InstallConfig].getProtectionDomain.getCodeSource.getLocation.toURI
         val pathToLibDir = File(uriToLibDir).parent
         findRootDirectory(pathToLibDir).getOrElse(
           throw new AssertionError(s"""unable to find root installation directory


### PR DESCRIPTION
there are use cases, e.g. when running joern/ocular integration tests,
where the console.jar from cpg is in `~/.cache/coursier/`...