### PR TITLE
Write INFO and lower logs to file instead of console when running tests

### DIFF
--- a/resources/log4j2-test.xml
+++ b/resources/log4j2-test.xml
@@ -4,6 +4,9 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="[%-5p] %m%n" />
         </Console>
+        <File name="FileAppender" fileName="${sys:user.dir}/logs/cpg.log">
+            <PatternLayout pattern="[%-5p] %m%n" />
+        </File>
     </Appenders>
     <Loggers>
         <Logger name="org.reflections8.Reflections" level="error"/>
@@ -12,8 +15,9 @@
         <Logger name="io.shiftleft.codepropertygraph.cpgloading" level="error"/>
         <Logger name="io.shiftleft.console.scripting" level="error"/>
 
-        <Root level="info">
-            <AppenderRef ref="Console" />
+        <Root level="all">
+            <AppenderRef ref="FileAppender" level="trace" />
+            <AppenderRef ref="Console" level="error" />
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
The CPG logs are currently written to the console when running tests, which is quite noisy and makes it difficult to identify test failures from `sbt test` output. With this change, only `ERROR` level logs are output to the console, while the rest of the logs are written to a file instead.

Another option I considered was dropping these logs to `DEBUG` and only printing `INFO` or higher logs. This is a perfectly fine option too, although having these logs available is nice as a cheap means of profiling.