### PR TITLE
github actions: run release builds sequentially

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,6 +29,7 @@ jobs:
       if: ${{ failure() }}
 
   release:
+    concurrency: release
     needs: [test-codepropertygraph]
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
Giving the release workflow a unique name (`release`) should lead to
making it non-parallel.

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency
