### PR TITLE
Introduce `reachableByTable`

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/queryengine/Engine.scala
@@ -34,11 +34,15 @@ class Engine(context: EngineContext) {
 
   /**
     * Determine flows from sources to sinks by analyzing backwards from sinks.
+    * Returns the list of results along with the ResultTable, a cache of known
+    * paths created during the analysis.
     * */
-  def backwards(sinks: List[CfgNode], sources: List[CfgNode]): List[ReachableByResult] = {
+  def backwards(sinks: List[CfgNode], sources: List[CfgNode]): (List[ReachableByResult], ResultTable) = {
     val sourcesSet = sources.toSet
-    val tasks = sinks.map(sink => ReachableByTask(sink, sourcesSet, new ResultTable))
-    solveTasks(tasks, sourcesSet)
+    val table = new ResultTable
+    val tasks = sinks.map(sink => ReachableByTask(sink, sourcesSet, table))
+    val results = solveTasks(tasks, sourcesSet)
+    (results, table)
   }
 
   private def solveTasks(tasks: List[ReachableByTask], sources: Set[CfgNode]): List[ReachableByResult] = {


### PR DESCRIPTION
While `reachableBy` only returns identified sources, `reachableByTable` provides the table that was created as part of data flow analysis. This table contains complete but also partial results. We are providing this primitive to allow accessing intermediate results for an experiment @DavidBakerEffendi is running.