### PR TITLE
Use order to classify TRY children

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -504,8 +504,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraph.Builder) {
       Traversal
         .fromSingle(node)
         .astChildren
-        .where(_.orderGt(1))
-        .where(_.codeNot("finally"))
+        .where(_.order(2))
         .toList match {
         case Nil  => List(Cfg.empty)
         case asts => asts.map(cfgFor)
@@ -515,7 +514,7 @@ class CfgCreator(entryNode: Method, diffGraph: DiffGraph.Builder) {
       Traversal
         .fromSingle(node)
         .astChildren
-        .where(_.codeExact("finally"))
+        .where(_.order(3))
         .map(cfgFor)
         .headOption // Assume there can only be one
         .toList


### PR DESCRIPTION
Revert to using the node order to classify the children of a `try` node as the try, catch or finally body. 

The previous approach used a `finally` tag in the code field of a block to classify it as a finally, but implementing this in `js2cpg` is more complicated than fixing the order in `javasrc2cpg`. C++ should be unaffected, since it doesn't support `finally` blocks in any case.