### PR TITLE
Use more consistent name for single property

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -209,7 +209,7 @@ object Hidden extends SchemaBase {
 
     val isExplicit = builder
       .addProperty(
-        name = "EXPLICIT_IMPORT",
+        name = "IS_EXPLICIT",
         valueType = ValueType.Boolean,
         comment = """Specifies whether this is an explicit import.
             |Most languages have implicit default imports of some standard library elements


### PR DESCRIPTION
We have IS_WILDCARD boolean, but EXPLICIT_IMPORT boolean.
IS_EXPLICIT makes them fit better together.
