### PR TITLE
Fixed pointer representation in method signatures

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/LocalsTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/LocalsTests.scala
@@ -44,7 +44,7 @@ class LocalsTests extends CCodeToCpgSuite {
 
   "should prove correct (name, type) pairs for locals" in {
     cpg.method.name("free_list").local.map(l => (l.name, l.typeFullName)).toSet shouldBe
-      Set(("q", "struct node *"), ("p", "struct node *"))
+      Set(("q", "struct node*"), ("p", "struct node*"))
   }
 
   "should allow finding filenames by local regex" in {

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/NodeTypeStartersTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/NodeTypeStartersTests.scala
@@ -66,7 +66,7 @@ class NodeTypeStartersTests extends CCodeToCpgSuite {
   }
 
   "should allow retrieving (used) types" in {
-    cpg.typ.name.toSet shouldBe Set("int", "void", "char * *", "ANY", "foo")
+    cpg.typ.name.toSet shouldBe Set("int", "void", "char**", "ANY", "foo")
   }
 
   "should allow retrieving namespaces" in {

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MethodParameterTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MethodParameterTests.scala
@@ -22,7 +22,7 @@ class MethodParameterTests extends CCodeToCpgSuite {
 
     val List(y) = cpg.parameter.name("argv").l
     y.code shouldBe "char **argv"
-    y.typeFullName shouldBe "char * *"
+    y.typeFullName shouldBe "char**"
     y.lineNumber shouldBe Some(2)
     y.columnNumber shouldBe Some(21)
     y.order shouldBe 2

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MethodTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/standard/MethodTests.scala
@@ -15,7 +15,7 @@ class MethodTests extends CCodeToCpgSuite {
     x.name shouldBe "main"
     x.fullName shouldBe "main"
     x.code shouldBe "int main (int argc,char **argv)"
-    x.signature shouldBe "int main (int,char * *)"
+    x.signature shouldBe "int main (int,char**)"
     x.isExternal shouldBe false
     x.order shouldBe 1
     x.filename.startsWith("/") shouldBe true

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreatorHelper.scala
@@ -231,7 +231,7 @@ trait AstCreatorHelper {
       case _                      => ""
     }
     if (pointers.isEmpty) { s"$nodeAsString$arr" } else {
-      s"$nodeAsString$arr ${"* " * pointers.size}".strip()
+      s"$nodeAsString$arr${"*" * pointers.size}".strip()
     }
   }
 
@@ -272,6 +272,9 @@ trait AstCreatorHelper {
       case s: IASTSimpleDeclaration if s.getParent.isInstanceOf[ICASTKnRFunctionDeclarator] =>
         val decl = s.getDeclarators.head
         pointersAsString(s.getDeclSpecifier, decl)
+      case s: IASTSimpleDeclSpecifier if s.getParent.isInstanceOf[IASTSimpleDeclaration] =>
+        val parentDecl = s.getParent.asInstanceOf[IASTSimpleDeclaration].getDeclarators.head
+        pointersAsString(s, parentDecl)
       case s: IASTSimpleDeclSpecifier =>
         ASTStringUtil.getReturnTypeString(s, null)
       case s: IASTNamedTypeSpecifier if s.getParent.isInstanceOf[IASTParameterDeclaration] =>

--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/passes/AstCreationPassTests.scala
@@ -36,12 +36,29 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
 
   "Method AST layout" should {
 
+    "be correct for method signature" in TestAstOnlyFixture("""
+       |char *foo() {};
+       |char *hello();
+       |""".stripMargin) { cpg =>
+      cpg.method("foo").l match {
+        case List(foo) =>
+          foo.signature shouldBe "char* foo ()"
+        case _ => fail()
+      }
+      cpg.method("hello").l match {
+        case List(hello) =>
+          hello.signature shouldBe "char* hello ()"
+        case _ => fail()
+      }
+    }
+
     "be correct for packed args" in TestAstOnlyFixture("""
        |void foo(int x, int*... args) {};
        |""".stripMargin,
                                                        "test.cpp") { cpg =>
       cpg.method("foo").l match {
         case List(m) =>
+          m.signature shouldBe "void foo (int,int*)"
           m.parameter.l match {
             case List(x, args) =>
               x.name shouldBe "x"
@@ -51,7 +68,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
               x.order shouldBe 1
               args.name shouldBe "args"
               args.code shouldBe "int*... args"
-              args.typeFullName shouldBe "int *"
+              args.typeFullName shouldBe "int*"
               args.isVariadic shouldBe true
               args.order shouldBe 2
             case _ => fail()
@@ -96,11 +113,11 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
             case List(x, y) =>
               x.name shouldBe "x"
               x.code shouldBe "int *x;"
-              x.typeFullName shouldBe "int *"
+              x.typeFullName shouldBe "int*"
               x.order shouldBe 1
               y.name shouldBe "y"
               y.code shouldBe "int *y;"
-              y.typeFullName shouldBe "int *"
+              y.typeFullName shouldBe "int*"
               y.order shouldBe 2
             case _ => fail()
           }
@@ -393,7 +410,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
         |""".stripMargin) { cpg =>
       cpg.method.name("method").parameter.l match {
         case List(param: MethodParameterIn) =>
-          param.typeFullName shouldBe "a_struct_type *"
+          param.typeFullName shouldBe "a_struct_type*"
           param.name shouldBe "a_struct"
         case _ => fail()
       }
@@ -408,7 +425,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
        |""".stripMargin) { cpg =>
       cpg.method.name("method").parameter.l match {
         case List(param: MethodParameterIn) =>
-          param.typeFullName shouldBe "struct date *"
+          param.typeFullName shouldBe "struct date*"
           param.name shouldBe "date"
         case _ => fail()
       }
@@ -469,7 +486,7 @@ class AstCreationPassTests extends AnyWordSpec with Matchers with CpgAstOnlyFixt
       |""".stripMargin) { cpg =>
       cpg.method.name("method").parameter.l match {
         case List(param: MethodParameterIn) =>
-          param.typeFullName shouldBe "a_struct_type[] *"
+          param.typeFullName shouldBe "a_struct_type[]*"
           param.name shouldBe "a_struct"
         case _ => fail()
       }


### PR DESCRIPTION
Fixes: https://github.com/ShiftLeftSecurity/codepropertygraph/issues/1433