### PR TITLE
stop using nested implicits v1

### DIFF
--- a/domainClasses/build.sbt
+++ b/domainClasses/build.sbt
@@ -8,4 +8,4 @@ Compile / sourceGenerators += Projects.schema / Compile / generateDomainClasses
  * we're trying to minimise them on a best effort basis, but don't want
  * to fail the build because of them
  */
-Compile / scalacOptions -= "-Xfatal-warnings" 
+Compile / scalacOptions --= Seq("-Xfatal-warnings", "-Wunused", "-Ywarn-unused")

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,6 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.14+5-ffe96893"
+libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.14+7-2a030790"
 
 Compile / generateDomainClasses / classWithSchema := "io.shiftleft.codepropertygraph.schema.CpgSchema$"
 Compile / generateDomainClasses / fieldName := "instance"

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,6 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.14+7-2a030790"
+libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.15"
 
 Compile / generateDomainClasses / classWithSchema := "io.shiftleft.codepropertygraph.schema.CpgSchema$"
 Compile / generateDomainClasses / fieldName := "instance"

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,6 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.14"
+libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.14+5-ffe96893"
 
 Compile / generateDomainClasses / classWithSchema := "io.shiftleft.codepropertygraph.schema.CpgSchema$"
 Compile / generateDomainClasses / fieldName := "instance"

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -412,7 +412,7 @@ object Ast extends SchemaBase {
                   stepNameOut = "parameter",
                   stepNameOutDoc = "Parameters of the method")
       .addOutEdge(edge = ast, inNode = modifier, cardinalityIn = Cardinality.One)
-      .addOutEdge(edge = ast, inNode = block, cardinalityOut = Cardinality.One, cardinalityIn = Cardinality.One)
+      .addOutEdge(edge = ast, inNode = block, cardinalityOut = Cardinality.One, cardinalityIn = Cardinality.One, stepNameOut = "block", stepNameOutDoc = "Root of the abstract syntax tree")
       .addOutEdge(edge = ast, inNode = typeParameter, cardinalityIn = Cardinality.One)
 
     ret

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -412,7 +412,14 @@ object Ast extends SchemaBase {
                   stepNameOut = "parameter",
                   stepNameOutDoc = "Parameters of the method")
       .addOutEdge(edge = ast, inNode = modifier, cardinalityIn = Cardinality.One)
-      .addOutEdge(edge = ast, inNode = block, cardinalityOut = Cardinality.One, cardinalityIn = Cardinality.One, stepNameOut = "block", stepNameOutDoc = "Root of the abstract syntax tree")
+      .addOutEdge(
+        edge = ast,
+        inNode = block,
+        cardinalityOut = Cardinality.One,
+        cardinalityIn = Cardinality.One,
+        stepNameOut = "block",
+        stepNameOutDoc = "Root of the abstract syntax tree"
+      )
       .addOutEdge(edge = ast, inNode = typeParameter, cardinalityIn = Cardinality.One)
 
     ret

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -63,7 +63,7 @@ object Cfg extends SchemaBase {
                   inNode = methodReturn,
                   cardinalityOut = Cardinality.ZeroOrOne,
                   cardinalityIn = Cardinality.ZeroOrOne)
-      .addOutEdge(edge = cfg, inNode = cfgNode)
+      .addOutEdge(edge = cfg, inNode = cfgNode, stepNameOut = "cfgFirst", stepNameOutDoc = "First control flow graph node")
 
     fieldIdentifier
       .addOutEdge(edge = cfg, inNode = cfgNode)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -63,7 +63,10 @@ object Cfg extends SchemaBase {
                   inNode = methodReturn,
                   cardinalityOut = Cardinality.ZeroOrOne,
                   cardinalityIn = Cardinality.ZeroOrOne)
-      .addOutEdge(edge = cfg, inNode = cfgNode, stepNameOut = "cfgFirst", stepNameOutDoc = "First control flow graph node")
+      .addOutEdge(edge = cfg,
+                  inNode = cfgNode,
+                  stepNameOut = "cfgFirst",
+                  stepNameOutDoc = "First control flow graph node")
 
     fieldIdentifier
       .addOutEdge(edge = cfg, inNode = cfgNode)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -4,6 +4,7 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
+import overflowdb.traversal.Traversal
 
 class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
 
@@ -65,5 +66,11 @@ class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
 
   def astParent: AstNode =
     node._astIn.onlyChecked.asInstanceOf[AstNode]
+
+  /**
+    * Nodes of the AST rooted in this node, including the node itself.
+    * */
+  def ast: Traversal[AstNode] =
+    Traversal.fromSingle(node).ast
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -9,6 +9,9 @@ import scala.jdk.CollectionConverters._
 
 class MethodMethods(val method: Method) extends AnyVal with NodeExtension with HasLocation {
 
+  def cfgFirst: Traversal[CfgNode] =
+    method._cfgNodeViaCfgOut
+
   def local: Traversal[Local] =
     method._blockViaContainsOut.flatMap(_._localViaAstOut)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, CfgNode, Local, Method, NewLocation}
+import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Local, Method, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, NodeOrdering, toCfgNodeMethods}
 import overflowdb.traversal.Traversal
@@ -8,9 +8,6 @@ import overflowdb.traversal.Traversal
 import scala.jdk.CollectionConverters._
 
 class MethodMethods(val method: Method) extends AnyVal with NodeExtension with HasLocation {
-
-  def block: Block =
-    method._blockViaAstOut
 
   def local: Traversal[Local] =
     method._blockViaContainsOut.flatMap(_._localViaAstOut)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -9,9 +9,6 @@ import scala.jdk.CollectionConverters._
 
 class MethodMethods(val method: Method) extends AnyVal with NodeExtension with HasLocation {
 
-  def cfgFirst: Traversal[CfgNode] =
-    method._cfgNodeViaCfgOut
-
   def local: Traversal[Local] =
     method._blockViaContainsOut.flatMap(_._localViaAstOut)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Local, Method, NewLocation}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, CfgNode, Local, Method, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, NodeOrdering, toCfgNodeMethods}
 import overflowdb.traversal.Traversal
@@ -8,6 +8,9 @@ import overflowdb.traversal.Traversal
 import scala.jdk.CollectionConverters._
 
 class MethodMethods(val method: Method) extends AnyVal with NodeExtension with HasLocation {
+
+  def block: Block =
+    method._blockViaAstOut
 
   def local: Traversal[Local] =
     method._blockViaContainsOut.flatMap(_._localViaAstOut)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Local, Method, NewLocation}
+import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, ControlStructure, Local, Method, NewLocation}
 import io.shiftleft.semanticcpg.NodeExtension
-import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, NodeOrdering, toCfgNodeMethods}
+import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
 
 import scala.jdk.CollectionConverters._
@@ -11,6 +11,12 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
 
   def local: Traversal[Local] =
     method._blockViaContainsOut.flatMap(_._localViaAstOut)
+
+  /**
+    * All control structures of this method
+    * */
+  def controlStructure: Traversal[ControlStructure] =
+    method.ast.isControlStructure
 
   def numberOfLines: Int = {
     if (method.lineNumber.isDefined && method.lineNumberEnd.isDefined) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -92,7 +92,7 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
     new IdentifierTraversal(f(a))
   implicit def toMember[A](a: A)(implicit f: A => Traversal[Member]): MemberTraversal = new MemberTraversal(f(a))
   implicit def toLocal[A](a: A)(implicit f: A => Traversal[Local]): LocalTraversal = new LocalTraversal(f(a))
-  implicit def toMethod[A](a: A)(implicit f: A => Traversal[Method]): OriginalMethod = new OriginalMethod(f(a))
+  implicit def toMethod[A](traversal: IterableOnce[Method]): OriginalMethod = new OriginalMethod(traversal)
   implicit def toMethodParameter[A](a: A)(implicit f: A => Traversal[MethodParameterIn]): MethodParameterTraversal =
     new MethodParameterTraversal(f(a))
   implicit def toMethodParameterOut[A](a: A)(

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
@@ -31,7 +31,7 @@ class MethodReturnTraversal(val traversal: Traversal[MethodReturn]) extends AnyV
     *  Can be multiple.
     */
   @Doc(info = "traverse to last expressions in CFG (can be multiple)")
-  def cfgLast: Traversal[Expression] =
+  def cfgLast: Traversal[CfgNode] =
     traversal.in(EdgeTypes.CFG).cast[Expression]
 
   /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -4,14 +4,14 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import overflowdb._
+import overflowdb.traversal._
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, help}
 
 /**
   * A method, function, or procedure
   * */
 @help.Traversal(elementType = classOf[Method])
-class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
+class MethodTraversal(val traversal: IterableOnce[Method]) extends AnyVal {
 
   /**
     * All control structures of this method
@@ -113,8 +113,9 @@ class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
     * but only referenced in the CPG.
     * */
   @Doc(info = "External methods (called, but no body available)")
-  def external: Traversal[Method] =
+  def external: Traversal[Method] = {
     traversal.has(Properties.IS_EXTERNAL -> true)
+  }
 
   /**
     * Traverse to internal methods, that is, methods for which

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -170,7 +170,7 @@ class MethodTraversal(val traversal: IterableOnce[Method]) extends AnyVal {
     * */
   @Doc(info = "Root of the abstract syntax tree")
   def block: Traversal[Block] =
-    traversal.out(EdgeTypes.AST).hasLabel(NodeTypes.BLOCK).cast[Block]
+    traversal.flatMap(_.block)
 
   /** Traverse to method body (alias for `block`) */
   @Doc(info = "Alias for `block`")

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -156,14 +156,14 @@ class MethodTraversal(val traversal: IterableOnce[Method]) extends AnyVal {
     *  Traverse to first expression in CFG.
     */
   @Doc(info = "First control flow graph node")
-  def cfgFirst: Traversal[Expression] =
-    traversal.out(EdgeTypes.CFG).cast[Expression]
+  def cfgFirst: Traversal[CfgNode] =
+    traversal.flatMap(_.cfgFirst)
 
   /**
     *  Traverse to last expression in CFG.
     */
   @Doc(info = "Last control flow graph node")
-  def cfgLast: Traversal[Expression] =
+  def cfgLast: Traversal[CfgNode] =
     traversal.methodReturn.cfgLast
 
   /** Traverse to method body (alias for `block`) */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -153,13 +153,6 @@ class MethodTraversal(val traversal: IterableOnce[Method]) extends AnyVal {
     traversal.flatMap(_.cfgNode)
 
   /**
-    *  Traverse to first expression in CFG.
-    */
-  @Doc(info = "First control flow graph node")
-  def cfgFirst: Traversal[CfgNode] =
-    traversal.flatMap(_.cfgFirst)
-
-  /**
     *  Traverse to last expression in CFG.
     */
   @Doc(info = "Last control flow graph node")

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -129,7 +129,8 @@ class MethodTraversal(val traversal: IterableOnce[Method]) extends AnyVal {
     * Traverse to the methods local variables
     * */
   @Doc(info = "Local variables declared in the method")
-  def local: Traversal[Local] = block.ast.isLocal
+  def local: Traversal[Local] =
+    traversal.block.ast.isLocal
 
   /**
     * Traverse to literals of method
@@ -165,16 +166,10 @@ class MethodTraversal(val traversal: IterableOnce[Method]) extends AnyVal {
   def cfgLast: Traversal[Expression] =
     traversal.methodReturn.cfgLast
 
-  /**
-    * Traverse to block
-    * */
-  @Doc(info = "Root of the abstract syntax tree")
-  def block: Traversal[Block] =
-    traversal.flatMap(_.block)
-
   /** Traverse to method body (alias for `block`) */
   @Doc(info = "Alias for `block`")
-  def body: Traversal[Block] = block
+  def body: Traversal[Block] =
+    traversal.block
 
   /** Traverse to namespace */
   @Doc(info = "Namespace this method is declared in")

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTests.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
-import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Literal, Method, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, Expression, Literal, Method, TypeDecl}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
@@ -78,15 +78,15 @@ class MethodTests extends AnyWordSpec with Matchers {
     }
 
     "expand to first expression" in {
-      val expressions: List[Expression] =
-        cpg.method.name("foo").cfgFirst.toList
+      val expressions: List[CfgNode] =
+        cpg.method.name("foo").cfgFirst.l
 
       expressions.size shouldBe 1
       expressions.head.code shouldBe "call"
     }
 
     "expand to last expression" in {
-      val expressions: List[Expression] =
+      val expressions: List[CfgNode] =
         cpg.method.name("foo").cfgLast.toList
 
       expressions.size shouldBe 1


### PR DESCRIPTION
* use IterableOnce to avoid chained implicits
* block: use named steps, which operate on schema-specific dsl (rather than generic graph dsl)

depends on https://github.com/ShiftLeftSecurity/overflowdb-codegen/pull/117
partial fix for https://github.com/joernio/joern/pull/796