### PR TITLE
Add `safeNavigation` operator

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
@@ -274,6 +274,12 @@ object Operators extends SchemaBase {
         comment =
           "Returns the length of the given collection e.g. (new int[]{ 1, 2, 3 }).length in Java or len([1, 2, 3]) in Python"
       ),
+      Constant(
+        name = "safeNavigation",
+        value = "<operator>.safeNavigation",
+        valueType = ValueTypes.STRING,
+        comment = "Returns null if the first operator is null, otherwise performs a dereferencing operation"
+      ),
     )
 
   }


### PR DESCRIPTION
Found in Kotlin, C#, Swift, Ruby, etc.

e.g. in Kotlin:
```
val b: String? = null
println(b?.length)
```

e.g. in C#:
```
var name = articles?[0]?.Author?.Name;
```