### PR TITLE
Fix: `Comment` needs to inherit from `AstNode`

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Comment.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Comment.scala
@@ -28,6 +28,7 @@ object Comment extends SchemaBase {
       )
       .protoId(511)
       .addProperties(lineNumber, code, filename)
+      .extendz(astNode)
 
 // node relations
     comment


### PR DESCRIPTION
Comments are included in the AST, but they are not AST nodes, causing crashes when using `.ast` as they cannot be cast to `AstNode`. This PR fixes the schema accordingly.