### PR TITLE
Introduce `openForInputPath`

### DIFF
--- a/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
+++ b/console/src/main/scala/io/shiftleft/console/BridgeBase.scala
@@ -26,7 +26,7 @@ case class Config(
     serverAuthPassword: String = "",
     nocolors: Boolean = false,
     cpgToLoad: Option[File] = None,
-    projectToOpen: Option[String] = None
+    forInputPath: Option[String] = None
 )
 
 /**
@@ -126,7 +126,7 @@ trait BridgeBase {
         .text("CPG to load")
 
       opt[String]("for-input-path")
-        .action((x, c) => c.copy(projectToOpen = Some(x)))
+        .action((x, c) => c.copy(forInputPath = Some(x)))
         .text("Open CPG for given input path - overrides <cpg.bin>")
 
       opt[Unit]("nocolors")
@@ -213,9 +213,7 @@ trait BridgeBase {
         |   save
         | } else {
         |    println("Using existing CPG - Use `--overwrite` if this is not what you want")
-        |    workspace.projects
-        |    .filter(x => x.inputPath == "$src")
-        |    .map(_.name).map(open)
+        |    openForInputPath(\"$src\")
         | }
         | run.$bundleName
         | $storeCode
@@ -240,11 +238,9 @@ trait BridgeBase {
       "banner()"
     ) ++ config.cpgToLoad.map { cpgFile =>
       "importCpg(\"" + cpgFile + "\")"
-    } ++ config.projectToOpen.map { name =>
+    } ++ config.forInputPath.map { name =>
       s"""
-        |workspace.projects.
-        | filter(x => x.inputPath == "$name").
-        | map(_.name).map(open)
+        |openForInputPath(\"$name\")
         |""".stripMargin
     }
     ammonite

--- a/console/src/main/scala/io/shiftleft/console/Console.scala
+++ b/console/src/main/scala/io/shiftleft/console/Console.scala
@@ -149,7 +149,7 @@ class Console[T <: Project](executor: AmmoniteExecutor,
   }
 
   @Doc(
-    "Open project",
+    "Open project by name",
     """
       |open([projectName])
       |
@@ -169,6 +169,28 @@ class Console[T <: Project](executor: AmmoniteExecutor,
     workspace.openProject(projectName).map { project =>
       project
     }
+  }
+
+  @Doc(
+    "Open project for input path",
+    """
+      |openForInputPath([input-path])
+      |
+      |Opens the project of the CPG generated for the input path `input-path`.
+      |
+      |Upon completion of this operation, the CPG stored in this project
+      |can be queried via `cpg`. Returns an optional reference to the
+      |project, which is empty on error.
+      |""".stripMargin
+  )
+  def openForInputPath(inputPath: String): Option[Project] = {
+    val absInputPath = File(inputPath).path.toAbsolutePath.toString
+    workspace.projects
+      .filter(x => x.inputPath == absInputPath)
+      .map(_.name)
+      .map(open)
+      .headOption
+      .flatten
   }
 
   /**


### PR DESCRIPTION
Currently, we can only open a project by name and the name is generated from the input path. There are situations, e.g., when using `joern-scan` where we have access to the input path but not to the project name, and in fact, as part of joern-scan, we have been retrieving the project name manually from the input path. This PR introduces `openForInputPath` for this purpose and also exposes it via `./joern|ocular --for-input-path <input-path>`.