### PR TITLE
Fixed filenames for preprocessor mappings

### DIFF
--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreator.scala
@@ -3,7 +3,6 @@ package io.shiftleft.c2cpg.astcreation
 import io.shiftleft.c2cpg.C2Cpg
 import io.shiftleft.c2cpg.datastructures.Stack._
 import io.shiftleft.c2cpg.datastructures.{Global, Scope}
-import io.shiftleft.c2cpg.utils.IOUtils
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes}
 import io.shiftleft.passes.DiffGraph
@@ -30,8 +29,6 @@ class AstCreator(val filename: String,
     with MacroHandler {
 
   protected val logger: Logger = LoggerFactory.getLogger(classOf[AstCreator])
-
-  protected val fileLines: Seq[Int] = IOUtils.linesInFile(IOUtils.readFile(filename)).map(_.length)
 
   protected val scope: Scope[String, (NewNode, String), NewNode] = new Scope()
 

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForFunctionsCreator.scala
@@ -23,7 +23,7 @@ trait AstForFunctionsCreator {
     val parentNode: NewTypeDecl = methodAstParentStack.collectFirst { case t: NewTypeDecl => t }.getOrElse {
       val astParentType = methodAstParentStack.head.label
       val astParentFullName = methodAstParentStack.head.properties("FULL_NAME").toString
-      val newTypeDeclNode = newTypeDecl(methodName, methodFullName, astParentType, astParentFullName)
+      val newTypeDeclNode = newTypeDecl(methodName, methodFullName, filename, astParentType, astParentFullName)
       Ast.storeInDiffGraph(Ast(newTypeDeclNode), diffGraph)
       newTypeDeclNode
     }
@@ -89,7 +89,7 @@ trait AstForFunctionsCreator {
       .columnNumber(column(lambdaExpression))
       .columnNumberEnd(columnEnd(lambdaExpression))
       .signature(signature)
-      .filename(filename)
+      .filename(fileName(lambdaExpression))
 
     scope.pushNewScope(methodNode)
     val parameterAsts = withOrder(parameters(lambdaExpression.getDeclarator)) { (p, o) =>
@@ -136,7 +136,7 @@ trait AstForFunctionsCreator {
       .columnNumber(column(funcDecl))
       .columnNumberEnd(columnEnd(funcDecl))
       .signature(signature)
-      .filename(filename)
+      .filename(fileName(funcDecl))
       .order(order)
 
     scope.pushNewScope(methodNode)
@@ -183,7 +183,7 @@ trait AstForFunctionsCreator {
       .columnNumber(column(funcDef))
       .columnNumberEnd(columnEnd(funcDef))
       .signature(signature)
-      .filename(filename)
+      .filename(fileName(funcDef))
       .order(order)
 
     methodAstParentStack.push(methodNode)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForPrimitivesCreator.scala
@@ -12,7 +12,7 @@ trait AstForPrimitivesCreator {
   this: AstCreator =>
 
   protected def astForComment(comment: IASTComment): Ast =
-    Ast(NewComment().code(nodeSignature(comment)).filename(filename).lineNumber(line(comment)))
+    Ast(NewComment().code(nodeSignature(comment)).filename(fileName(comment)).lineNumber(line(comment)))
 
   protected def astForLiteral(lit: IASTLiteralExpression, order: Int): Ast = {
     val tpe = ASTTypeUtil.getType(lit.getExpressionType)

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstNodeBuilder.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstNodeBuilder.scala
@@ -76,6 +76,7 @@ trait AstNodeBuilder {
 
   protected def newTypeDecl(name: String,
                             fullname: String,
+                            filename: String,
                             astParentType: String = "",
                             astParentFullName: String = "",
                             order: Int = -1,


### PR DESCRIPTION
If an AST node is the result of a preprocessor inclusion we have to remap its filename using `flattenLocationsToFile`.
Also: its line/column numbers need to be calculated based on that filename.