### PR TITLE
Method stubs for macros

### DIFF
--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/MacroHandlingTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/MacroHandlingTests.scala
@@ -118,7 +118,7 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     val List(call1: Call) = cpg.method("foo").call.nameExact("A_MACRO").l
     call1.code shouldBe "A_MACRO(dst, ptr, 1)"
     call1.name shouldBe "A_MACRO"
-    call1.methodFullName shouldBe "A_MACRO"
+    call1.methodFullName.endsWith("A_MACRO:3") shouldBe true
     call1.lineNumber shouldBe Some(22)
     call1.columnNumber shouldBe Some(8)
     call1.typeFullName shouldBe "ANY"
@@ -131,7 +131,7 @@ class MacroHandlingTests4 extends CCodeToCpgSuite {
     val List(call2: Call) = cpg.method("foo").call.nameExact("A_MACRO_2").l
     call2.code shouldBe "A_MACRO_2()"
     call2.name shouldBe "A_MACRO_2"
-    call2.methodFullName shouldBe "A_MACRO_2"
+    call2.methodFullName.endsWith("A_MACRO_2:0") shouldBe true
     call2.lineNumber shouldBe Some(24)
     call2.columnNumber shouldBe Some(8)
     call2.typeFullName shouldBe "ANY"

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/MacroHandlingTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/MacroHandlingTests.scala
@@ -40,6 +40,7 @@ class MacroHandlingTests1 extends CCodeToCpgSuite {
     val List(m: Method) = cpg.method.name("A_MACRO").l
     m.fullName.endsWith("A_MACRO:2") shouldBe true
     m.filename.endsWith(".c") shouldBe true
+    m.lineNumber shouldBe Some(2)
     val List(param1, param2) = m.parameter.l.sortBy(_.order)
     param1.name shouldBe "p1"
     param2.name shouldBe "p2"

--- a/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/MacroHandlingTests.scala
+++ b/c2cpg-tests/src/test/scala/io/shiftleft/c2cpg/querying/MacroHandlingTests.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.c2cpg.querying
 
 import io.shiftleft.c2cpg.testfixtures.{CCodeToCpgSuite, DataFlowCodeToCpgSuite}
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Identifier, Literal, Method}
 import io.shiftleft.codepropertygraph.generated.{DispatchTypes, Operators}
 import io.shiftleft.dataflowengineoss.language._
 import io.shiftleft.semanticcpg.language._
@@ -35,6 +35,16 @@ class MacroHandlingTests1 extends CCodeToCpgSuite {
     arg2.order shouldBe 2
     arg2.argumentIndex shouldBe 2
   }
+
+  "should create a METHOD for the expanded macro" in {
+    val List(m: Method) = cpg.method.name("A_MACRO").l
+    m.fullName.endsWith("A_MACRO:2") shouldBe true
+    m.filename.endsWith(".c") shouldBe true
+    val List(param1, param2) = m.parameter.l.sortBy(_.order)
+    param1.name shouldBe "p1"
+    param2.name shouldBe "p2"
+  }
+
 }
 
 class MacroHandlingTests2 extends CCodeToCpgSuite {

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -109,8 +109,17 @@ trait MacroHandler {
     val name = macroDef.getName.toString
     val code = node.getRawSignature.replaceAll(";$", "")
     val argAsts = argumentTrees(arguments, ast).map(_.getOrElse(Ast()))
-    val lineNo = macroDef.getFileLocation.getStartingLineNumber
-    val fullName = macroDef.getFileLocation.getFileName + ":" + lineNo + ":" + name + ":" + argAsts.size
+    val fileLocation = macroDef.getFileLocation
+
+    val fullName = {
+      if (fileLocation != null) {
+        val lineNo = fileLocation.getStartingLineNumber
+        val fileName = fileLocation.getFileName
+        fileName + ":" + lineNo + ":" + name + ":" + argAsts.size
+      } else {
+        "<empty>:-1:" + name + ":" + argAsts.size
+      }
+    }
 
     val callNode = NewCall()
       .name(name)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -108,9 +108,12 @@ trait MacroHandler {
                                  order: Int): Ast = {
     val name = macroDef.getName.toString
     val code = node.getRawSignature.replaceAll(";$", "")
+    val argAsts = argumentTrees(arguments, ast).map(_.getOrElse(Ast()))
+    val fullName = macroDef.getFileLocation.getFileName + ":" + name + ":" + argAsts.size
+
     val callNode = NewCall()
       .name(name)
-      .methodFullName(name)
+      .methodFullName(fullName)
       .code(code)
       .lineNumber(line(node))
       .columnNumber(column(node))
@@ -119,7 +122,6 @@ trait MacroHandler {
       .order(order)
       .argumentIndex(order)
 
-    val argAsts = argumentTrees(arguments, ast).map(_.getOrElse(Ast()))
     Ast(callNode)
       .withChildren(argAsts)
       .withArgEdges(callNode, argAsts.flatMap(x => x.root))

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/MacroHandler.scala
@@ -109,7 +109,8 @@ trait MacroHandler {
     val name = macroDef.getName.toString
     val code = node.getRawSignature.replaceAll(";$", "")
     val argAsts = argumentTrees(arguments, ast).map(_.getOrElse(Ast()))
-    val fullName = macroDef.getFileLocation.getFileName + ":" + name + ":" + argAsts.size
+    val lineNo = macroDef.getFileLocation.getStartingLineNumber
+    val fullName = macroDef.getFileLocation.getFileName + ":" + lineNo + ":" + name + ":" + argAsts.size
 
     val callNode = NewCall()
       .name(name)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -57,7 +57,7 @@ class MethodStubCreator(cpg: Cpg) extends ParallelCpgPass[(NameAndSignature, Int
                                signature: String,
                                parameterCount: Int,
                                dstGraph: DiffGraph.Builder): MethodBase = {
-    val methodNode = NewMethod()
+    val methodNode1 = NewMethod()
       .name(name)
       .fullName(fullName)
       .isExternal(true)
@@ -65,6 +65,15 @@ class MethodStubCreator(cpg: Cpg) extends ParallelCpgPass[(NameAndSignature, Int
       .astParentType(NodeTypes.NAMESPACE_BLOCK)
       .astParentFullName("<global>")
       .order(0)
+
+    val methodNode = {
+      val s = fullName.split(":")
+      if (s.size == 3) {
+        methodNode1.filename(s(0))
+      } else {
+        methodNode1
+      }
+    }
 
     dstGraph.addNode(methodNode)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/languagespecific/fuzzyc/MethodStubCreator.scala
@@ -68,8 +68,8 @@ class MethodStubCreator(cpg: Cpg) extends ParallelCpgPass[(NameAndSignature, Int
 
     val methodNode = {
       val s = fullName.split(":")
-      if (s.size == 3) {
-        methodNode1.filename(s(0))
+      if (s.size == 4) {
+        methodNode1.filename(s(0)).lineNumber(s(1).toInt)
       } else {
         methodNode1
       }


### PR DESCRIPTION
The `MethodStubCreator` now also creates method stubs for macros and we fill out `filename` and `lineNumber`.