### PR TITLE
Allow launching joern/ocular with cpg.bin parameter

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -290,9 +290,12 @@ trait BridgeBase {
     val actualScriptFile =
       if (isEncryptedScript) decryptedScript(scriptFile)
       else scriptFile
+    val importCpgCode = config.cpgToLoad.map { cpgFile =>
+      "importCpg(\"" + cpgFile + "\")"
+    }.toList
     ammonite
       .Main(
-        predefCode = predefPlus(additionalImportCode(config) ++ shutdownHooks),
+        predefCode = predefPlus(additionalImportCode(config) ++ importCpgCode ++ shutdownHooks),
         remoteLogging = false,
         colors = ammoniteColors(config)
       )


### PR DESCRIPTION
`joern <cpg.bin>` will start the interactive shell and immediately import the given CPG. If the CPG at this location has been loaded before, it is reloaded to ensure that it is up to date. This feature enables us to directly drop `joern-parse` and `joern-scan` users into an interactive session for the generated CPG.

The following now also works:
```
echo "cpg.method.foreach(println)" > foo.sc; ./joern cpg.bin --script foo.sc
```