### PR TITLE
some steps for downstream usage were missing

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -57,8 +57,7 @@ object DotSerializer {
       case node: MethodRef         => node.parentExpression.get
       case node: Literal           => node.parentExpression.get
       case node: MethodParameterIn => node.method
-      case node: MethodParameterOut =>
-        node.method.methodReturn
+      case node: MethodParameterOut => node.method.methodReturn
       case node: Call if MemberAccess.isGenericMemberAccessName(node.name) =>
         node.parentExpression.get
       case node: CallRepr     => node

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -53,10 +53,10 @@ object DotSerializer {
 
   private def toCfgNode(node: StoredNode): CfgNode = {
     node match {
-      case node: Identifier        => node.parentExpression.get
-      case node: MethodRef         => node.parentExpression.get
-      case node: Literal           => node.parentExpression.get
-      case node: MethodParameterIn => node.method
+      case node: Identifier         => node.parentExpression.get
+      case node: MethodRef          => node.parentExpression.get
+      case node: Literal            => node.parentExpression.get
+      case node: MethodParameterIn  => node.method
       case node: MethodParameterOut => node.method.methodReturn
       case node: Call if MemberAccess.isGenericMemberAccessName(node.name) =>
         node.parentExpression.get

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,6 +1,14 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, CfgNode, ControlStructure, Local, Method, NewLocation, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Block,
+  CfgNode,
+  ControlStructure,
+  Local,
+  Method,
+  NewLocation,
+  TypeDecl
+}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,6 +1,6 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{CfgNode, ControlStructure, Local, Method, NewLocation}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, CfgNode, ControlStructure, Local, Method, NewLocation, TypeDecl}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.Traversal
@@ -56,6 +56,16 @@ class MethodMethods(val method: Method) extends AnyVal with NodeExtension with H
       )
     )
   }
+
+  /**
+    * The type declaration associated with this method, e.g., the class it is defined in.
+    * */
+  def definingTypeDecl: Traversal[TypeDecl] =
+    Traversal.fromSingle(method).definingTypeDecl
+
+  /** Traverse to method body (alias for `block`) */
+  def body: Traversal[Block] =
+    method.block
 
   override def location: NewLocation = {
     LocationCreator(


### PR DESCRIPTION
context: they used to be available via nested implicits, which have
been removed since (because those are deprecated)