### PR TITLE
Use integer sets in reaching definition calculation

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -65,7 +65,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
     val in = solution.in
     val gen = solution.problem.transferFunction
       .asInstanceOf[ReachingDefTransferFunction]
-      .initGen(method)
+      .gen
       .withDefaultValue(Set())
     val allNodes = in.keys.toList
     val usageAnalyzer = new UsageAnalyzer(in)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -28,8 +28,8 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
     }
 
     val solution = new DataFlowSolver().calculateMopSolutionForwards(problem)
-    val dstGraph = addReachingDefEdges(method, solution)
-    addEdgesFromLoneIdentifiersToExit(dstGraph, method, solution)
+    val dstGraph = addReachingDefEdges(problem, method, solution)
+    addEdgesFromLoneIdentifiersToExit(dstGraph, problem, method, solution)
     Iterator(dstGraph.build())
   }
 
@@ -60,7 +60,10 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
     * by seeing which of these reaching definitions are relevant in the sense that
     * they are used.
     * */
-  private def addReachingDefEdges(method: Method, solution: Solution[mutable.Set[Definition]]): DiffGraph.Builder = {
+  private def addReachingDefEdges(problem: DataFlowProblem[mutable.Set[Definition]],
+                                  method: Method,
+                                  solution: Solution[mutable.Set[Definition]]): DiffGraph.Builder = {
+    val numberToNode = problem.flowGraph.asInstanceOf[ReachingDefFlowGraph].numberToNode
     implicit val dstGraph: DiffGraph.Builder = DiffGraph.newBuilder
     val in = solution.in
     val gen = solution.problem.transferFunction
@@ -68,7 +71,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
       .gen
       .withDefaultValue(Set())
     val allNodes = in.keys.toList
-    val usageAnalyzer = new UsageAnalyzer(in)
+    val usageAnalyzer = new UsageAnalyzer(problem, in)
 
     allNodes.foreach { node: StoredNode =>
       node match {
@@ -77,8 +80,9 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
           usageAnalyzer.usedIncomingDefs(call).foreach {
             case (use, ins) =>
               ins.foreach { in =>
-                if (in.node != use) {
-                  addEdge(in.node, use, nodeToEdgeLabel(in.node))
+                val inNode = numberToNode(in.nodeNum)
+                if (inNode != use) {
+                  addEdge(inNode, use, nodeToEdgeLabel(inNode))
                 }
               }
           }
@@ -88,8 +92,9 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
           // and the return value
           usageAnalyzer.uses(node).foreach { use =>
             gen(node).foreach { g =>
-              if (use != g.node && nodeMayBeSource(use)) {
-                addEdge(use, g.node, nodeToEdgeLabel(use))
+              val genNode = numberToNode(g.nodeNum)
+              if (use != genNode && nodeMayBeSource(use)) {
+                addEdge(use, genNode, nodeToEdgeLabel(use))
               }
             }
           }
@@ -98,8 +103,9 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
           usageAnalyzer.usedIncomingDefs(ret).foreach {
             case (use, inElements) =>
               addEdge(use, ret, use.asInstanceOf[CfgNode].code)
-              inElements.filter(x => x.node != use).foreach { inElement =>
-                addEdge(inElement.node, ret, nodeToEdgeLabel(inElement.node))
+              inElements.filter(x => numberToNode(x.nodeNum) != use).foreach { inElement =>
+                val inElemNode = numberToNode(inElement.nodeNum)
+                addEdge(inElemNode, ret, nodeToEdgeLabel(inElemNode))
               }
               if (inElements.isEmpty) {
                 addEdge(method, ret)
@@ -109,7 +115,8 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
 
         case exitNode: MethodReturn =>
           in(exitNode).foreach { i =>
-            addEdge(i.node, exitNode, nodeToEdgeLabel(i.node))
+            val iNode = numberToNode(i.nodeNum)
+            addEdge(iNode, exitNode, nodeToEdgeLabel(iNode))
           }
         case _ =>
       }
@@ -158,8 +165,10 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
     * to the exit node.
     * */
   def addEdgesFromLoneIdentifiersToExit(builder: DiffGraph.Builder,
+                                        problem: DataFlowProblem[mutable.Set[Definition]],
                                         method: Method,
                                         solution: Solution[mutable.Set[Definition]]): Unit = {
+    val numberToNode = problem.flowGraph.asInstanceOf[ReachingDefFlowGraph].numberToNode
     implicit val dstGraph: DiffGraph.Builder = builder
     val exitNode = method.methodReturn
     val transferFunction = solution.problem.transferFunction.asInstanceOf[OptimizedReachingDefTransferFunction]
@@ -167,7 +176,8 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
     genOnce.foreach {
       case (_, defs) =>
         defs.foreach { d =>
-          addEdge(d.node, exitNode, nodeToEdgeLabel(d.node))
+          val dNode = numberToNode(d.nodeNum)
+          addEdge(dNode, exitNode, nodeToEdgeLabel(dNode))
         }
     }
   }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -50,10 +50,10 @@ class ReachingDefFlowGraph(method: Method) extends FlowGraph {
   val entryNode: StoredNode = method
   val exitNode: StoredNode = method.methodReturn
 
-  val allNodesReversePostOrder: List[StoredNode] =
+  lazy val allNodesReversePostOrder: List[StoredNode] =
     List(entryNode) ++ method.parameter.toList ++ method.reversePostOrder.toList ++ List(exitNode)
 
-  val allNodesPostOrder: List[StoredNode] =
+  lazy val allNodesPostOrder: List[StoredNode] =
     List(exitNode) ++ method.postOrder.toList ++ method.parameter.toList ++ List(entryNode)
 
   val succ: Map[StoredNode, List[StoredNode]] = initSucc(allNodesReversePostOrder)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Scpg.scala
@@ -164,7 +164,6 @@ class Scpg(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
           new FileCreationPass(cpg),
           new StaticCallLinker(cpg),
           new MemberAccessLinker(cpg),
-          new MethodExternalDecoratorPass(cpg),
           new ContainsEdgePass(cpg),
           new NamespaceCreator(cpg),
           new CfgDominatorPass(cpg),

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/methoddecorations/MethodDecoratorPass.scala
@@ -21,7 +21,7 @@ class MethodDecoratorPass(cpg: Cpg) extends CpgPass(cpg) {
   private[this] var loggedDeprecatedWarning = false
   private[this] var loggedMissingTypeFullName = false
 
-  override def run() = {
+  override def run(): Iterator[DiffGraph] = {
     val dstGraph = DiffGraph.newBuilder
 
     cpg.parameter.foreach { parameterIn =>

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/typenodes/TypeDeclStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/typenodes/TypeDeclStubCreator.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg.passes.typenodes
 
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.NodeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{NewTypeDecl, TypeDeclBase}
-import io.shiftleft.codepropertygraph.generated.{NodeTypes, nodes}
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.types.structure.{FileTraversal, NamespaceTraversal}
@@ -16,6 +16,13 @@ import io.shiftleft.semanticcpg.language.types.structure.{FileTraversal, Namespa
 class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
 
   private var typeDeclFullNameToNode = Map[String, TypeDeclBase]()
+
+  private def init(): Unit = {
+    cpg.typeDecl
+      .foreach { typeDecl =>
+        typeDeclFullNameToNode += typeDecl.fullName -> typeDecl
+      }
+  }
 
   override def run(): Iterator[DiffGraph] = {
     val dstGraph = DiffGraph.newBuilder
@@ -34,8 +41,7 @@ class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   private def createTypeDeclStub(name: String, fullName: String): NewTypeDecl = {
-    nodes
-      .NewTypeDecl()
+    NewTypeDecl()
       .name(name)
       .fullName(fullName)
       .isExternal(true)
@@ -45,11 +51,4 @@ class TypeDeclStubCreator(cpg: Cpg) extends CpgPass(cpg) {
       .filename(FileTraversal.UNKNOWN)
   }
 
-  private def init(): Unit = {
-    cpg.typeDecl
-      .sideEffect { typeDecl =>
-        typeDeclFullNameToNode += typeDecl.fullName -> typeDecl
-      }
-      .exec()
-  }
 }


### PR DESCRIPTION
Optimization for reaching definition calculation, saves us 30 seconds on a 6 minute CPG construction: instead of using `case class Definition(x : StoredNode)`, use `class Definition(x : Int) extends AnyVal`. PR also includes a bit of cleanup here and there.