### PR TITLE
Dedup Ast creation in presence of system header files

### DIFF
--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstCreator.scala
@@ -3,6 +3,7 @@ package io.shiftleft.c2cpg.astcreation
 import io.shiftleft.c2cpg.C2Cpg
 import io.shiftleft.c2cpg.datastructures.Stack._
 import io.shiftleft.c2cpg.datastructures.{Global, Scope}
+import io.shiftleft.c2cpg.parser.FileDefaults
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EvaluationStrategies, NodeTypes}
 import io.shiftleft.passes.DiffGraph
@@ -12,7 +13,59 @@ import io.shiftleft.x2cpg.Ast
 import org.eclipse.cdt.core.dom.ast.IASTTranslationUnit
 import org.slf4j.{Logger, LoggerFactory}
 
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
+
+object AstCreator {
+  // we cache our previously created CPG Sub-ASTs by (filename, linenumber, columnnumber)
+  private val newAstCache: TrieMap[(String, Int, Int), Seq[Ast]] = TrieMap.empty
+
+  def getAstsFromAstCache(filename: String,
+                          linenumber: Option[Integer],
+                          columnnumber: Option[Integer],
+                          astCreatorFunction: => Seq[Ast]): Seq[Ast] = this.synchronized {
+    if (FileDefaults.isHeaderFile(filename) && linenumber.isDefined && columnnumber.isDefined) {
+      if (filename.endsWith("stdio.h") && linenumber.get == 213 && columnnumber.get == 11) {
+        println("Get: " + filename + " " + linenumber.get + " " + columnnumber.get)
+        println("Contains: " + newAstCache.contains((filename, 213, 11)))
+      }
+      // newAstCache.getOrElseUpdate((filename, linenumber.get, columnnumber.get), astCreatorFunction)
+      if (newAstCache.contains((filename, linenumber.get, columnnumber.get))) {
+        newAstCache((filename, linenumber.get, columnnumber.get))
+      } else {
+        if (filename.endsWith("stdio.h") && linenumber.get == 213 && columnnumber.get == 11) {
+          println("Adding for: " + filename + " " + linenumber.get + " " + columnnumber.get)
+        }
+        val value = astCreatorFunction
+        newAstCache((filename, linenumber.get, columnnumber.get)) = value.map(_.copy(addNodes = false))
+        value
+      }
+    } else { astCreatorFunction }
+  }
+
+  def getAstFromAstCache(filename: String,
+                         linenumber: Option[Integer],
+                         columnnumber: Option[Integer],
+                         astCreatorFunction: => Ast): Ast = this.synchronized {
+    if (FileDefaults.isHeaderFile(filename) && linenumber.isDefined && columnnumber.isDefined) {
+      // newAstCache.getOrElseUpdate((filename, linenumber.get, columnnumber.get), Seq(astCreatorFunction)).head
+      if (filename.endsWith("stdio.h") && linenumber.get == 213 && columnnumber.get == 11) {
+        println("Get: " + filename + " " + linenumber.get + " " + columnnumber.get)
+        println("Contains: " + newAstCache.contains((filename, 213, 11)))
+      }
+      if (newAstCache.contains((filename, linenumber.get, columnnumber.get))) {
+        newAstCache((filename, linenumber.get, columnnumber.get)).head
+      } else {
+        if (filename.endsWith("stdio.h") && linenumber.get == 213 && columnnumber.get == 11) {
+          println("Adding for: " + filename + " " + linenumber.get + " " + columnnumber.get)
+        }
+        val value = astCreatorFunction
+        newAstCache((filename, linenumber.get, columnnumber.get)) = Seq(value.copy(addNodes = false))
+        value
+      }
+    } else { astCreatorFunction }
+  }
+}
 
 class AstCreator(val filename: String,
                  val global: Global,

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -85,10 +85,10 @@ trait AstForExpressionsCreator {
       case unaryExpression: IASTUnaryExpression if unaryExpression.getOperand.isInstanceOf[IASTUnaryExpression] =>
         astForUnaryExpression(unaryExpression.getOperand.asInstanceOf[IASTUnaryExpression], 0)
       case lambdaExpression: ICPPASTLambdaExpression =>
-        val methodRef = methodRefForLambda(lambdaExpression)
-        methodRef.order = 0
-        methodRef.argumentIndex = 0
-        Ast(methodRef)
+        val methodRefAst = astForMethodRefForLambda(lambdaExpression)
+        methodRefAst.root.get.asInstanceOf[NewMethodRef].order = 0
+        methodRefAst.root.get.asInstanceOf[NewMethodRef].argumentIndex = 0
+        methodRefAst
       case other => astForExpression(other, 0)
     }
 
@@ -324,7 +324,7 @@ trait AstForExpressionsCreator {
       case delExpression: ICPPASTDeleteExpression             => astForDeleteExpression(delExpression, order)
       case typeIdInit: IASTTypeIdInitializerExpression        => astForTypeIdInitExpression(typeIdInit, order)
       case c: ICPPASTSimpleTypeConstructorExpression          => astForConstructorExpression(c, order)
-      case lambdaExpression: ICPPASTLambdaExpression          => Ast(methodRefForLambda(lambdaExpression))
+      case lambdaExpression: ICPPASTLambdaExpression          => astForMethodRefForLambda(lambdaExpression)
       case compoundExpression: IGNUASTCompoundStatementExpression =>
         astForCompoundStatementExpression(compoundExpression, order)
       case packExpansionExpression: ICPPASTPackExpansionExpression =>

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/CdtParser.scala
@@ -42,8 +42,7 @@ class CdtParser(private val parseConfig: ParserConfig, private val headerFileFin
   private val opts: Int = ILanguage.OPTION_PARSE_INACTIVE_CODE
 
   private def createParseLanguage(file: Path): ILanguage = {
-    val fileAsString = file.toString
-    if (fileAsString.endsWith(FileDefaults.CPP_EXT) || fileAsString.endsWith(FileDefaults.CPP_HEADER_EXT)) {
+    if (FileDefaults.isCPPFile(file.toString)) {
       new GPPLanguage()
     } else {
       new GCCLanguage()

--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/FileDefaults.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/parser/FileDefaults.scala
@@ -10,4 +10,13 @@ object FileDefaults {
 
   val SOURCE_FILE_EXTENSIONS = Set(C_EXT, CC_EXT, CPP_EXT, C_HEADER_EXT, CPP_HEADER_EXT)
 
+  val HEADER_FILE_EXTENSIONS = Set(C_HEADER_EXT, CPP_HEADER_EXT)
+
+  val CPP_FILE_EXTENSIONS = Set(CPP_EXT, CPP_HEADER_EXT)
+
+  def isHeaderFile(filePath: String): Boolean =
+    HEADER_FILE_EXTENSIONS.exists(filePath.endsWith)
+
+  def isCPPFile(filePath: String): Boolean =
+    CPP_FILE_EXTENSIONS.exists(filePath.endsWith)
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.passes
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.nodes.{AbstractNode, NewNode, StoredNode}
+import io.shiftleft.codepropertygraph.generated.nodes.{AbstractNode, Method, NewNode, StoredNode}
 import io.shiftleft.proto.cpg.Cpg.{DiffGraph => DiffGraphProto}
 import overflowdb._
 import overflowdb.traversal._
@@ -417,12 +417,16 @@ object DiffGraph {
       }
     }
     private def tryAddNodeInit(node: NewNode): Unit = {
+      if (node.properties.get("AST_PARENT_FULL_NAME").filter(_ == "fclose").isDefined) {
+        println(s"XXX0 about to add $node to the graph")
+        println("XXX1 existing fclosed method nodes: " + graph.nodes(Method.Label).has("NAME", "fclose").l)
+      }
       if (overlayNodeToOdbNode.get(node) == null) {
         val newNode = keyPool match {
           case Some(pool) => graph.addNode(pool.next, node.label).asInstanceOf[StoredNode]
           case None       => graph.addNode(node.label).asInstanceOf[StoredNode]
         }
-        inverseBuilder.onNewNode(newNode.asInstanceOf[StoredNode])
+        inverseBuilder.onNewNode(newNode)
         newNode.fromNewNode(node, mapping = nodeMapping)
         overlayNodeToOdbNode.put(node, newNode)
       }

--- a/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/Ast.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/Ast.scala
@@ -26,7 +26,7 @@ object Ast {
     ast.edges.foreach { edge =>
       edge.dst match {
         case n: NewMethod if n.name == "fclose" =>
-          println("Adding edge from " + edge.src.label + " to fclose: " + n)
+          println("Adding edge from " + edge.src.label + s" (${edge.src}) to fclose: " + n)
         case _ =>
       }
       diffGraph.addEdge(edge.src, edge.dst, EdgeTypes.AST)


### PR DESCRIPTION
This fails currently as e.g., method nodes are still added twice (2 edges from blocks from 2 files).

The reproduce:
Create a test folder with two .c files (e.g., `a.c` and `b.c`) with the following content:
```
#include<stdio.h>

int main() {
	printf("Hello World\n");
	return 0;
}
``` 

Run c2cpg:
```
./c2cpg.sh testfolder --output /tmp/cpg.bin --with-include-auto-discovery
```

This should print:
```
...
Get: /usr/include/stdio.h 213 11
Contains: false
Adding for: /usr/include/stdio.h 213 11
Get: /usr/include/stdio.h 213 11
Contains: true
Adding fclose: io.shiftleft.codepropertygraph.generated.nodes.NewMethod@4ef39ff6
Adding edge from BLOCK to fclose: io.shiftleft.codepropertygraph.generated.nodes.NewMethod@4ef39ff6
Adding edge from BLOCK to fclose: io.shiftleft.codepropertygraph.generated.nodes.NewMethod@4ef39ff6
...
```

Even so we only add the method once the following 2 edges result in 2 methods. This can be seen with:
Load the CPG within ocular and execute:
```
ocular> cpg.method.name("fclose").l 
res32: List[Method] = List(
  Method(
    id -> 1000513L,
    astParentFullName -> "fclose",
    astParentType -> "TYPE_DECL",
    binarySignature -> None,
    code -> "int fclose (FILE *__stream)",
    columnNumber -> Some(value = 11),
    columnNumberEnd -> Some(value = 34),
    depthFirstOrder -> 0,
    filename -> "/usr/include/stdio.h",
    fullName -> "fclose",
    hasMapping -> None,
    hash -> None,
    internalFlags -> 4,
    isExternal -> false,
    lineNumber -> Some(value = 213),
    lineNumberEnd -> Some(value = 213),
    name -> "fclose",
    order -> 100,
    signature -> "int fclose (FILE*)",
    varargParameter -> -1
  ),
  Method(
    id -> 1001019L,
    astParentFullName -> "fclose",
    astParentType -> "TYPE_DECL",
    binarySignature -> None,
    code -> "int fclose (FILE *__stream)",
    columnNumber -> Some(value = 11),
    columnNumberEnd -> Some(value = 34),
    depthFirstOrder -> 0,
    filename -> "/usr/include/stdio.h",
    fullName -> "fclose",
    hasMapping -> None,
    hash -> None,
    internalFlags -> 4,
    isExternal -> false,
    lineNumber -> Some(value = 213),
    lineNumberEnd -> Some(value = 213),
    name -> "fclose",
    order -> 100,
    signature -> "int fclose (FILE*)",
    varargParameter -> -1
  )
)
```



