### PR TITLE
Cleanup node starter steps

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -19,6 +19,36 @@ class NodeTypeStarters(cpg: Cpg) {
     cpg.graph.nodes.cast[StoredNode]
 
   /**
+  Traverse to all arguments passed to methods
+    */
+  @Doc("All arguments (actual parameters)")
+  def argument: Traversal[Expression] =
+    call.argument
+
+  /**
+    * Shorthand for `cpg.argument.code(code)`
+    * */
+  def argument(code: String): Traversal[Expression] =
+    argument.code(code)
+
+  @Doc("All breaks (`ControlStructure` nodes)")
+  def break: Traversal[ControlStructure] =
+    controlStructure.isBreak
+
+  /**
+  Traverse to all call sites
+    */
+  @Doc("All call sites")
+  def call: Traversal[Call] =
+    cpg.graph.nodes(NodeTypes.CALL).cast[Call]
+
+  /**
+    * Shorthand for `cpg.call.name(name)`
+    * */
+  def call(name: String): Traversal[Call] =
+    call.name(name)
+
+  /**
     * Traverse to all comments in source-based CPGs.
     * */
   @Doc("All comments in source-based CPGs")
@@ -35,52 +65,24 @@ class NodeTypeStarters(cpg: Cpg) {
   def controlStructure: Traversal[ControlStructure] =
     cpg.graph.nodes(NodeTypes.CONTROL_STRUCTURE).cast[ControlStructure]
 
-  @Doc("All try blocks (`ControlStructure` nodes)")
-  def tryBlock: Traversal[ControlStructure] =
-    controlStructure.isTry
-
-  @Doc("All if blocks (`ControlStructure` nodes)")
-  def ifBlock: Traversal[ControlStructure] =
-    controlStructure.isIf
-
-  @Doc("All else blocks (`ControlStructure` nodes)")
-  def elseBlock: Traversal[ControlStructure] =
-    controlStructure.isElse
-
-  @Doc("All switch blocks (`ControlStructure` nodes)")
-  def switchBlock: Traversal[ControlStructure] =
-    controlStructure.isSwitch
+  @Doc("All continues (`ControlStructure` nodes)")
+  def continue: Traversal[ControlStructure] =
+    controlStructure.isContinue
 
   @Doc("All do blocks (`ControlStructure` nodes)")
   def doBlock: Traversal[ControlStructure] =
     controlStructure.isDo
 
-  @Doc("All for blocks (`ControlStructure` nodes)")
-  def forBlock: Traversal[ControlStructure] =
-    controlStructure.isFor
-
-  @Doc("All while blocks (`ControlStructure` nodes)")
-  def whileBlock: Traversal[ControlStructure] =
-    controlStructure.isWhile
-
-  @Doc("All gotos (`ControlStructure` nodes)")
-  def goto: Traversal[ControlStructure] =
-    controlStructure.isGoto
-
-  @Doc("All breaks (`ControlStructure` nodes)")
-  def break: Traversal[ControlStructure] =
-    controlStructure.isBreak
-
-  @Doc("All continues (`ControlStructure` nodes)")
-  def continue: Traversal[ControlStructure] =
-    controlStructure.isContinue
+  @Doc("All else blocks (`ControlStructure` nodes)")
+  def elseBlock: Traversal[ControlStructure] =
+    controlStructure.isElse
 
   @Doc("All throws (`ControlStructure` nodes)")
   def throws: Traversal[ControlStructure] =
     controlStructure.isThrow
 
   /**
-    Traverse to all source files
+  Traverse to all source files
     */
   @Doc("All source files")
   def file: Traversal[File] =
@@ -92,12 +94,131 @@ class NodeTypeStarters(cpg: Cpg) {
   def file(name: String): Traversal[File] =
     file.name(name)
 
+  @Doc("All for blocks (`ControlStructure` nodes)")
+  def forBlock: Traversal[ControlStructure] =
+    controlStructure.isFor
+
+  @Doc("All gotos (`ControlStructure` nodes)")
+  def goto: Traversal[ControlStructure] =
+    controlStructure.isGoto
+
+  /**
+  Begin traversal at node with id.
+    */
+  def id[NodeType <: StoredNode](anId: Long): Traversal[NodeType] =
+    cpg.graph.nodes(anId).cast[NodeType]
+
+  /**
+  Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
+    */
+  @Doc("All identifier usages")
+  def identifier: Traversal[Identifier] =
+    cpg.graph.nodes(NodeTypes.IDENTIFIER).cast[Identifier]
+
+  /**
+  Begin traversal at set of nodes - specified by their ids
+    */
+  def id[NodeType <: StoredNode](ids: Seq[Long]): Traversal[NodeType] =
+    if (ids.isEmpty) Traversal.empty
+    else cpg.graph.nodes(ids: _*).cast[NodeType]
+
+  /**
+    * Shorthand for `cpg.identifier.name(name)`
+    * */
+  def identifier(name: String): Traversal[Identifier] =
+    identifier.name(name)
+
+  @Doc("All if blocks (`ControlStructure` nodes)")
+  def ifBlock: Traversal[ControlStructure] =
+    controlStructure.isIf
+
   /**
     * Traverse to all jump targets
     * */
   @Doc("All jump targets, i.e., labels")
   def jumpTarget: Traversal[JumpTarget] =
     cpg.graph.nodes(NodeTypes.JUMP_TARGET).cast[JumpTarget]
+
+  /**
+  Traverse to all local variable declarations
+    */
+  @Doc("All local variables")
+  def local: Traversal[Local] =
+    cpg.graph.nodes(NodeTypes.LOCAL).cast[Local]
+
+  /**
+    * Shorthand for `cpg.local.name`
+    * */
+  def local(name: String): Traversal[Local] =
+    local.name(name)
+
+  /**
+  Traverse to all literals (constant strings and numbers provided directly in the code).
+    */
+  @Doc("All literals, e.g., numbers or strings")
+  def literal: Traversal[Literal] =
+    cpg.graph.nodes(NodeTypes.LITERAL).cast[Literal]
+
+  /**
+    * Shorthand for `cpg.literal.code(code)`
+    * */
+  def literal(code: String): Traversal[Literal] =
+    literal.code(code)
+
+  /**
+  Traverse to all methods
+    */
+  @Doc("All methods")
+  def method: Traversal[Method] =
+    cpg.graph.nodes(NodeTypes.METHOD).cast[Method]
+
+  /**
+    * Shorthand for `cpg.method.name(fullName)`
+    * */
+  @Doc("All methods with given name")
+  def method(name: String): Traversal[Method] =
+    method.name(name)
+
+  /**
+  Traverse to all formal return parameters
+    */
+  @Doc("All formal return parameters")
+  def methodReturn: Traversal[MethodReturn] =
+    cpg.graph.nodes(NodeTypes.METHOD_RETURN).cast[MethodReturn]
+
+  /**
+  Traverse to all class members
+    */
+  @Doc("All members of complex types (e.g., classes/structures)")
+  def member: Traversal[Member] =
+    cpg.graph.nodes(NodeTypes.MEMBER).cast[Member]
+
+  /**
+    * Shorthand for `cpg.member.name(name)`
+    * */
+  def member(name: String): Traversal[Member] =
+    member.name(name)
+
+  /**
+    * Traverse to all meta data entries
+    */
+  @Doc("Meta data blocks for graph")
+  def metaData: Traversal[MetaData] =
+    cpg.graph.nodes(NodeTypes.META_DATA).cast[MetaData]
+
+  /**
+    * Traverse to all method references
+    * */
+  @Doc("All method references")
+  def methodRef: Traversal[MethodRef] =
+    cpg.graph.nodes(NodeTypes.METHOD_REF).cast[MethodRef]
+
+  /**
+    * Shorthand for `cpg.methodRef
+    * .filter(_.referencedMethod.name(name))`
+    * */
+  def methodRef(name: String): Traversal[MethodRef] =
+    methodRef.where(_.referencedMethod.name(name))
 
   /**
     Traverse to all namespaces, e.g., packages in Java.
@@ -125,67 +246,7 @@ class NodeTypeStarters(cpg: Cpg) {
     namespaceBlock.name(name)
 
   /**
-  Traverse to all types, e.g., Set<String>
-    */
-  @Doc("All used types")
-  def typ: Traversal[Type] =
-    cpg.graph.nodes(NodeTypes.TYPE).cast[Type]
-
-  /**
-    * Shorthand for `cpg.types.fullName(fullName)`
-    * */
-  def typ(fullName: String): Traversal[Type] =
-    typ.fullName(fullName)
-
-  /**
-    Traverse to all types, e.g., Set<String>
-    */
-  @deprecated("Use typ")
-  def types: Traversal[Type] =
-    cpg.graph.nodes(NodeTypes.TYPE).cast[Type]
-
-  /**
-    * Shorthand for `cpg.types.fullName(fullName)`
-    * */
-  @deprecated("Use typ")
-  def types(fullName: String): Traversal[Type] =
-    typ.fullName(fullName)
-
-  /**
-    Traverse to all declarations, e.g., Set<T>
-    */
-  @Doc("All declarations of types")
-  def typeDecl: Traversal[TypeDecl] =
-    cpg.graph.nodes(NodeTypes.TYPE_DECL).cast[TypeDecl]
-
-  /**
-    * Shorthand for cpg.typeDecl.fullName(fullName)
-    * */
-  def typeDecl(fullName: String): Traversal[TypeDecl] =
-    typeDecl.fullName(fullName)
-
-  /**
-    Traverse to all methods
-    */
-  @Doc("All methods")
-  def method: Traversal[Method] =
-    cpg.graph.nodes(NodeTypes.METHOD).cast[Method]
-
-  /**
-    * Shorthand for `cpg.method.fullName(fullName)`
-    * */
-  def method(fullName: String): Traversal[Method] =
-    method.fullName(fullName)
-
-  /**
-    Traverse to all formal return parameters
-    */
-  @Doc("All formal return parameters")
-  def methodReturn: Traversal[MethodReturn] =
-    cpg.graph.nodes(NodeTypes.METHOD_RETURN).cast[MethodReturn]
-
-  /**
-    Traverse to all input parameters
+  Traverse to all input parameters
     */
   @Doc("All parameters")
   def parameter: Traversal[MethodParameterIn] =
@@ -196,85 +257,6 @@ class NodeTypeStarters(cpg: Cpg) {
     * */
   def parameter(name: String): Traversal[MethodParameterIn] =
     parameter.name(name)
-
-  /**
-    Traverse to all class members
-    */
-  @Doc("All members of complex types (e.g., classes/structures)")
-  def member: Traversal[Member] =
-    cpg.graph.nodes(NodeTypes.MEMBER).cast[Member]
-
-  /**
-    * Shorthand for `cpg.member.name(name)`
-    * */
-  def member(name: String): Traversal[Member] =
-    member.name(name)
-
-  /**
-    Traverse to all call sites
-    */
-  @Doc("All call sites")
-  def call: Traversal[Call] =
-    cpg.graph.nodes(NodeTypes.CALL).cast[Call]
-
-  /**
-    * Shorthand for `cpg.call.name(name)`
-    * */
-  def call(name: String): Traversal[Call] =
-    call.name(name)
-
-  /**
-    Traverse to all local variable declarations
-
-    */
-  @Doc("All local variables")
-  def local: Traversal[Local] =
-    cpg.graph.nodes(NodeTypes.LOCAL).cast[Local]
-
-  /**
-    * Shorthand for `cpg.local.name`
-    * */
-  def local(name: String): Traversal[Local] =
-    local.name(name)
-
-  /**
-    Traverse to all literals (constant strings and numbers provided directly in the code).
-    */
-  @Doc("All literals, e.g., numbers or strings")
-  def literal: Traversal[Literal] =
-    cpg.graph.nodes(NodeTypes.LITERAL).cast[Literal]
-
-  /**
-    * Shorthand for `cpg.literal.code(code)`
-    * */
-  def literal(code: String): Traversal[Literal] =
-    literal.code(code)
-
-  /**
-    Traverse to all identifiers, e.g., occurrences of local variables or class members in method bodies.
-    */
-  @Doc("All identifier usages")
-  def identifier: Traversal[Identifier] =
-    cpg.graph.nodes(NodeTypes.IDENTIFIER).cast[Identifier]
-
-  /**
-    * Shorthand for `cpg.identifier.name(name)`
-    * */
-  def identifier(name: String): Traversal[Identifier] =
-    identifier.name(name)
-
-  /**
-    Traverse to all arguments passed to methods
-    */
-  @Doc("All arguments (actual parameters)")
-  def argument: Traversal[Expression] =
-    call.argument
-
-  /**
-    * Shorthand for `cpg.argument.code(code)`
-    * */
-  def argument(code: String): Traversal[Expression] =
-    argument.code(code)
 
   /**
     * Traverse to all return expressions
@@ -289,61 +271,40 @@ class NodeTypeStarters(cpg: Cpg) {
   def ret(code: String): Traversal[Return] =
     ret.code(code)
 
+  @Doc("All switch blocks (`ControlStructure` nodes)")
+  def switchBlock: Traversal[ControlStructure] =
+    controlStructure.isSwitch
+
+  @Doc("All try blocks (`ControlStructure` nodes)")
+  def tryBlock: Traversal[ControlStructure] =
+    controlStructure.isTry
+
   /**
-    * Traverse to all return expressions
+  Traverse to all types, e.g., Set<String>
     */
-  @deprecated("Use ret")
-  def returns: Traversal[Return] =
-    cpg.graph.nodes(NodeTypes.RETURN).cast[Return]
+  @Doc("All used types")
+  def typ: Traversal[Type] =
+    cpg.graph.nodes(NodeTypes.TYPE).cast[Type]
 
   /**
-    * Shorthand for `returns.code(code)`
+    * Shorthand for `cpg.typ.name(name)`
     * */
-  @deprecated("Use ret")
-  def returns(code: String): Traversal[Return] =
-    ret.code(code)
+  @Doc("All used types with given name")
+  def typ(name: String): Traversal[Type] =
+    typ.fullName(name)
 
   /**
-    * Traverse to all meta data entries
+  Traverse to all declarations, e.g., Set<T>
     */
-  @Doc("Meta data blocks for graph")
-  def metaData: Traversal[MetaData] =
-    cpg.graph.nodes(NodeTypes.META_DATA).cast[MetaData]
+  @Doc("All declarations of types")
+  def typeDecl: Traversal[TypeDecl] =
+    cpg.graph.nodes(NodeTypes.TYPE_DECL).cast[TypeDecl]
 
   /**
-    * Traverse to all method references
+    * Shorthand for cpg.typeDecl.name(name)
     * */
-  @Doc("All method references")
-  def methodRef: Traversal[MethodRef] =
-    cpg.graph.nodes(NodeTypes.METHOD_REF).cast[MethodRef]
-
-  /**
-    * Traverse to all type references
-    * */
-  @Doc("All type references")
-  def typeRef: Traversal[TypeRef] =
-    cpg.graph.nodes(NodeTypes.TYPE_REF).cast[TypeRef]
-
-  /**
-    * Shorthand for `cpg.methodRef
-    * .filter(_.referencedMethod.fullName(fullName))`
-    * */
-  def methodRef(fullName: String): Traversal[MethodRef] =
-    methodRef.where(_.referencedMethod.fullName(fullName))
-
-  /**
-  Begin traversal at node with id.
-    */
-  def id[NodeType <: StoredNode](anId: Long): Traversal[NodeType] = {
-    cpg.graph.nodes(anId).cast[NodeType]
-  }
-
-  /**
-  Begin traversal at set of nodes - specified by their ids
-    */
-  def id[NodeType <: StoredNode](ids: Seq[Long]): Traversal[NodeType] =
-    if (ids.isEmpty) Traversal.empty
-    else cpg.graph.nodes(ids: _*).cast[NodeType]
+  def typeDecl(name: String): Traversal[TypeDecl] =
+    typeDecl.name(name)
 
   /**
   Traverse to all tags
@@ -355,5 +316,16 @@ class NodeTypeStarters(cpg: Cpg) {
   @Doc("All tags with given name")
   def tag(name: String): Traversal[Tag] =
     tag.name(name)
+
+  /**
+    * Traverse to all type references
+    * */
+  @Doc("All type references")
+  def typeRef: Traversal[TypeRef] =
+    cpg.graph.nodes(NodeTypes.TYPE_REF).cast[TypeRef]
+
+  @Doc("All while blocks (`ControlStructure` nodes)")
+  def whileBlock: Traversal[ControlStructure] =
+    controlStructure.isWhile
 
 }


### PR DESCRIPTION
* Remove starter steps that have been deprecated for over a year
* Sort steps by name
* Be consistent about using `name` as opposed to `fullName` in starter steps that accept a name

This may require downstream adaptions. Checking.