### PR TITLE
Fix line/column numbers for preprocessor mappings

### DIFF
--- a/c2cpg/src/test/scala/io/shiftleft/c2cpg/MethodHeaderTests.scala
+++ b/c2cpg/src/test/scala/io/shiftleft/c2cpg/MethodHeaderTests.scala
@@ -22,7 +22,7 @@ class MethodHeaderTests extends AnyWordSpec with Matchers {
       method.property(Properties.LINE_NUMBER) shouldBe 1
       method.property(Properties.COLUMN_NUMBER) shouldBe 0
       method.property(Properties.LINE_NUMBER_END) shouldBe 3
-      method.property(Properties.COLUMN_NUMBER_END) shouldBe 0
+      method.property(Properties.COLUMN_NUMBER_END) shouldBe 1
       method.property(Properties.CODE) shouldBe "int foo (int x,int y)"
     }
 


### PR DESCRIPTION
If an AST node is the result of a preprocessor inclusion we have to remap its location using `flattenLocationsToFile`.