### PR TITLE
refactor 'optionsUnused' one-arg constructor to use additional constructor

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Base.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/Base.scala
@@ -3,18 +3,7 @@ package io.shiftleft.semanticcpg.layers
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.PropertyNames
 import io.shiftleft.passes.CpgPassBase
-import io.shiftleft.semanticcpg.passes.base.{
-  AstLinkerPass,
-  ContainsEdgePass,
-  FileCreationPass,
-  MethodDecoratorPass,
-  MethodStubCreator,
-  NamespaceCreator,
-  TypeDeclStubCreator,
-  TypeUsagePass
-}
-
-import scala.annotation.nowarn
+import io.shiftleft.semanticcpg.passes.base._
 
 object Base {
   val overlayName: String = "base"
@@ -34,8 +23,7 @@ object Base {
 
 }
 
-@nowarn
-class Base(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
+class Base extends LayerCreator {
   override val overlayName: String = Base.overlayName
   override val description: String = Base.description
 
@@ -48,4 +36,6 @@ class Base(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
     }
   }
 
+  // LayerCreators need one-arg constructor, because they're called by reflection from io.joern.console.Run
+  def this(optionsUnused: LayerCreatorOptions) = this()
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/CallGraph.scala
@@ -4,8 +4,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.passes.callgraph.{DynamicCallLinker, MethodRefLinker, StaticCallLinker}
 
-import scala.annotation.nowarn
-
 object CallGraph {
   val overlayName: String = "callgraph"
   val description: String = "Call graph layer"
@@ -21,8 +19,7 @@ object CallGraph {
 
 }
 
-@nowarn
-class CallGraph(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
+class CallGraph extends LayerCreator {
   override val overlayName: String = CallGraph.overlayName
   override val description: String = CallGraph.description
   override val dependsOn = List(TypeRelations.overlayName)
@@ -34,4 +31,7 @@ class CallGraph(optionsUnused: LayerCreatorOptions = null) extends LayerCreator 
         runPass(pass, context, storeUndoInfo, index)
     }
   }
+
+  // LayerCreators need one-arg constructor, because they're called by reflection from io.joern.console.Run
+  def this(optionsUnused: LayerCreatorOptions) = this()
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/ControlFlow.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/ControlFlow.scala
@@ -8,8 +8,6 @@ import io.shiftleft.semanticcpg.passes.controlflow.CfgCreationPass
 import io.shiftleft.semanticcpg.passes.controlflow.cfgdominator.CfgDominatorPass
 import io.shiftleft.semanticcpg.passes.controlflow.codepencegraph.CdgPass
 
-import scala.annotation.nowarn
-
 object ControlFlow {
   val overlayName: String = "controlflow"
   val description: String = "Control flow layer (including dominators and CDG edges)"
@@ -29,8 +27,7 @@ object ControlFlow {
 
 }
 
-@nowarn
-class ControlFlow(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
+class ControlFlow extends LayerCreator {
   override val overlayName: String = ControlFlow.overlayName
   override val description: String = ControlFlow.description
   override val dependsOn = List(Base.overlayName)
@@ -42,4 +39,7 @@ class ControlFlow(optionsUnused: LayerCreatorOptions = null) extends LayerCreato
         runPass(pass, context, storeUndoInfo, index)
     }
   }
+
+  // LayerCreators need one-arg constructor, because they're called by reflection from io.joern.console.Run
+  def this(optionsUnused: LayerCreatorOptions) = this()
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/TypeRelations.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/layers/TypeRelations.scala
@@ -4,8 +4,6 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.passes.CpgPassBase
 import io.shiftleft.semanticcpg.passes.typerelations.{AliasLinkerPass, TypeHierarchyPass}
 
-import scala.annotation.nowarn
-
 object TypeRelations {
   val overlayName: String = "typerel"
   val description: String = "Type relations layer (hierarchy and aliases)"
@@ -15,11 +13,9 @@ object TypeRelations {
     new TypeHierarchyPass(cpg),
     new AliasLinkerPass(cpg),
   )
-
 }
 
-@nowarn
-class TypeRelations(optionsUnused: LayerCreatorOptions = null) extends LayerCreator {
+class TypeRelations extends LayerCreator {
   override val overlayName: String = TypeRelations.overlayName
   override val description: String = TypeRelations.description
   override val dependsOn = List(Base.overlayName)
@@ -32,4 +28,6 @@ class TypeRelations(optionsUnused: LayerCreatorOptions = null) extends LayerCrea
     }
   }
 
+  // Layers need one-arg constructor, because they're called by reflection from io.joern.console.Run
+  def this(optionsUnused: LayerCreatorOptions) = this()
 }


### PR DESCRIPTION
* looks nicer, no @nowarn required, hides the ugly fact that we need it
for reflection...
* tested in joern