### PR TITLE
More optimizations for ossdataflowengine

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
@@ -28,7 +28,7 @@ class DataFlowProblem[V](val flowGraph: FlowGraph,
   * */
 class FlowGraph(val method: Method) {
 
-  val entryNode: StoredNode = method
+  private val entryNode: StoredNode = method
   val exitNode: StoredNode = method.methodReturn
 
   private val reversePostOrder = List(entryNode) ++ method.parameter.toList ++ method.reversePostOrder.toList ++ List(
@@ -38,9 +38,6 @@ class FlowGraph(val method: Method) {
 
   val nodeToNumber: Map[StoredNode, Int] = reversePostOrder.zipWithIndex.map { case (x, i) => x -> i }.toMap
   val numberToNode: Map[Int, StoredNode] = reversePostOrder.zipWithIndex.map { case (x, i) => i -> x }.toMap
-
-  lazy val allNodesPostOrder: List[Int] =
-    (List(exitNode) ++ method.postOrder.toList ++ method.parameter.toList ++ List(entryNode)).map(nodeToNumber)
 
   val succ: Map[Int, List[Int]] = initSucc()
   val pred: Map[Int, List[Int]] = initPred()

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowProblem.scala
@@ -31,8 +31,8 @@ class FlowGraph(val method: Method) {
   private val entryNode: StoredNode = method
   val exitNode: StoredNode = method.methodReturn
 
-  private val reversePostOrder = List(entryNode) ++ method.parameter.toList ++ method.reversePostOrder.toList ++ List(
-    exitNode)
+  private val reversePostOrder = List(entryNode) ++ method.parameter.toList ++ method.reversePostOrder.toList
+    .filter(_.id != entryNode.id) ++ List(exitNode)
 
   val allNodesReversePostOrder: List[Int] = List.range(0, reversePostOrder.size)
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -1,7 +1,4 @@
 package io.shiftleft.dataflowengineoss.passes.reachingdef
-
-import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
-
 import scala.collection.mutable
 
 class DataFlowSolver {
@@ -13,9 +10,9 @@ class DataFlowSolver {
     * exit respectively.
     * */
   def calculateMopSolutionForwards[T <: Iterable[_]](problem: DataFlowProblem[T]): Solution[T] = {
-    var out: Map[StoredNode, T] = problem.inOutInit.initOut
+    var out: Map[Int, T] = problem.inOutInit.initOut
     var in = problem.inOutInit.initIn
-    val workList = mutable.Set.empty[StoredNode]
+    val workList = mutable.Set.empty[Int]
     workList ++= problem.flowGraph.allNodesReversePostOrder
 
     while (workList.nonEmpty) {
@@ -38,7 +35,9 @@ class DataFlowSolver {
       workList.clear()
       workList ++= newEntries
     }
-    Solution(in, out, problem)
+    val inResult = in.map { case (k, v)   => problem.flowGraph.numberToNode(k) -> v }
+    val outResult = out.map { case (k, v) => problem.flowGraph.numberToNode(k) -> v }
+    Solution(inResult, outResult, problem)
   }
 
   /**
@@ -48,9 +47,9 @@ class DataFlowSolver {
     * exit respectively.
     * */
   def calculateMopSolutionBackwards[T <: Iterable[_]](problem: DataFlowProblem[T]): Solution[T] = {
-    var out: Map[StoredNode, T] = problem.inOutInit.initOut
+    var out: Map[Int, T] = problem.inOutInit.initOut
     var in = problem.inOutInit.initIn
-    val workList = mutable.Set.empty[StoredNode]
+    val workList = mutable.Set.empty[Int]
     workList ++= problem.flowGraph.allNodesPostOrder
 
     while (workList.nonEmpty) {
@@ -73,7 +72,9 @@ class DataFlowSolver {
       workList.clear()
       workList ++= newEntries
     }
-    Solution(in, out, problem)
+    val inResult = in.map { case (k, v)   => problem.flowGraph.numberToNode(k) -> v }
+    val outResult = out.map { case (k, v) => problem.flowGraph.numberToNode(k) -> v }
+    Solution(inResult, outResult, problem)
   }
 
 }

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/DataFlowSolver.scala
@@ -15,7 +15,7 @@ class DataFlowSolver {
   def calculateMopSolutionForwards[T <: Iterable[_]](problem: DataFlowProblem[T]): Solution[T] = {
     var out: Map[Int, T] = problem.inOutInit.initOut
     var in = problem.inOutInit.initIn
-    val workList = mutable.BitSet()
+    val workList = mutable.ListBuffer[Int]()
     workList ++= problem.flowGraph.allNodesReversePostOrder
 
     while (workList.nonEmpty) {
@@ -36,7 +36,7 @@ class DataFlowSolver {
           List()
       }
       workList.clear()
-      workList ++= newEntries
+      workList ++= newEntries.distinct
     }
     implicit val p: DataFlowProblem[T] = problem
     Solution(toNodes(in), toNodes(out), problem)
@@ -51,7 +51,7 @@ class DataFlowSolver {
   def calculateMopSolutionBackwards[T <: Iterable[_]](problem: DataFlowProblem[T]): Solution[T] = {
     var out: Map[Int, T] = problem.inOutInit.initOut
     var in = problem.inOutInit.initIn
-    val workList = mutable.BitSet()
+    val workList = mutable.ListBuffer[Int]()
     workList ++= problem.flowGraph.allNodesReversePostOrder.reverse
 
     while (workList.nonEmpty) {
@@ -72,7 +72,7 @@ class DataFlowSolver {
           List()
       }
       workList.clear()
-      workList ++= newEntries
+      workList ++= newEntries.distinct
     }
     implicit val p: DataFlowProblem[T] = problem
     Solution(toNodes(in), toNodes(out), problem)

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -41,7 +41,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
     * if desired.
     * */
   private def shouldBailOut(problem: DataFlowProblem[mutable.BitSet]): Boolean = {
-    val method = problem.flowGraph.entryNode.asInstanceOf[Method]
+    val method = problem.flowGraph.method
     val transferFunction = problem.transferFunction.asInstanceOf[ReachingDefTransferFunction]
     // For each node, the `gen` map contains the list of definitions it generates
     // We add up the sizes of these lists to obtain the total number of definitions

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -91,7 +91,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
           // taint corresponding output arguments
           // and the return value
           usageAnalyzer.uses(node).foreach { use =>
-            gen(node).foreach { g =>
+            gen(problem.flowGraph.nodeToNumber(node)).foreach { g =>
               val genNode = numberToNode(g)
               if (use != genNode && nodeMayBeSource(use)) {
                 addEdge(use, genNode, nodeToEdgeLabel(use))

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -63,7 +63,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
   private def addReachingDefEdges(problem: DataFlowProblem[mutable.BitSet],
                                   method: Method,
                                   solution: Solution[mutable.BitSet]): DiffGraph.Builder = {
-    val numberToNode = problem.flowGraph.asInstanceOf[ReachingDefFlowGraph].numberToNode
+    val numberToNode = problem.flowGraph.numberToNode
     implicit val dstGraph: DiffGraph.Builder = DiffGraph.newBuilder
     val in = solution.in
     val gen = solution.problem.transferFunction
@@ -168,7 +168,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
                                         problem: DataFlowProblem[mutable.BitSet],
                                         method: Method,
                                         solution: Solution[mutable.BitSet]): Unit = {
-    val numberToNode = problem.flowGraph.asInstanceOf[ReachingDefFlowGraph].numberToNode
+    val numberToNode = problem.flowGraph.numberToNode
     implicit val dstGraph: DiffGraph.Builder = builder
     val exitNode = method.methodReturn
     val transferFunction = solution.problem.transferFunction.asInstanceOf[OptimizedReachingDefTransferFunction]

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/UsageAnalyzer.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/UsageAnalyzer.scala
@@ -17,7 +17,7 @@ import scala.collection.{Set, mutable}
   * */
 class UsageAnalyzer(problem: DataFlowProblem[mutable.BitSet], in: Map[StoredNode, Set[Definition]]) {
 
-  val numberToNode = problem.flowGraph.asInstanceOf[ReachingDefFlowGraph].numberToNode
+  val numberToNode = problem.flowGraph.numberToNode
   private val allNodes = in.keys.toList
   val usedIncomingDefs: Map[StoredNode, Map[StoredNode, Set[Definition]]] = initUsedIncomingDefs()
 


### PR DESCRIPTION
* Collapse `ReachingDefFlowGraph` into `FlowGraph`
* Use bitsets of node numbers for gen/kill
* Use a list for the worklist because otherwise we lose ordering
* Fix bug: method was returned multiple times in `reversePostOrder` (thanks, @johannescoetzee )

I am still running a few benchmarks before merging this.