### PR TITLE
Introduce utility step `address`

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -142,6 +142,18 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
     case _: Expression | _: JumpTarget           => walkUpContains(node)
   }
 
+  /**
+    * Obtain hexadecimal string representation of lineNumber field.
+    *
+    * Binary frontends store addresses in the lineNumber field as
+    * integers. For interoperability with other binary analysis
+    * tooling, it is convenient to allow retrieving these as
+    * hex strings.
+    * */
+  def address: Option[String] = {
+    node.lineNumber.map(_.toLong.toHexString)
+  }
+
   private def walkUpAst(node: CfgNode): Method =
     node._astIn.onlyChecked.asInstanceOf[Method]
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -54,6 +54,16 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
       .cast[CfgNode]
 
   /**
+    * All nodes reachable in the CFG by up to n forward expansions
+    */
+  def cfgNext(n: Int): Traversal[CfgNode] = traversal.flatMap(_.cfgNext(n))
+
+  /**
+    * All nodes reachable in the CFG by up to n backward expansions
+    */
+  def cfgPrev(n: Int): Traversal[CfgNode] = traversal.flatMap(_.cfgPrev(n))
+
+  /**
     * Recursively determine all nodes on which any of
     * the nodes in this traversal are control dependent
     * */
@@ -100,5 +110,12 @@ class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal
   @Doc("All nodes that are post dominated by this node")
   def postDominates: Traversal[CfgNode] =
     traversal.flatMap(_.postDominates)
+
+  /**
+    * Obtain hexadecimal string representation of lineNumber field.
+    */
+  @Doc("Address of the code (for binary code)")
+  def address: Traversal[Option[String]] =
+    traversal.map(_.address)
 
 }


### PR DESCRIPTION
+ add two methods I forgot in the previous PR: `cfgNext` and `cfgPrev` on traversals.