### PR TITLE
Improved DynamicCallLinker Performance

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
@@ -78,7 +78,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
         val directSubclasses =
           cpg.typ
             .nameExact(typDeclFullName)
-            .flatMap(_.in(EdgeTypes.INHERITS_FROM).asScala)
+            .flatMap(_.in(EdgeTypes.INHERITS_FROM))
             .collect {
               case x: TypeDecl =>
                 x.fullName


### PR DESCRIPTION
- Included class documentation
- Call edges are checked before being added
- Used `indexManager` if `FULL_NAME` is present for methods
- Uses a map with `FULL_NAME` and `TypeDecl` to be independent of `indexManager` until it's indexed by default