### PR TITLE
Make data flow engine more robust against strange CPGs

### DIFF
--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefPass.scala
@@ -7,7 +7,7 @@ import io.shiftleft.passes.{DiffGraph, ParallelCpgPass}
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.collection.{Set, mutable}
+import scala.collection.mutable
 
 /**
   * A pass that calculates reaching definitions ("data dependencies").
@@ -69,7 +69,7 @@ class ReachingDefPass(cpg: Cpg, maxNumberOfDefinitions: Int = 4000) extends Para
     val gen = solution.problem.transferFunction
       .asInstanceOf[ReachingDefTransferFunction]
       .gen
-      .withDefaultValue(Set())
+
     val allNodes = in.keys.toList
     val usageAnalyzer = new UsageAnalyzer(problem, in)
 

--- a/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
+++ b/dataflowengineoss/src/main/scala/io/shiftleft/dataflowengineoss/passes/reachingdef/ReachingDefProblem.scala
@@ -51,8 +51,10 @@ class ReachingDefFlowGraph(val method: Method) extends FlowGraph {
     List(entryNode) ++ method.parameter.toList ++ method.reversePostOrder.toList.filter(x =>
       x.id != entryNode.id && x.id != exitNode.id) ++ List(exitNode)
 
-  val nodeToNumber: Map[StoredNode, Int] = allNodesReversePostOrder.zipWithIndex.map { case (x, i) => x -> i }.toMap
-  val numberToNode: Map[Int, StoredNode] = allNodesReversePostOrder.zipWithIndex.map { case (x, i) => i -> x }.toMap
+  private val allNodesEvenUnreachable = allNodesReversePostOrder ++ method.cfgNode.l.filterNot(x =>
+    allNodesReversePostOrder.contains(x))
+  val nodeToNumber: Map[StoredNode, Int] = allNodesEvenUnreachable.zipWithIndex.map { case (x, i) => x -> i }.toMap
+  val numberToNode: Map[Int, StoredNode] = allNodesEvenUnreachable.zipWithIndex.map { case (x, i) => i -> x }.toMap
 
   lazy val allNodesPostOrder: List[StoredNode] = allNodesReversePostOrder.reverse
 


### PR DESCRIPTION
It seems there are CPGs where not all CFG nodes are reachable via `cfgNext`, and so, if we just add the reachable ones to `nodeToNumber` and `numberToNode`, we can't translate unreachable ones. To fix this, we now use `method.cfgNode.l` to retrieve all CFG nodes - whether reachable or not - and add the unreachable nodes to `nodeToNumber` and `numberToNode` as well.