### PR TITLE
Added support for designated initializers and a Macro fix

### DIFF
--- a/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
+++ b/c2cpg/src/main/scala/io/shiftleft/c2cpg/astcreation/AstForExpressionsCreator.scala
@@ -291,11 +291,10 @@ trait AstForExpressionsCreator {
     val name = c.getDeclSpecifier.toString
     val callNode = newCallNode(c, name, name, DispatchTypes.STATIC_DISPATCH, order)
 
-    // TODO: how to represent the initializer here?
-    val arg = newUnknown(c.getInitializer, 1)
+    val arg = astForNode(c.getInitializer, 1)
 
-    val ast = Ast(callNode).withChild(Ast(arg))
-    ast.withArgEdge(callNode, arg)
+    val ast = Ast(callNode).withChild(arg)
+    if (arg.root.isDefined) { ast.withArgEdge(callNode, arg.root.get) } else ast
   }
 
   private def astForCompoundStatementExpression(compoundExpression: IGNUASTCompoundStatementExpression,


### PR DESCRIPTION
This eliminates all remaining warnings about unsupported AST elements for VLC.

Explanation for the fix for macro call generation:
We need to wrap the copied AST as it may contain CPG nodes not being allowed to be connected via AST edges under a CALL. E.g., LOCALs.

As an example see: `/usr/include/c++/11.1.0/bits/exception_defines.h` (line 35)
```
# define __try      if (true)
```

A simple copy of the AST for the block directly under the `if` may contain LOCALs. They would end up as AST children under the new CALL `__try`
which would result in an invalid CPG crashing certain backend passes.