### PR TITLE
Added lengthOf Operator

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
@@ -267,6 +267,13 @@ object Operators extends SchemaBase {
                value = "<operator>.notNullAssert",
                valueType = ValueTypes.STRING,
                comment = "Converts any value to a not-null type"),
+      Constant(
+        name = "lengthOf",
+        value = "<operator>.lengthOf",
+        valueType = ValueTypes.STRING,
+        comment =
+          "Returns the length of the given collection e.g. (new int[]{ 1, 2, 3 }).length in Java or len([1, 2, 3]) in Python"
+      ),
     )
 
   }


### PR DESCRIPTION
To represent Java ASM's `Opcodes.ARRAYLENGTH`, Jimple `LengthExpr`, Python's `len` operator we've introduced `<operator>.lengthOf`. This is different to `<operator>.sizeOf` as this does not necessarily concern itself with memory usage but rather a number of elements in a collection.