### PR TITLE
Register SCPG passes for ghidra2cpg

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -23,7 +23,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
     val problem = ReachingDefProblem.create(method)
 
     if (shouldBailOut(problem)) {
-      logger.warn("Bailing out.")
+      logger.warn("Skipping.")
       return Iterator()
     }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -170,6 +170,18 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
           new CfgDominatorPass(cpg),
           new CdgPass(cpg),
         )
+      case Languages.GHIDRA =>
+        Iterator(
+          new MethodStubCreator(cpg),
+          new MethodDecoratorPass(cpg),
+          new Linker(cpg),
+          new FileCreationPass(cpg),
+          new StaticCallLinker(cpg),
+          new MemberAccessLinker(cpg),
+          new MethodExternalDecoratorPass(cpg),
+          new ContainsEdgePass(cpg),
+          new NamespaceCreator(cpg)
+        )
       case _ => Iterator()
     }
   }


### PR DESCRIPTION
Right now, ghidra2cpg runs passes by itself, which is different from the way all other frontends do it. This PR brings them into `Scpg`. Adaption of ghidra2cpg follows.