### PR TITLE
Pick up line number end in MethodStubCreator

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/base/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/base/MethodStubCreator.scala
@@ -54,7 +54,8 @@ class MethodStubCreator(cpg: Cpg) extends ParallelCpgPass[(NameAndSignature, Int
       val filename = s(0)
       val lineNumber = s(1).toInt
       val lineNumberEnd = s(2).toInt
-      methodNode.filename(filename)
+      methodNode
+        .filename(filename)
         .lineNumber(lineNumber)
         .lineNumberEnd(lineNumberEnd)
     } else {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/base/MethodStubCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/base/MethodStubCreator.scala
@@ -48,30 +48,36 @@ class MethodStubCreator(cpg: Cpg) extends ParallelCpgPass[(NameAndSignature, Int
     Iterator(dstGraph.build())
   }
 
+  private def addLineNumberInfo(methodNode: NewMethod, fullName: String): NewMethod = {
+    val s = fullName.split(":")
+    if (s.size == 5 && Try { s(1).toInt }.isSuccess && Try { s(2).toInt }.isSuccess) {
+      val filename = s(0)
+      val lineNumber = s(1).toInt
+      val lineNumberEnd = s(2).toInt
+      methodNode.filename(filename)
+        .lineNumber(lineNumber)
+        .lineNumberEnd(lineNumberEnd)
+    } else {
+      methodNode
+    }
+  }
+
   private def createMethodStub(name: String,
                                fullName: String,
                                signature: String,
                                parameterCount: Int,
                                dstGraph: DiffGraph.Builder): MethodBase = {
-    val methodNode1 = NewMethod()
-      .name(name)
-      .fullName(fullName)
-      .isExternal(true)
-      .signature(signature)
-      .astParentType(NodeTypes.NAMESPACE_BLOCK)
-      .astParentFullName("<global>")
-      .order(0)
-
-    val methodNode = {
-      val s = fullName.split(":")
-      if (s.size == 4 && Try { s(1).toInt }.isSuccess) {
-        val filename = s(0)
-        val lineNumber = s(1).toInt
-        methodNode1.filename(filename).lineNumber(lineNumber)
-      } else {
-        methodNode1
-      }
-    }
+    val methodNode = addLineNumberInfo(
+      NewMethod()
+        .name(name)
+        .fullName(fullName)
+        .isExternal(true)
+        .signature(signature)
+        .astParentType(NodeTypes.NAMESPACE_BLOCK)
+        .astParentFullName("<global>")
+        .order(0),
+      fullName
+    )
 
     dstGraph.addNode(methodNode)
 


### PR DESCRIPTION
Method full names of call nodes are inspected in the `MethodStubCreator` already to create the correct line number field for the method stub. With this PR, we allow/require an additional line number end field in the method full name. This enables `.dump` on METHOD nodes for macros created by c2cpg.