### PR TITLE
CpgPass with one method required to extend

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "", keyPools: Option[Iterator[KeyPool]] = None)
-    extends CpgPassBase {
+    extends CpgPassBase[ExecutionContext] {
 
   def init(): Unit = {}
 
@@ -149,7 +149,7 @@ object ConcurrentWriterCpgPass {
 }
 
 abstract class ConcurrentWriterCpgPass[T <: AnyRef](cpg: Cpg, outName: String = "", keyPool: Option[KeyPool] = None)
-    extends CpgPassBase {
+    extends CpgPassBase[ExecutionContext] {
 
   // generate Array of parts that can be processed in parallel
   def generateParts(): Array[_ <: AnyRef] = Array[AnyRef](null)


### PR DESCRIPTION
Just a draft, in response to https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1527/files#r749653226

The idea is that `CpgPass` subtype can parametrize whether it accepts EC or not with type parameter `T`