### PR TITLE
Allow REACHING_DEF edges as OUT and IN on TYPE_REF nodes.

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Pdg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Pdg.scala
@@ -199,11 +199,13 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = methodParameterIn)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     ret
       .addOutEdge(edge = reachingDef, inNode = methodReturn)
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     methodRef
       .addOutEdge(edge = reachingDef, inNode = callNode)
@@ -211,6 +213,15 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
+
+    typeRef
+      .addOutEdge(edge = reachingDef, inNode = callNode)
+      .addOutEdge(edge = reachingDef, inNode = ret)
+      .addOutEdge(edge = reachingDef, inNode = identifier)
+      .addOutEdge(edge = reachingDef, inNode = literal)
+      .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     methodParameterIn
       .addOutEdge(edge = reachingDef, inNode = callNode)
@@ -218,6 +229,7 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     literal
       .addOutEdge(edge = reachingDef, inNode = callNode)
@@ -225,6 +237,7 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     callNode
       .addOutEdge(edge = reachingDef, inNode = callNode)
@@ -232,6 +245,7 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     identifier
       .addOutEdge(edge = reachingDef, inNode = callNode)
@@ -239,6 +253,7 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     block
       .addOutEdge(edge = reachingDef, inNode = callNode)
@@ -247,6 +262,7 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     controlStructure
       .addOutEdge(edge = reachingDef, inNode = callNode)
@@ -254,6 +270,7 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
     unknown
       .addOutEdge(edge = reachingDef, inNode = callNode)
@@ -261,6 +278,7 @@ object Pdg extends SchemaBase {
       .addOutEdge(edge = reachingDef, inNode = identifier)
       .addOutEdge(edge = reachingDef, inNode = literal)
       .addOutEdge(edge = reachingDef, inNode = methodRef)
+      .addOutEdge(edge = reachingDef, inNode = typeRef)
 
   }
 


### PR DESCRIPTION
This was missed before.
Since TYPE_REF is a generalisation of METHOD_REF
it is fine to allow the same relations as we already have for
METHOD_REF.