### PR TITLE
Fixed DOT file method names

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/dotgenerator/DotAstGeneratorTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/dotgenerator/DotAstGeneratorTests.scala
@@ -28,7 +28,7 @@ class DotAstGeneratorTests extends CCodeToCpgSuite {
     "generate dot graph" in {
       cpg.method.name("my_func").dotAst.l match {
         case x :: _ =>
-          x.startsWith("digraph my_func") shouldBe true
+          x.startsWith("digraph \"my_func\"") shouldBe true
           x.contains("""[label = "(CONTROL_STRUCTURE,if (y > 42),if (y > 42))" ]""") shouldBe true
           x.endsWith("}\n") shouldBe true
         case _ => fail()
@@ -37,7 +37,7 @@ class DotAstGeneratorTests extends CCodeToCpgSuite {
 
     "allow selection method" in {
       cpg.method.name("boop").dotAst.l match {
-        case x :: _ => x.startsWith("digraph boop") shouldBe true
+        case x :: _ => x.startsWith("digraph \"boop\"") shouldBe true
         case _      => fail()
       }
     }

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/dotgenerator/DotCfgGeneratorTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/dotgenerator/DotCfgGeneratorTests.scala
@@ -22,7 +22,7 @@ class DotCfgGeneratorTests extends CCodeToCpgSuite {
     "create a dot graph" in {
       cpg.method.name("main").dotCfg.l match {
         case x :: _ =>
-          x.startsWith("digraph main {") shouldBe true
+          x.startsWith("digraph \"main\" {") shouldBe true
           x.contains("(<operator>.assignment,i = 0)") shouldBe true
           x.endsWith("}\n") shouldBe true
         case _ => fail()

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/dotgenerator/DotDdgGeneratorTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/dotgenerator/DotDdgGeneratorTests.scala
@@ -24,7 +24,7 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
     "create a dot graph with 31 edges" in {
       implicit val s: Semantics = semantics
       val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
-      lines.head.startsWith("digraph foo") shouldBe true
+      lines.head.startsWith("digraph \"foo\"") shouldBe true
       lines.count(x => x.contains("->")) shouldBe 32
       lines.last.startsWith("}") shouldBe true
     }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotAstGeneratorTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotAstGeneratorTests.scala
@@ -28,7 +28,7 @@ class DotAstGeneratorTests extends FuzzyCCodeToCpgSuite {
     "generate dot graph" in {
       cpg.method.name("my_func").dotAst.l match {
         case x :: _ =>
-          x.startsWith("digraph my_func") shouldBe true
+          x.startsWith("digraph \"my_func\"") shouldBe true
           x.contains("""[label = "(CONTROL_STRUCTURE,if (y > 42),if (y > 42))" ]""") shouldBe true
           x.endsWith("}\n") shouldBe true
         case _ => fail()
@@ -37,7 +37,7 @@ class DotAstGeneratorTests extends FuzzyCCodeToCpgSuite {
 
     "allow selection method" in {
       cpg.method.name("boop").dotAst.l match {
-        case x :: _ => x.startsWith("digraph boop") shouldBe true
+        case x :: _ => x.startsWith("digraph \"boop\"") shouldBe true
         case _      => fail()
       }
     }

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotCfgGeneratorTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotCfgGeneratorTests.scala
@@ -22,7 +22,7 @@ class DotCfgGeneratorTests extends FuzzyCCodeToCpgSuite {
     "create a dot graph" in {
       cpg.method.name("main").dotCfg.l match {
         case x :: _ =>
-          x.startsWith("digraph main {") shouldBe true
+          x.startsWith("digraph \"main\" {") shouldBe true
           x.contains("(<operator>.assignment,i = 0)") shouldBe true
           x.endsWith("}\n") shouldBe true
         case _ => fail()

--- a/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotDdgGeneratorTests.scala
+++ b/fuzzyc2cpg-tests/src/test/scala/io/shiftleft/fuzzyc2cpg/dotgenerator/DotDdgGeneratorTests.scala
@@ -22,7 +22,7 @@ class DotDdgGeneratorTests extends DataFlowCodeToCpgSuite {
     "create a dot graph with 31 edges" in {
       implicit val s = semantics
       val lines = cpg.method.name("foo").dotDdg.l.head.split("\n")
-      lines.head.startsWith("digraph foo") shouldBe true
+      lines.head.startsWith("digraph \"foo\"") shouldBe true
       lines.count(x => x.contains("->")) shouldBe 32
       lines.last.startsWith("}") shouldBe true
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -33,7 +33,7 @@ object DotSerializer {
       case method: Method => method.name
       case _              => ""
     }
-    sb.append(s"digraph $name {  \n")
+    sb.append(s"""digraph "$name" {  \n""")
   }
 
   private def stringRepr(vertex: StoredNode): String = {


### PR DESCRIPTION
Method names coming from JS contain `:` which breaks DOT files when not surrounded with `"`.

Fixes: https://github.com/joernio/joern/issues/612