### PR TITLE
Fix duplicate methods in allNodes(Reverse)PostOrder

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -48,13 +48,14 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph {
   val exitNode: StoredNode = method.methodReturn
 
   val allNodesReversePostOrder: List[StoredNode] =
-    List(entryNode) ++ method.parameter.toList ++ method.reversePostOrder.toList ++ List(exitNode)
+    List(entryNode) ++ method.parameter.toList ++ method.reversePostOrder.filter(_.id != entryNode.id).toList ++ List(
+      exitNode)
 
   val nodeToNumber: Map[StoredNode, Int] = allNodesReversePostOrder.zipWithIndex.map { case (x, i) => x -> i }.toMap
   val numberToNode: Map[Int, StoredNode] = allNodesReversePostOrder.zipWithIndex.map { case (x, i) => i -> x }.toMap
 
   lazy val allNodesPostOrder: List[StoredNode] =
-    List(exitNode) ++ method.postOrder.toList ++ method.parameter.toList ++ List(entryNode)
+    List(exitNode) ++ method.postOrder.filter(_.id != entryNode.id).toList ++ method.parameter.toList ++ List(entryNode)
 
   val succ: Map[StoredNode, List[StoredNode]] = initSucc(allNodesReversePostOrder)
   val pred: Map[StoredNode, List[StoredNode]] = initPred(allNodesReversePostOrder, method)


### PR DESCRIPTION
I noticed that `allNodesReversePostOrder` contained a duplicate `Method` node as it was added both as the entry node and the first node in the `method.reversePostOrder` list. This meant that there wasn't a direct correspondence between the `nodeToNumber` and `numberToNode` maps, as the method was deduplicated but the number index was not. For example, it would be possible to have something like:
```
numberToNode = Map(
  0 -> Method,
  1 -> Method,
  2 -> ...
)

// BUT

nodeToNumber = Map(
  Method -> 0,
  ... -> 2
)
```

I'm not sure if this actually caused any issues, but there could potentially be subtle bugs due to the potential inconsistent translations.