### PR TITLE
Add control structure type `throw`

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -297,7 +297,7 @@ object Ast extends SchemaBase {
         valueType = ValueType.String,
         comment = """The `CONTROL_STRUCTURE_TYPE` field indicates which kind of control structure
             |a `CONTROL_STRUCTURE` node represents. The available types are the following:
-            | BREAK, CONTINUE, DO, WHILE, FOR, GOTO, IF, ELSE, TRY, and SWITCH.
+            | BREAK, CONTINUE, DO, WHILE, FOR, GOTO, IF, ELSE, TRY, THROW and SWITCH.
             |""".stripMargin
       )
       .mandatory(PropertyDefaults.String)
@@ -337,6 +337,8 @@ object Ast extends SchemaBase {
                comment = "Represents a switch statement").protoId(9),
       Constant(name = "TRY", value = "TRY", valueType = ValueTypes.STRING, comment = "Represents a try statement")
         .protoId(10),
+      Constant(name = "THROW", value = "THROW", valueType = ValueTypes.STRING, comment = "Represents a throw statement")
+        .protoId(11)
     )
 
     val controlStructure: NodeType = builder

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -75,6 +75,10 @@ class NodeTypeStarters(cpg: Cpg) {
   def continue: Traversal[ControlStructure] =
     controlStructure.isContinue
 
+  @Doc("All throws (`ControlStructure` nodes)")
+  def throws: Traversal[ControlStructure] =
+    controlStructure.isThrow
+
   /**
     Traverse to all source files
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -70,4 +70,8 @@ class ControlStructureTraversal(val traversal: Traversal[ControlStructure]) exte
   def isContinue: Traversal[ControlStructure] =
     traversal.controlStructureTypeExact(ControlStructureTypes.CONTINUE)
 
+  @Doc("Only `Throw` control structures")
+  def isThrow: Traversal[ControlStructure] =
+    traversal.controlStructureTypeExact(ControlStructureTypes.THROW)
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -80,6 +80,10 @@ class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
   def continue: Traversal[ControlStructure] =
     controlStructure.isContinue
 
+  @Doc("All throws (`ControlStructure` nodes)")
+  def throws: Traversal[ControlStructure] =
+    controlStructure.isThrow
+
   /**
     * The type declaration associated with this method, e.g., the class it is defined in.
     * */


### PR DESCRIPTION
The current approach for handling throws is to represent them as a call to a throw operator. The behaviour of a `throw statement is closer to a control structure (specifically `break` and `continue`), however, so it makes more sense to represent this as a CS instead of a call.