### PR TITLE
Added DATA_FLOW edge to the schema

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -90,18 +90,17 @@ object Cfg extends SchemaBase {
     methodRef.addOutEdge(edge = cfg, inNode = methodReturn)
     typeRef.addOutEdge(edge = cfg, inNode = methodReturn)
 
-    // TODO: Should this perhaps be in Hidden? Can I access cfgNode base type from Hidden?
+    // TODO: Should this perhaps be in Hidden and/or Pdg? Can I access cfgNode base type from these classes?
     val dataFlow = builder
       .addEdgeType(
         name = "DATA_FLOW",
-        comment =
-          """
+        comment = """
             |EXPERIMENTAL: This edge indicates data flow between two CFG nodes. This is calculated on calls to
             |reachableBy using REACHING_DEFs edges and used to store cached data to improve the performance of
             |incremental data flow analysis.""".stripMargin
       )
       // TODO: Advise on protoId
-      .protoId(19)
+      .protoId(12345)
 
     block.addOutEdge(edge = dataFlow, inNode = cfgNode)
     callNode.addOutEdge(edge = dataFlow, inNode = cfgNode)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -102,15 +102,7 @@ object Cfg extends SchemaBase {
       // TODO: Advise on protoId
       .protoId(12345)
 
-    block.addOutEdge(edge = dataFlow, inNode = cfgNode)
-    callNode.addOutEdge(edge = dataFlow, inNode = cfgNode)
-    controlStructure.addOutEdge(edge = dataFlow, inNode = cfgNode)
-    jumpTarget.addOutEdge(edge = dataFlow, inNode = cfgNode)
-    identifier.addOutEdge(edge = dataFlow, inNode = cfgNode)
-    literal.addOutEdge(edge = dataFlow, inNode = cfgNode)
-    methodRef.addOutEdge(edge = dataFlow, inNode = cfgNode)
-    typeRef.addOutEdge(edge = dataFlow, inNode = cfgNode)
-    unknown.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    cfgNode.addOutEdge(edge = dataFlow, inNode = cfgNode)
   }
 
 }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -89,7 +89,6 @@ object Cfg extends SchemaBase {
 
     methodRef.addOutEdge(edge = cfg, inNode = methodReturn)
     typeRef.addOutEdge(edge = cfg, inNode = methodReturn)
-
   }
 
 }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -90,19 +90,6 @@ object Cfg extends SchemaBase {
     methodRef.addOutEdge(edge = cfg, inNode = methodReturn)
     typeRef.addOutEdge(edge = cfg, inNode = methodReturn)
 
-    // TODO: Should this perhaps be in Hidden and/or Pdg? Can I access cfgNode base type from these classes?
-    val dataFlow = builder
-      .addEdgeType(
-        name = "DATA_FLOW",
-        comment = """
-            |EXPERIMENTAL: This edge indicates data flow between two CFG nodes. This is calculated on calls to
-            |reachableBy using REACHING_DEFs edges and used to store cached data to improve the performance of
-            |incremental data flow analysis.""".stripMargin
-      )
-      // TODO: Advise on protoId
-      .protoId(12345)
-
-    cfgNode.addOutEdge(edge = dataFlow, inNode = cfgNode)
   }
 
 }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -89,6 +89,29 @@ object Cfg extends SchemaBase {
 
     methodRef.addOutEdge(edge = cfg, inNode = methodReturn)
     typeRef.addOutEdge(edge = cfg, inNode = methodReturn)
+
+    // TODO: Should this perhaps be in Hidden? Can I access cfgNode base type from Hidden?
+    val dataFlow = builder
+      .addEdgeType(
+        name = "DATA_FLOW",
+        comment =
+          """
+            |EXPERIMENTAL: This edge indicates data flow between two CFG nodes. This is calculated on calls to
+            |reachableBy using REACHING_DEFs edges and used to store cached data to improve the performance of
+            |incremental data flow analysis.""".stripMargin
+      )
+      // TODO: Advise on protoId
+      .protoId(19)
+
+    block.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    callNode.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    controlStructure.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    jumpTarget.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    identifier.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    literal.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    methodRef.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    typeRef.addOutEdge(edge = dataFlow, inNode = cfgNode)
+    unknown.addOutEdge(edge = dataFlow, inNode = cfgNode)
   }
 
 }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
@@ -27,7 +27,7 @@ class CpgSchema(builder: SchemaBuilder) {
   val tagsAndLocation = TagsAndLocation(builder, base, typeSchema, method, ast, fs, callGraph)
   val binding = Binding(builder, base, typeSchema, method)
   val finding = Finding(builder, base)
-  val hidden = Hidden(builder, base, method, typeSchema, ast, fs, callGraph)
+  val hidden = Hidden(builder, base, method, typeSchema, ast, cfg, fs, callGraph)
   val protoSerialize = ProtoSerialize(builder, ast)
 }
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.codepropertygraph.schema
 
 import overflowdb.schema.Property.ValueType
-import overflowdb.schema.{EdgeType, NodeBaseType, NodeType, SchemaBuilder, SchemaInfo}
+import overflowdb.schema.{EdgeType, NodeType, SchemaBuilder, SchemaInfo}
 
 object Hidden extends SchemaBase {
   override def index: Int = -1

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.codepropertygraph.schema
 
 import overflowdb.schema.Property.ValueType
-import overflowdb.schema.{EdgeType, NodeType, SchemaBuilder, SchemaInfo}
+import overflowdb.schema.{EdgeType, NodeBaseType, NodeType, SchemaBuilder, SchemaInfo}
 
 object Hidden extends SchemaBase {
   override def index: Int = -1
@@ -18,14 +18,16 @@ object Hidden extends SchemaBase {
             methodSchema: Method.Schema,
             typeDecl: Type.Schema,
             ast: Ast.Schema,
+            cfg: Cfg.Schema,
             fs: FileSystem.Schema,
-            callGraph: CallGraph.Schema) = new Schema(builder, base, methodSchema, typeDecl, ast, fs, callGraph)
+            callGraph: CallGraph.Schema) = new Schema(builder, base, methodSchema, typeDecl, ast, cfg, fs, callGraph)
 
   class Schema(builder: SchemaBuilder,
                base: Base.Schema,
                methodSchema: Method.Schema,
                typeDeclSchema: Type.Schema,
                astSchema: Ast.Schema,
+               cfg: Cfg.Schema,
                fsSchema: FileSystem.Schema,
                callGraph: CallGraph.Schema) {
 
@@ -227,6 +229,18 @@ object Hidden extends SchemaBase {
     block.addOutEdge(edge = ast, inNode = importNode)
     file.addOutEdge(edge = ast, inNode = importNode)
     typeDecl.addOutEdge(edge = ast, inNode = importNode)
+
+    val dataFlow = builder
+      .addEdgeType(
+        name = "DATA_FLOW",
+        comment = """
+                    |EXPERIMENTAL: This edge indicates data flow between two CFG nodes. This is calculated on calls to
+                    |reachableBy using REACHING_DEFs edges and used to store cached data to improve the performance of
+                    |incremental data flow analysis.""".stripMargin
+      )
+      .protoId(12345)
+
+    cfg.cfgNode.addOutEdge(edge = dataFlow, inNode = cfg.cfgNode)
   }
 
 }


### PR DESCRIPTION
- I am experimenting to see if `reachableBy` results can be stored in the CPG and used in later increments.
- This is [being done in Plume](https://github.com/plume-oss/plume/blob/0b0bb620b0411e171c9af2ed21262f7a5d318b52/src/main/scala/io/github/plume/oss/drivers/OverflowDbDriver.scala#L215) to find out if one can save the data-flow paths from these for later use e.g. on code change only update CPG on changed classes and re-use old results.
- Part of this is seeing if there is a negligible performance tradeoff from storing and if this speeds up data-flow analysis long term.

TODO: Is this in the right place? I know there is the `Hidden` schema file but not sure how to access the `cfgNode` from there.