### PR TITLE
Make available `reversePostOrdering`/`postOrdering` for CFGs

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
@@ -25,7 +25,8 @@ class DataFlowProblem[V](val flowGraph: FlowGraph,
 trait FlowGraph {
   val entryNode: StoredNode
   val exitNode: StoredNode
-  val allNodes: List[StoredNode]
+  def allNodesReversePostOrder: List[StoredNode]
+  def allNodesPostOrder: List[StoredNode]
   val succ: Map[StoredNode, List[StoredNode]]
   val pred: Map[StoredNode, List[StoredNode]]
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
@@ -25,8 +25,8 @@ class DataFlowProblem[V](val flowGraph: FlowGraph,
 trait FlowGraph {
   val entryNode: StoredNode
   val exitNode: StoredNode
-  def allNodesReversePostOrder: List[StoredNode]
-  def allNodesPostOrder: List[StoredNode]
+  val allNodesReversePostOrder: List[StoredNode]
+  val allNodesPostOrder: List[StoredNode]
   val succ: Map[StoredNode, List[StoredNode]]
   val pred: Map[StoredNode, List[StoredNode]]
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -51,7 +51,7 @@ class DataFlowSolver {
     var out: Map[StoredNode, T] = problem.inOutInit.initOut
     var in = problem.inOutInit.initIn
     val workList = mutable.Set.empty[StoredNode]
-    workList ++= problem.flowGraph.allNodesReversePostOrder
+    workList ++= problem.flowGraph.allNodesPostOrder
 
     while (workList.nonEmpty) {
       val newEntries = workList.flatMap { n =>

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -16,7 +16,7 @@ class DataFlowSolver {
     var out: Map[StoredNode, T] = problem.inOutInit.initOut
     var in = problem.inOutInit.initIn
     val workList = mutable.Set.empty[StoredNode]
-    workList ++= problem.flowGraph.allNodes
+    workList ++= problem.flowGraph.allNodesReversePostOrder
 
     while (workList.nonEmpty) {
       val newEntries = workList.flatMap { n =>
@@ -51,7 +51,7 @@ class DataFlowSolver {
     var out: Map[StoredNode, T] = problem.inOutInit.initOut
     var in = problem.inOutInit.initIn
     val workList = mutable.Set.empty[StoredNode]
-    workList ++= problem.flowGraph.allNodes
+    workList ++= problem.flowGraph.allNodesReversePostOrder
 
     while (workList.nonEmpty) {
       val newEntries = workList.flatMap { n =>

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -50,11 +50,11 @@ class ReachingDefFlowGraph(method: Method) extends FlowGraph {
   val entryNode: StoredNode = method
   val exitNode: StoredNode = method.methodReturn
 
-  override def allNodesReversePostOrder: List[StoredNode] =
-    List(exitNode) ++ method.reversePostOrder.toList ++ method.parameter.toList ++ List(entryNode)
+  val allNodesReversePostOrder: List[StoredNode] =
+    List(entryNode) ++ method.reversePostOrder.toList ++ method.parameter.toList ++ List(exitNode)
 
-  override def allNodesPostOrder: List[StoredNode] =
-    List(entryNode) ++ method.postOrder.toList ++ method.parameter.toList ++ List(exitNode)
+  val allNodesPostOrder: List[StoredNode] =
+    List(exitNode) ++ method.postOrder.toList ++ method.parameter.toList ++ List(entryNode)
 
   val succ: Map[StoredNode, List[StoredNode]] = initSucc(allNodesReversePostOrder)
   val pred: Map[StoredNode, List[StoredNode]] = initPred(allNodesReversePostOrder, method)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -49,10 +49,15 @@ class ReachingDefFlowGraph(method: Method) extends FlowGraph {
 
   val entryNode: StoredNode = method
   val exitNode: StoredNode = method.methodReturn
-  val allNodes: List[StoredNode] = method.cfgNode.toList ++ List(entryNode, exitNode) ++ method.parameter.toList
 
-  val succ: Map[StoredNode, List[StoredNode]] = initSucc(allNodes)
-  val pred: Map[StoredNode, List[StoredNode]] = initPred(allNodes, method)
+  override def allNodesReversePostOrder: List[StoredNode] =
+    List(exitNode) ++ method.reversePostOrder.toList ++ method.parameter.toList ++ List(entryNode)
+
+  override def allNodesPostOrder: List[StoredNode] =
+    List(entryNode) ++ method.postOrder.toList ++ method.parameter.toList ++ List(exitNode)
+
+  val succ: Map[StoredNode, List[StoredNode]] = initSucc(allNodesReversePostOrder)
+  val pred: Map[StoredNode, List[StoredNode]] = initPred(allNodesReversePostOrder, method)
 
   /**
     * Create a map that allows CFG successors to be retrieved for each node

--- a/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
+++ b/semanticcpg-tests/src/test/scala/io/shiftleft/semanticcpg/passes/CfgDominatorFrontierTests.scala
@@ -6,7 +6,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import overflowdb._
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 class CfgDominatorFrontierTests extends AnyWordSpec with Matchers {
@@ -19,7 +18,7 @@ class CfgDominatorFrontierTests extends AnyWordSpec with Matchers {
       node.in("CFG").asScala
   }
 
-  private class TestDomTreeAdapter(immediateDominators: mutable.Map[Node, Node]) extends DomTreeAdapter[Node] {
+  private class TestDomTreeAdapter(immediateDominators: Map[Node, Node]) extends DomTreeAdapter[Node] {
     override def immediateDominator(cfgNode: Node): Option[Node] = {
       immediateDominators.get(cfgNode)
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeOrdering.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeOrdering.scala
@@ -43,4 +43,14 @@ object NodeOrdering {
       .map { case (node, _) => node }
   }
 
+  /**
+    * For a list of (node, number) pairs, return the list of nodes obtained
+    * by sorting nodes according to number.
+    * */
+  def nodeList[NodeType](nodeNumberPairs: List[(NodeType, Int)]): List[NodeType] = {
+    nodeNumberPairs
+      .sortBy { case (_, num) => num }
+      .map { case (node, _) => node }
+  }
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeOrdering.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeOrdering.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.semanticcpg.passes.cfgdominator
+package io.shiftleft.semanticcpg.language
 
 import scala.collection.mutable
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -3,6 +3,7 @@ package io.shiftleft.semanticcpg.language.nodemethods
 import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
+import io.shiftleft.semanticcpg.language.toCfgNode
 import overflowdb.traversal.Traversal
 
 import scala.jdk.CollectionConverters._
@@ -19,6 +20,20 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
       case expr: Expression                           => expr.code
       case call: CallRepr if !call.isInstanceOf[Call] => call.code
     }
+
+  /**
+    * Successors in the CFG
+    * */
+  def cfgNext: Traversal[CfgNode] = {
+    Traversal.fromSingle(node).cfgNext
+  }
+
+  /**
+    * Predecessors in the CFG
+    * */
+  def cfgPrev: Traversal[CfgNode] = {
+    Traversal.fromSingle(node).cfgPrev
+  }
 
   /**
     * Recursively determine all nodes on which this

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -9,7 +9,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
   NewLocation
 }
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator}
+import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, NodeOrdering, toCfgNodeMethods}
 import overflowdb.traversal.Traversal
 
 import scala.jdk.CollectionConverters._
@@ -39,6 +39,18 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
 
   def cfgNode: Traversal[CfgNode] =
     method._containsOut.asScala.collect { case cfgNode: CfgNode => cfgNode }
+
+  /**
+    * List of CFG nodes in reverse post order
+    * */
+  def reversePostOrder: Traversal[CfgNode] = {
+    def expand(x: CfgNode) = { x.cfgNext.iterator }
+    Traversal.from(
+      NodeOrdering.reverseNodeList(
+        NodeOrdering.postOrderNumbering(method, expand).toList
+      )
+    )
+  }
 
   override def location: NewLocation = {
     LocationCreator(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -52,6 +52,18 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
     )
   }
 
+  /**
+    * List of CFG nodes in post order
+    * */
+  def postOrder: Traversal[CfgNode] = {
+    def expand(x: CfgNode) = { x.cfgNext.iterator }
+    Traversal.from(
+      NodeOrdering.nodeList(
+        NodeOrdering.postOrderNumbering(method, expand).toList
+      )
+    )
+  }
+
   override def location: NewLocation = {
     LocationCreator(
       method,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
@@ -1,5 +1,7 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
+import io.shiftleft.semanticcpg.language.NodeOrdering
+
 class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominator.scala
@@ -1,7 +1,5 @@
 package io.shiftleft.semanticcpg.passes.cfgdominator
 
-import scala.collection.mutable
-
 class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
 
   /**
@@ -9,24 +7,27 @@ class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
     * Since the cfgEntry does not have an immediate dominator, it has no entry in the
     * return map.
     *
-    * The used algorithm is from: "A Simple, Fast Dominance Algorithm" from
+    * The algorithm is from: "A Simple, Fast Dominance Algorithm" from
     * "Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy".
     */
-  def calculate(cfgEntry: NodeType): mutable.Map[NodeType, NodeType] = {
+  def calculate(cfgEntry: NodeType): Map[NodeType, NodeType] = {
     val UNDEFINED = -1
-    val postOrderNumbering = createPostOrderNumbering(cfgEntry)
-    val indexOf = postOrderNumbering.withDefaultValue(UNDEFINED) // Index of each node into dominators array.
+    def expand(x: NodeType) = { adapter.successors(x).iterator }
+    val postOrderNumbering = NodeOrdering.createPostOrderNumbering(cfgEntry, expand)
+    // Index of each node into dominators array.
+    val indexOf = postOrderNumbering.withDefaultValue(UNDEFINED)
     // We use withDefault because unreachable/dead
     // code nodes are not numbered but may be touched
     // as predecessors of reachable nodes.
-    val nodesInReversePostOrder = postOrderNumbering.toList // Does not contain entry.
-      .sortBy { case (_, index) => -index }
-      .map { case (node, _) => node }
-      .filter { _ != cfgEntry }
+    // Do not include cfgEntry.
+    val nodesInReversePostOrder = NodeOrdering.reverseNodeList(postOrderNumbering.toList).filter { _ != cfgEntry }
     val dominators = Array.fill(indexOf.size)(UNDEFINED)
 
-    // Used in places where index might be UNDEFINED.
-    def saveDominators(index: Int): Int = {
+    /**
+      * Retrieve index of immediate dominator for node with given index. If the
+      * index is `UNDEFINED`, UNDEFINED is returned.
+      * */
+    def safeDominators(index: Int): Int = {
       if (index != UNDEFINED) {
         dominators(index)
       } else {
@@ -44,14 +45,14 @@ class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
           .predecessors(node)
           .iterator
           .find { predecessor =>
-            saveDominators(indexOf(predecessor)) != UNDEFINED
+            safeDominators(indexOf(predecessor)) != UNDEFINED
           }
           .get
 
         var newImmediateDominator = indexOf(firstNotUndefinedPred)
         adapter.predecessors(node).iterator.foreach { predecessor =>
           val predecessorIndex = indexOf(predecessor)
-          if (saveDominators(predecessorIndex) != UNDEFINED) {
+          if (safeDominators(predecessorIndex) != UNDEFINED) {
             newImmediateDominator = intersect(dominators, predecessorIndex, newImmediateDominator)
           }
         }
@@ -89,29 +90,4 @@ class CfgDominator[NodeType](adapter: CfgAdapter[NodeType]) {
     finger1
   }
 
-  private def createPostOrderNumbering(cfgEntry: NodeType): mutable.Map[NodeType, Int] = {
-    var stack = (cfgEntry, adapter.successors(cfgEntry).iterator) :: Nil
-    val visited = mutable.Set.empty[NodeType]
-    val numbering = mutable.Map.empty[NodeType, Int]
-    var nextNumber = 0
-
-    while (stack.nonEmpty) {
-      val (node, successorIt) = stack.head
-
-      visited += node
-
-      if (successorIt.hasNext) {
-        val successor = successorIt.next()
-        if (!visited.contains(successor)) {
-          stack = (successor, adapter.successors(successor).iterator) :: stack
-        }
-      } else {
-        stack = stack.tail
-        numbering += (node -> nextNumber)
-        nextNumber += 1
-      }
-    }
-
-    numbering
-  }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/CfgDominatorPass.scala
@@ -6,8 +6,6 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Method, StoredNode}
 import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 
-import scala.collection.mutable
-
 /**
   * This pass has no prerequisites.
   */
@@ -34,8 +32,8 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[Method](cpg) {
   }
 
   private def addDomTreeEdges(dstGraph: DiffGraph.Builder,
-                              cfgNodeToImmediateDominator: mutable.Map[StoredNode, StoredNode]): Unit = {
-    // TODO do not iterate over potential hash map to ensure same interation order for
+                              cfgNodeToImmediateDominator: Map[StoredNode, StoredNode]): Unit = {
+    // TODO do not iterate over potential hash map to ensure same iteration order for
     // edge creation.
     cfgNodeToImmediateDominator.foreach {
       case (node, immediateDominator) =>
@@ -44,8 +42,8 @@ class CfgDominatorPass(cpg: Cpg) extends ParallelCpgPass[Method](cpg) {
   }
 
   private def addPostDomTreeEdges(dstGraph: DiffGraph.Builder,
-                                  cfgNodeToPostImmediateDominator: mutable.Map[StoredNode, StoredNode]): Unit = {
-    // TODO do not iterate over potential hash map to ensure same interation order for
+                                  cfgNodeToPostImmediateDominator: Map[StoredNode, StoredNode]): Unit = {
+    // TODO do not iterate over potential hash map to ensure same iteration order for
     // edge creation.
     cfgNodeToPostImmediateDominator.foreach {
       case (node, immediatePostDominator) =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/NodeOrdering.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/NodeOrdering.scala
@@ -9,8 +9,7 @@ object NodeOrdering {
     * return a map that associates each node with an index such that nodes are numbered
     * in post order.
     * */
-  def createPostOrderNumbering[NodeType](cfgEntry: NodeType,
-                                         expand: NodeType => Iterator[NodeType]): Map[NodeType, Int] = {
+  def postOrderNumbering[NodeType](cfgEntry: NodeType, expand: NodeType => Iterator[NodeType]): Map[NodeType, Int] = {
     var stack = (cfgEntry, expand(cfgEntry)) :: Nil
     val visited = mutable.Set.empty[NodeType]
     val numbering = mutable.Map.empty[NodeType, Int]
@@ -34,9 +33,13 @@ object NodeOrdering {
     numbering.toMap
   }
 
-  def reverseNodeList[NodeType](ordering: List[(NodeType, Int)]): List[NodeType] = {
-    ordering
-      .sortBy { case (_, index) => -index }
+  /**
+    * For a list of (node, number) pairs, return the list of nodes obtained
+    * by sorting nodes according to number in reverse order.
+    * */
+  def reverseNodeList[NodeType](nodeNumberPairs: List[(NodeType, Int)]): List[NodeType] = {
+    nodeNumberPairs
+      .sortBy { case (_, num) => -num }
       .map { case (node, _) => node }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/NodeOrdering.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/cfgdominator/NodeOrdering.scala
@@ -1,0 +1,43 @@
+package io.shiftleft.semanticcpg.passes.cfgdominator
+
+import scala.collection.mutable
+
+object NodeOrdering {
+
+  /**
+    * For a given CFG with the entry node `cfgEntry` and an expansion function `expand`,
+    * return a map that associates each node with an index such that nodes are numbered
+    * in post order.
+    * */
+  def createPostOrderNumbering[NodeType](cfgEntry: NodeType,
+                                         expand: NodeType => Iterator[NodeType]): Map[NodeType, Int] = {
+    var stack = (cfgEntry, expand(cfgEntry)) :: Nil
+    val visited = mutable.Set.empty[NodeType]
+    val numbering = mutable.Map.empty[NodeType, Int]
+    var nextNumber = 0
+
+    while (stack.nonEmpty) {
+      val (node, successors) = stack.head
+      visited += node
+
+      if (successors.hasNext) {
+        val successor = successors.next()
+        if (!visited.contains(successor)) {
+          stack = (successor, expand(successor)) :: stack
+        }
+      } else {
+        stack = stack.tail
+        numbering += (node -> nextNumber)
+        nextNumber += 1
+      }
+    }
+    numbering.toMap
+  }
+
+  def reverseNodeList[NodeType](ordering: List[(NodeType, Int)]): List[NodeType] = {
+    ordering
+      .sortBy { case (_, index) => -index }
+      .map { case (node, _) => node }
+  }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
@@ -37,19 +37,23 @@ class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
           .lineNumber(parameterIn.lineNumber)
           .columnNumber(parameterIn.columnNumber)
 
-        val method = parameterIn._methodViaAstIn
-        if (parameterIn.typeFullName == null) {
-          val evalType = parameterIn._typeViaEvalTypeOut
-          dstGraph.addEdgeToOriginal(parameterOut, evalType, EdgeTypes.EVAL_TYPE)
-          if (!loggedMissingTypeFullName) {
-            logger.warn("Using deprecated CPG format with missing TYPE_FULL_NAME on METHOD_PARAMETER_IN nodes.")
-            loggedMissingTypeFullName = true
+        val method = parameterIn.astIn.headOption
+        if (method.isEmpty) {
+          logger.warn("Parameter without method encountered: " + parameterIn.toString)
+        } else {
+          if (parameterIn.typeFullName == null) {
+            val evalType = parameterIn._typeViaEvalTypeOut
+            dstGraph.addEdgeToOriginal(parameterOut, evalType, EdgeTypes.EVAL_TYPE)
+            if (!loggedMissingTypeFullName) {
+              logger.warn("Using deprecated CPG format with missing TYPE_FULL_NAME on METHOD_PARAMETER_IN nodes.")
+              loggedMissingTypeFullName = true
+            }
           }
-        }
 
-        dstGraph.addNode(parameterOut)
-        dstGraph.addEdgeFromOriginal(method, parameterOut, EdgeTypes.AST)
-        dstGraph.addEdgeFromOriginal(parameterIn, parameterOut, EdgeTypes.PARAMETER_LINK)
+          dstGraph.addNode(parameterOut)
+          dstGraph.addEdgeFromOriginal(method.get, parameterOut, EdgeTypes.AST)
+          dstGraph.addEdgeFromOriginal(parameterIn, parameterOut, EdgeTypes.PARAMETER_LINK)
+        }
       } else if (!loggedDeprecatedWarning) {
         logger.warn("Using deprecated CPG format with PARAMETER_LINK edges")
         loggedDeprecatedWarning = true


### PR DESCRIPTION
In the `CfgDominator` pass, we had some code that calculated CFG node sequences in post order and reverse post order and I noticed that in the OSS data flow tracker, we are not yet using such ordered sequences although this would optimize the algorithm for reaching definition calculation. I therefore cleaned up and isolated the code for calculation of these orderings and made them available via the query language. Finally, I made use of these methods in the OSS data flow tracker. The speedup encountered on a few examples is only marginal, however.