### PR TITLE
Use `NEWC` as a language for the new frontend throughout

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/NodeTypeStartersTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/NodeTypeStartersTests.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.c2cpg.querying
 
 import io.shiftleft.c2cpg.testfixtures.CCodeToCpgSuite
-import io.shiftleft.codepropertygraph.generated.NodeTypes
+import io.shiftleft.codepropertygraph.generated.{Languages, NodeTypes}
 import io.shiftleft.semanticcpg.language._
 
 /**
@@ -82,7 +82,7 @@ class NodeTypeStartersTests extends CCodeToCpgSuite {
   }
 
   "should allow retrieving of meta data" in {
-    cpg.metaData.language.l shouldBe List("C")
+    cpg.metaData.language.l shouldBe List(Languages.NEWC)
   }
 
   "should allow retrieving all nodes" in {

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MetaDataTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MetaDataTests.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.c2cpg.standard
 
 import io.shiftleft.c2cpg.testfixtures.CCodeToCpgSuite
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.semanticcpg.language._
 
 class MetaDataTests extends CCodeToCpgSuite {
@@ -12,7 +13,7 @@ class MetaDataTests extends CCodeToCpgSuite {
 
   "should contain exactly one node with all mandatory fields set" in {
     val List(x) = cpg.metaData.l
-    x.language shouldBe "C"
+    x.language shouldBe Languages.NEWC
     x.version shouldBe "0.1"
     x.overlays shouldBe List("semanticcpg")
     // C-frontend does not set hash for entire CPG.

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/C2Cpg.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/C2Cpg.scala
@@ -41,7 +41,7 @@ class C2Cpg {
     val cpg = newEmptyCpg(Some(config.outputPath))
     val sourceFileNames = SourceFiles.determine(config.inputPaths, config.sourceFileExtensions)
 
-    new MetaDataPass(cpg, Languages.C, Some(metaDataKeyPool)).createAndApply()
+    new MetaDataPass(cpg, Languages.NEWC, Some(metaDataKeyPool)).createAndApply()
     val headerFileFinder = new HeaderFileFinder(config.inputPaths.toList)
     val astCreationPass =
       new AstCreationPass(sourceFileNames, cpg, functionKeyPool, config, createParseConfig(config), headerFileFinder)

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -3,6 +3,7 @@ package io.shiftleft.console
 import ammonite.ops.{Path, pwd}
 import ammonite.util.{Colors, Res}
 import better.files._
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.console.cpgqlserver.CPGQLServer
 import io.shiftleft.console.embammonite.EmbeddedAmmonite
 import io.shiftleft.console.qdbwserver.QDBWServer
@@ -211,7 +212,7 @@ trait BridgeBase {
       io.shiftleft.console.cpgcreation
         .guessLanguage(src)
         .map(_.toLowerCase)
-        .getOrElse("c"))
+        .getOrElse(Languages.C))
     val storeCode = if (config.store) { "save" } else { "" }
     val runDataflow = if (productName == "ocular") { "run.dataflow" } else { "run.ossdataflow" }
     val code = s"""

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -3,7 +3,6 @@ package io.shiftleft.console
 import ammonite.ops.{Path, pwd}
 import ammonite.util.{Colors, Res}
 import better.files._
-import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.console.cpgqlserver.CPGQLServer
 import io.shiftleft.console.embammonite.EmbeddedAmmonite
 import io.shiftleft.console.qdbwserver.QDBWServer

--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -212,7 +212,7 @@ trait BridgeBase {
       io.shiftleft.console.cpgcreation
         .guessLanguage(src)
         .map(_.toLowerCase)
-        .getOrElse(Languages.C))
+        .getOrElse("c"))
     val storeCode = if (config.store) { "save" } else { "" }
     val runDataflow = if (productName == "ocular") { "run.dataflow" } else { "run.ossdataflow" }
     val code = s"""

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -26,7 +26,7 @@ object CodeDumper {
     }
 
     val node = location.node.get
-    if (language.isEmpty || !Set(Languages.C).contains(language.get)) {
+    if (language.isEmpty || !Set(Languages.C, Languages.NEWC).contains(language.get)) {
       logger.info("dump not supported for this language or language not set in CPG")
       return ""
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -155,6 +155,21 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
           new CdgPass(cpg),
           new NamespaceCreator(cpg),
         )
+      case Languages.NEWC =>
+        Iterator(
+          new TypeDeclStubCreator(cpg),
+          new MethodStubCreator(cpg),
+          new MethodDecoratorPass(cpg),
+          new Linker(cpg),
+          new FileCreationPass(cpg),
+          new StaticCallLinker(cpg),
+          new MemberAccessLinker(cpg),
+          new MethodExternalDecoratorPass(cpg),
+          new ContainsEdgePass(cpg),
+          new NamespaceCreator(cpg),
+          new CfgDominatorPass(cpg),
+          new CdgPass(cpg),
+        )
       case _ => Iterator()
     }
   }


### PR DESCRIPTION
Fixes #1415 

There was a bit of confusion around whether we use `NEWC` or `C` as a language identifier in the meta data node, leading to enhancements not being executed when constructing CPGs using  `joern-scan --language newc`.  We now use `NEWC` throughout.