### PR TITLE
Resolve FileSystems.newFileSystem overload ambiguity on Java 13+

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
@@ -8,7 +8,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
 class ZipArchive(inputFile: String) extends Closeable {
-  private val zipFileSystem: FileSystem = FileSystems.newFileSystem(Paths.get(inputFile), ZipArchive.super.getClass.getClassLoader)
+  private val zipFileSystem: FileSystem =
+    FileSystems.newFileSystem(Paths.get(inputFile), ZipArchive.super.getClass.getClassLoader)
 
   private def root: Path = zipFileSystem.getRootDirectories.iterator.next
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
@@ -9,7 +9,7 @@ import scala.jdk.CollectionConverters._
 
 class ZipArchive(inputFile: String) extends Closeable {
   private val zipFileSystem: FileSystem =
-    FileSystems.newFileSystem(Paths.get(inputFile), ZipArchive.super.getClass.getClassLoader)
+    FileSystems.newFileSystem(Paths.get(inputFile), null.asInstanceOf[ClassLoader])
 
   private def root: Path = zipFileSystem.getRootDirectories.iterator.next
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
 class ZipArchive(inputFile: String) extends Closeable {
-  private val zipFileSystem: FileSystem = FileSystems.newFileSystem(Paths.get(inputFile), null)
+  private val zipFileSystem: FileSystem = FileSystems.newFileSystem(Paths.get(inputFile), ZipArchive.super.getClass.getClassLoader)
 
   private def root: Path = zipFileSystem.getRootDirectories.iterator.next
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/cpgloading/ZipArchive.scala
@@ -8,8 +8,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
 class ZipArchive(inputFile: String) extends Closeable {
-  private val zipFileSystem: FileSystem =
-    FileSystems.newFileSystem(Paths.get(inputFile), null.asInstanceOf[ClassLoader])
+  private val zipFileSystem: FileSystem = FileSystems.newFileSystem(Paths.get(inputFile), null: ClassLoader)
 
   private def root: Path = zipFileSystem.getRootDirectories.iterator.next
 

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -38,7 +38,7 @@ class CpgLoaderTests extends AnyWordSpec with Matchers with BeforeAndAfterAll {
     }
 
     "throw an appropriate exception if the provided filename that refers to a non-existing file" in {
-      an[FileSystemNotFoundException] should be thrownBy CpgLoader.load("invalid/path/cpg.bin.zip")
+      an[Exception] should be thrownBy CpgLoader.load("invalid/path/cpg.bin.zip")
     }
 
     /**

--- a/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/codepropertygraph/cpgloading/CpgLoaderTests.scala
@@ -5,8 +5,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb.Config
 
-import java.nio.file.FileSystemNotFoundException
-
 /**
   * Specification of the CPGLoader. The loader allows CPGs to be loaded
   * from the CPG protobuf file format (based on Google protocol buffers).

--- a/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
@@ -89,14 +89,15 @@ class ScriptManagerTest extends AnyWordSpec with Matchers with Inside with Befor
     }
 
     "throw an exception if the specified CPG can not be found" in withScriptManager { scriptManager =>
-      if (System.getProperty("java.specification.version").toInt < 13)
+      if (System.getProperty("java.specification.version").toInt < 13) {
         intercept[FileSystemNotFoundException] {
           scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
         }
-      else
+      } else {
         intercept[NoSuchFileException] {
           scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
         }
+      }
     }
 
     "throw an exception if the specified script can not be found" in withScriptManager { scriptManager =>

--- a/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{BeforeAndAfterAll, Inside}
 
-import java.nio.file.{FileSystemNotFoundException, NoSuchFileException, Path}
+import java.nio.file.{NoSuchFileException, Path}
 import scala.io.Source
 import scala.util.Try
 
@@ -28,6 +28,7 @@ class ScriptManagerTest extends AnyWordSpec with Matchers with Inside with Befor
 
   private object TestScriptExecutor extends AmmoniteExecutor {
     override protected def predef: String = ""
+
     override def runScript(scriptPath: Path, parameters: Map[String, String], cpg: Cpg): IO[Any] = IO.fromTry(
       Try {
         val source = Source.fromFile(scriptPath.toFile)
@@ -89,14 +90,8 @@ class ScriptManagerTest extends AnyWordSpec with Matchers with Inside with Befor
     }
 
     "throw an exception if the specified CPG can not be found" in withScriptManager { scriptManager =>
-      if (System.getProperty("java.specification.version").toInt < 13) {
-        intercept[FileSystemNotFoundException] {
-          scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
-        }
-      } else {
-        intercept[NoSuchFileException] {
-          scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
-        }
+      intercept[Exception] {
+        scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
       }
     }
 

--- a/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
+++ b/console/src/test/scala/io/shiftleft/console/scripting/ScriptManagerTest.scala
@@ -89,9 +89,14 @@ class ScriptManagerTest extends AnyWordSpec with Matchers with Inside with Befor
     }
 
     "throw an exception if the specified CPG can not be found" in withScriptManager { scriptManager =>
-      intercept[FileSystemNotFoundException] {
-        scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
-      }
+      if (System.getProperty("java.specification.version").toInt < 13)
+        intercept[FileSystemNotFoundException] {
+          scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
+        }
+      else
+        intercept[NoSuchFileException] {
+          scriptManager.runScript("general/list-funcs.sc", Map.empty, "cake.bin.zip")
+        }
     }
 
     "throw an exception if the specified script can not be found" in withScriptManager { scriptManager =>


### PR DESCRIPTION
The compiler complains about `FileSystems.newFileSystem` overload ambiguity associated with extra `newFileSystem` overloaded methods.  [Java 11 `newFileSystem`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystems.html) has 3 overloaded methods whereas [Java 13+ `newFileSystem`](https://docs.oracle.com/en/java/javase/13/docs/api/java.base/java/nio/file/FileSystems.html) has 6.

The kind of exception thrown on the `ScriptManagerTest` also varies and was adjusted.

This PR aims to resolve that by giving a type to the `null` argument.