### PR TITLE
Add imports for implicit conversions.

### DIFF
--- a/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/passes/KeyPoolTests.scala
@@ -39,7 +39,7 @@ class KeyPoolTests extends AnyWordSpec with Matchers {
 
     "return empty iterator when asked to create 0 partitions" in {
       val keyPool = new IntervalKeyPool(1, 1000)
-      keyPool.split(0) shouldBe Iterator()
+      keyPool.split(0).hasNext shouldBe false
     }
 
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/ICallResolver.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.generated.nodes.{CallRepr, Method}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewNodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewNodeSteps.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.generated.nodes.NewNode
 import io.shiftleft.passes.DiffGraph
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 trait HasStoreMethod {
   def store()(implicit diffBuilder: DiffGraph.Builder): Unit

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewTagNodePairTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NewTagNodePairTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{NewNode, NewTagNodePair, StoredNode}
 import io.shiftleft.passes.DiffGraph
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class NewTagNodePairTraversal(traversal: Traversal[NewTagNodePair]) extends HasStoreMethod {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -7,6 +7,7 @@ import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import overflowdb.Node
 import overflowdb.traversal.help.Doc
 import overflowdb.traversal.{Traversal, help}
+import overflowdb.traversal._
 
 /**
   * Steps for all node types

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeSteps.scala
@@ -5,9 +5,8 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.codedumper.CodeDumper
 import overflowdb.Node
-import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, help}
 import overflowdb.traversal._
+import overflowdb.traversal.help.Doc
 
 /**
   * Steps for all node types

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/Steps.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language
 import io.shiftleft.codepropertygraph.generated.nodes.StoredNode
 import org.json4s.native.Serialization.{write, writePretty}
 import org.json4s.{CustomSerializer, Extraction}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 import overflowdb.traversal.help.DocFinder._
 import overflowdb.traversal.help.{Doc, TraversalHelp}
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/TagTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import overflowdb.traversal.{Traversal, iterableToTraversal}
+import overflowdb.traversal._
 
 class TagTraversal(val traversal: Traversal[Tag]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/MethodTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.bindingextension
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Method, TypeDecl}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/bindingextension/TypeDeclTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.bindingextension
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Binding, Method, TypeDecl}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/CallTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.callgraphextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class CallTraversal(val traversal: Traversal[Call]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
@@ -3,8 +3,8 @@ package io.shiftleft.semanticcpg.language.callgraphextension
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.help.Doc
 import overflowdb.traversal._
+import overflowdb.traversal.help.Doc
 
 class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{PathAwareTraversal, Traversal}
+import overflowdb.traversal._
 
 class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/AstNodeDot.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.dotextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
 import io.shiftleft.semanticcpg.dotgenerator.DotAstGenerator
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class AstNodeDot[NodeType <: AstNode](val traversal: Traversal[NodeType]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/dotextension/CfgNodeDot.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.dotextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.Method
 import io.shiftleft.semanticcpg.dotgenerator.{DotCdgGenerator, DotCfgGenerator}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class CfgNodeDot(val traversal: Traversal[Method]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -4,7 +4,7 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -4,7 +4,7 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{toCfgNode, toCfgNodeMethods}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -11,7 +11,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{
 }
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/NodeMethods.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/StoredNodeMethods.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{StoredNode, Tag}
 import io.shiftleft.semanticcpg.NodeExtension
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Identifier}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class ArrayAccessTraversal(val traversal: Traversal[opnodes.ArrayAccess]) extends AnyVal {
   def array: Traversal[Expression] = traversal.map(_.array)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class AssignmentTraversal(val traversal: Traversal[opnodes.Assignment]) extends AnyVal {
   def target: Traversal[Expression] = traversal.map(_.target)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Implicits.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Implicits.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Expression}
 import io.shiftleft.semanticcpg.language.operatorextension.nodemethods._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 trait Implicits {
   implicit def toNodeTypeStartersOperatorExtension(cpg: Cpg): NodeTypeStarters = new NodeTypeStarters(cpg)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 import overflowdb.traversal.help.{Doc, TraversalSource}
 
 object NodeTypeStarters {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNode.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.AstNode
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class OpAstNode[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {
   def inAssignment: Traversal[opnodes.Assignment] = traversal.flatMap(_.inAssignment)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class TargetTraversal(val traversal: Traversal[Expression]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Identifier}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.opnodes
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class ArrayAccessMethods(val arrayAccess: opnodes.ArrayAccess) extends AnyVal {
   def array: Expression =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language.operatorextension.opnodes
+import io.shiftleft.semanticcpg.language._
 
 class AssignmentMethods(val assignment: opnodes.Assignment) extends AnyVal {
   def target: Expression = assignment.argument(1)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
@@ -1,8 +1,8 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
-import io.shiftleft.semanticcpg.language.operatorextension.opnodes
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.semanticcpg.language.operatorextension.opnodes
 
 class AssignmentMethods(val assignment: opnodes.Assignment) extends AnyVal {
   def target: Expression = assignment.argument(1)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
@@ -2,18 +2,18 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension._
+import io.shiftleft.semanticcpg.language.operatorextension.{NodeTypeStarters => ExtStarters, _}
 import overflowdb.traversal._
 
 class OpAstNodeMethods[A <: AstNode](val node: A) extends AnyVal {
   def inAssignment: Traversal[opnodes.Assignment] =
-    node.start.inAstMinusLeaf.isCall.name(NodeTypeStarters.assignmentPattern).map(new opnodes.Assignment(_))
+    node.start.inAstMinusLeaf.isCall.name(ExtStarters.assignmentPattern).map(new opnodes.Assignment(_))
 
   def assignments: Traversal[opnodes.Assignment] =
-    rawTravForPattern(NodeTypeStarters.assignmentPattern).map(new opnodes.Assignment(_))
+    rawTravForPattern(ExtStarters.assignmentPattern).map(new opnodes.Assignment(_))
 
   def arithmetics: Traversal[opnodes.Arithmetic] =
-    rawTravForPattern(NodeTypeStarters.arithmeticPattern).map(new opnodes.Arithmetic(_))
+    rawTravForPattern(ExtStarters.arithmeticPattern).map(new opnodes.Arithmetic(_))
 
   private def rawTravForPattern(pattern: String): Traversal[Call] =
     node.ast.isCall.name(pattern)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.opnodes
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class TargetMethods(val expr: Expression) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -43,7 +43,7 @@ import io.shiftleft.semanticcpg.language.types.expressions.generalizations.{
 import io.shiftleft.semanticcpg.language.types.expressions.{CallTraversal => OriginalCall, _}
 import io.shiftleft.semanticcpg.language.types.propertyaccessors._
 import io.shiftleft.semanticcpg.language.types.structure.{MethodTraversal => OriginalMethod, _}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   Language for traversing the code property graph

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   A call site

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, ControlStructure, Expression}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 import overflowdb.traversal.help.Doc
 
 object ControlStructureTraversal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/IdentifierTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Declaration, Identifier}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   An identifier, e.g., an instance of a local variable, or a temporary variable

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/LiteralTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/LiteralTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Literal, Method}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   A literal, e.g., a constant string or number

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRefTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/MethodRefTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.expressions
 
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Method, MethodRef}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class MethodRefTraversal(val traversal: Traversal[MethodRef]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, help}
+import overflowdb.traversal._
 
 @help.Traversal(elementType = classOf[AstNode])
 class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -3,8 +3,8 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.help.Doc
 import overflowdb.traversal._
+import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[AstNode])
 class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, help}
+import overflowdb.traversal._
 
 @help.Traversal(elementType = classOf[CfgNode])
 class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/CfgNodeTraversal.scala
@@ -4,8 +4,8 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.help.Doc
 import overflowdb.traversal._
+import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[CfgNode])
 class CfgNodeTraversal[A <: CfgNode](val traversal: Traversal[A]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/ExpressionTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
@@ -1,10 +1,9 @@
 package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Properties}
-import overflowdb.Node
 import overflowdb.traversal._
 import overflowdb.traversal.filter.P
-import overflowdb.toPropertyKeyOps
+import overflowdb.{Node, toPropertyKeyOps}
 
 class EvalTypeAccessors[A <: Node](val traversal: Traversal[A]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/EvalTypeAccessors.scala
@@ -2,8 +2,9 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Properties}
 import overflowdb.Node
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 import overflowdb.traversal.filter.P
+import overflowdb.toPropertyKeyOps
 
 class EvalTypeAccessors[A <: Node](val traversal: Traversal[A]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ModifierAccessors.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/propertyaccessors/ModifierAccessors.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.propertyaccessors
 import io.shiftleft.codepropertygraph.generated.nodes.Modifier
 import io.shiftleft.codepropertygraph.generated.{ModifierTypes, NodeTypes, Properties}
 import overflowdb._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class ModifierAccessors[A <: Node](val traversal: Traversal[A]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/BlockTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/BlockTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Local}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, help}
+import overflowdb.traversal._
 
 @help.Traversal(elementType = classOf[Block])
 class BlockTraversal(val traversal: Traversal[Block]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/BlockTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/BlockTraversal.scala
@@ -2,8 +2,8 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Block, Local}
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import overflowdb.traversal.help.Doc
 import overflowdb.traversal._
+import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[Block])
 class BlockTraversal(val traversal: Traversal[Block]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/FileTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/FileTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   * A compilation unit

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LocalTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/LocalTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   * A local variable

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Member, Type, TypeDecl}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   * A member variable of a class/type.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterOutTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodParameterTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{Traversal, help}
+import overflowdb.traversal._
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.help.Doc
-import overflowdb.traversal.{Traversal, help}
+import overflowdb.traversal._
 
 @help.Traversal(elementType = classOf[MethodReturn])
 class MethodReturnTraversal(val traversal: Traversal[MethodReturn]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodReturnTraversal.scala
@@ -3,8 +3,8 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.help.Doc
 import overflowdb.traversal._
+import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[MethodReturn])
 class MethodReturnTraversal(val traversal: Traversal[MethodReturn]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlockTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceBlockTraversal.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class NamespaceBlockTraversal(val traversal: Traversal[NamespaceBlock]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   * A namespace, e.g., Java package or C# namespace

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
 import overflowdb._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   * Type declaration - possibly a template that requires instantiation

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/base/AstLinkerPass.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/base/AstLinkerPass.scala
@@ -11,6 +11,7 @@ import io.shiftleft.semanticcpg.passes.callgraph.MethodRefLinker.{
   namespaceBlockFullNameToNode,
   typeDeclFullNameToNode
 }
+import overflowdb.traversal._
 
 class AstLinkerPass(cpg: Cpg) extends CpgPass(cpg) {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Dispatch
 import io.shiftleft.passes.DiffGraph
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.controlflow.cfgcreation.Cfg.CfgEdgeType
-import overflowdb.traversal.Traversal
+import overflowdb.traversal._
 
 /**
   * Translation of abstract syntax trees into control flow graphs

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -4,11 +4,11 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Properties}
 import io.shiftleft.semanticcpg.testing.MockCpg
-import org.json4s.JString
+import org.json4s._
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.traversal.{Traversal, jIteratortoTraversal}
+import overflowdb.traversal._
 
 class StepsTest extends AnyWordSpec with Matchers {
 
@@ -57,7 +57,7 @@ class StepsTest extends AnyWordSpec with Matchers {
         val results: List[Method] = cpg.method.id(methods.map(_.id): _*).toList
 
         results.size shouldBe 2
-        results.toSet shouldBe methods.toSet
+        results.toSetMutable shouldBe methods.toSetMutable
       }
     }
   }
@@ -257,16 +257,16 @@ class StepsTest extends AnyWordSpec with Matchers {
     methodParameterOut.head.typ.name.head shouldBe "paramtype"
 
     def methodReturn = cpg.methodReturn.typeFullNameExact("int")
-    methodReturn.method.name.toSet shouldBe Set("foo", "woo")
-    methodReturn.map(_.method.name).toSet shouldBe Set("foo", "woo")
+    methodReturn.method.name.toSetMutable shouldBe Set("foo", "woo")
+    methodReturn.map(_.method.name).toSetMutable shouldBe Set("foo", "woo")
 
     def namespace = cpg.namespace.name("anamespace")
-    namespace.typeDecl.name.toSet shouldBe Set("AClass")
-    namespace.head.typeDecl.name.toSet shouldBe Set("AClass")
+    namespace.typeDecl.name.toSetMutable shouldBe Set("AClass")
+    namespace.head.typeDecl.name.toSetMutable shouldBe Set("AClass")
 
     def namespaceBlock = cpg.namespaceBlock.name("anamespace")
-    namespaceBlock.typeDecl.name.toSet shouldBe Set("AClass")
-    namespaceBlock.flatMap(_.typeDecl.name).toSet shouldBe Set("AClass")
+    namespaceBlock.typeDecl.name.toSetMutable shouldBe Set("AClass")
+    namespaceBlock.flatMap(_.typeDecl.name).toSetMutable shouldBe Set("AClass")
 
     def file = cpg.file.name("afile.c")
     file.typeDecl.name.head shouldBe "AClass"
@@ -312,8 +312,8 @@ class StepsTest extends AnyWordSpec with Matchers {
     local.head.typeFullName shouldBe "alocaltype"
 
     // modifierAccessors
-    method.modifier.modifierType.toSet shouldBe Set("modifiertype")
-    method.head.modifier.modifierType.toSet shouldBe Set("modifiertype")
+    method.modifier.modifierType.toSetMutable shouldBe Set("modifiertype")
+    method.head.modifier.modifierType.toSetMutable shouldBe Set("modifiertype")
   }
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/types/structure/MemberTests.scala
@@ -14,7 +14,7 @@ class MemberTests extends AnyWordSpec with Matchers {
 
   "Member traversals" should {
     "should find two members: `member` and `static_member`" in {
-      cpg.member.name.toSet shouldBe Set("amember")
+      cpg.member.name.toSetMutable shouldBe Set("amember")
     }
 
     "filter by modifier" in {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpAstTests.scala
@@ -2,9 +2,10 @@ package io.shiftleft.semanticcpg.layers
 
 import better.files.File
 import io.shiftleft.semanticcpg.testing.MockCpg
-import java.nio.file.Files
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
 
 class DumpAstTests extends AnyWordSpec with Matchers {
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpAstTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpAstTests.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.layers
 
 import better.files.File
 import io.shiftleft.semanticcpg.testing.MockCpg
+import java.nio.file.Files
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -23,8 +24,8 @@ class DumpAstTests extends AnyWordSpec with Matchers {
         new DumpAst(opts).run(context)
         (tmpDir / "0-ast.dot").exists shouldBe true
         (tmpDir / "1-ast.dot").exists shouldBe true
-        (tmpDir / "0-ast.dot").size should not be 0
-        (tmpDir / "1-ast.dot").size should not be 0
+        Files.size((tmpDir / "0-ast.dot").path) should not be 0
+        Files.size((tmpDir / "1-ast.dot").path) should not be 0
       }
     }
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCdgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCdgTests.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.layers
 
 import better.files.File
 import io.shiftleft.semanticcpg.testing.MockCpg
+import java.nio.file.Files
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -24,8 +25,8 @@ class DumpCdgTests extends AnyWordSpec with Matchers {
         new DumpCdg(opts).run(context)
         (tmpDir / "0-cdg.dot").exists shouldBe true
         (tmpDir / "1-cdg.dot").exists shouldBe true
-        (tmpDir / "0-cdg.dot").size should not be 0
-        (tmpDir / "1-cdg.dot").size should not be 0
+        Files.size((tmpDir / "0-cdg.dot").path) should not be 0
+        Files.size((tmpDir / "1-cdg.dot").path) should not be 0
       }
     }
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCdgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCdgTests.scala
@@ -2,9 +2,10 @@ package io.shiftleft.semanticcpg.layers
 
 import better.files.File
 import io.shiftleft.semanticcpg.testing.MockCpg
-import java.nio.file.Files
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
 
 class DumpCdgTests extends AnyWordSpec with Matchers {
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCfgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCfgTests.scala
@@ -2,6 +2,7 @@ package io.shiftleft.semanticcpg.layers
 
 import better.files.File
 import io.shiftleft.semanticcpg.testing.MockCpg
+import java.nio.file.Files
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -24,8 +25,8 @@ class DumpCfgTests extends AnyWordSpec with Matchers {
         new DumpCfg(opts).run(context)
         (tmpDir / "0-cfg.dot").exists shouldBe true
         (tmpDir / "1-cfg.dot").exists shouldBe true
-        (tmpDir / "0-cfg.dot").size should not be 0
-        (tmpDir / "1-cfg.dot").size should not be 0
+        Files.size((tmpDir / "0-cfg.dot").path) should not be 0
+        Files.size((tmpDir / "1-cfg.dot").path) should not be 0
       }
     }
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCfgTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/layers/DumpCfgTests.scala
@@ -2,9 +2,10 @@ package io.shiftleft.semanticcpg.layers
 
 import better.files.File
 import io.shiftleft.semanticcpg.testing.MockCpg
-import java.nio.file.Files
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
 
 class DumpCfgTests extends AnyWordSpec with Matchers {
 


### PR DESCRIPTION
In Scala 3 those are not looked up in the package object anymore.