### PR TITLE
Dynamic Call Linker Fallback for Method Stubs

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
@@ -17,10 +17,10 @@ object CallGraph {
     Iterator(
       new MethodRefLinker(cpg),
       new StaticCallLinker(cpg),
-    ) ++ cpg.metaData.language.lastOption match {
+    ) ++ (cpg.metaData.language.lastOption match {
       case Some(Languages.C) => Iterator[CpgPassBase]()
       case _                 => Iterator[CpgPassBase](new DynamicCallLinker(cpg))
-    }
+    })
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
@@ -1,7 +1,9 @@
 package io.shiftleft.semanticcpg.layers
 
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPassBase
+import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.callgraph.{DynamicCallLinker, MethodRefLinker, StaticCallLinker}
 
 import scala.annotation.nowarn

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.layers
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.CpgPassBase
-import io.shiftleft.semanticcpg.passes.callgraph.{MethodRefLinker, StaticCallLinker}
+import io.shiftleft.semanticcpg.passes.callgraph.{DynamicCallLinker, MethodRefLinker, StaticCallLinker}
 
 import scala.annotation.nowarn
 
@@ -11,10 +11,15 @@ object CallGraph {
   val description: String = "Call graph layer"
   def defaultOpts = new LayerCreatorOptions()
 
-  def passes(cpg: Cpg): Iterator[CpgPassBase] = Iterator(
-    new MethodRefLinker(cpg),
-    new StaticCallLinker(cpg),
-  )
+  def passes(cpg: Cpg): Iterator[CpgPassBase] = {
+    Iterator(
+      new MethodRefLinker(cpg),
+      new StaticCallLinker(cpg),
+    ) ++ cpg.metaData.language.lastOption match {
+      case Some(Languages.C) => Iterator[CpgPassBase]()
+      case _                 => Iterator[CpgPassBase](new DynamicCallLinker(cpg))
+    }
+  }
 
 }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
@@ -1,9 +1,7 @@
 package io.shiftleft.semanticcpg.layers
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.passes.CpgPassBase
-import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.callgraph.{DynamicCallLinker, MethodRefLinker, StaticCallLinker}
 
 import scala.annotation.nowarn
@@ -17,10 +15,8 @@ object CallGraph {
     Iterator(
       new MethodRefLinker(cpg),
       new StaticCallLinker(cpg),
-    ) ++ (cpg.metaData.language.lastOption match {
-      case Some(Languages.C) => Iterator[CpgPassBase]()
-      case _                 => Iterator[CpgPassBase](new DynamicCallLinker(cpg))
-    })
+      new DynamicCallLinker(cpg),
+    )
   }
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
@@ -6,7 +6,6 @@ import io.shiftleft.codepropertygraph.generated.{DispatchTypes, EdgeTypes, Prope
 import io.shiftleft.passes.{CpgPass, DiffGraph}
 import io.shiftleft.semanticcpg.language._
 import org.slf4j.{Logger, LoggerFactory}
-import overflowdb.traversal.jIteratortoTraversal
 import overflowdb.{NodeDb, NodeRef}
 
 import scala.collection.mutable

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
@@ -137,8 +137,8 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   /** In the case where the method isn't an internal method and cannot be resolved by crawling TYPE_DECL nodes it can be
-   *  resolved from the map of external methods.
-   */
+    *  resolved from the map of external methods.
+    */
   private def fallbackToStaticResolution(call: Call, dstGraph: DiffGraph.Builder): Unit = {
     methodStubMap.get(call.methodFullName) match {
       case Some(tgtM) => dstGraph.addEdgeInOriginal(call, tgtM, EdgeTypes.CALL)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
@@ -91,7 +91,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
         val directSubclasses =
           cpg.typ
             .nameExact(typDeclFullName)
-            .flatMap(_.in(EdgeTypes.INHERITS_FROM))
+            .flatMap(_.in(EdgeTypes.INHERITS_FROM).asScala)
             .collect {
               case x: TypeDecl =>
                 x.fullName


### PR DESCRIPTION
- The current AST linking sees types decls associated for stubs being `<global>` and `ANY` style nodes which affects call hierarchy resolution which depends on the true type full name
- This fix maps loose method stubs and if these calls are not resolved will fallback to this map
- Enabled `DynamicCallLinker` for non-C languages