### PR TITLE
Escape nodes correctly for Dot file generation

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -84,7 +84,9 @@ object DotSerializer {
     if (str == null) {
       ""
     } else {
-      str.replace("\"", "\\\"")
+      // Here, \\\\ means a literal \ and \" means a literal ".
+      // We need this to get valid dot files for literal \" sequences.
+      str.replace("\"", "\\\\"")
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -86,7 +86,7 @@ object DotSerializer {
     } else {
       // Here, \\\\ means a literal \ and \" means a literal ".
       // We need this to get valid dot files for literal \" sequences.
-      str.replace("\"", "\\\\"")
+      str.replace("\"", "\\\"").replace("\\\\\"", "\\\\\\\"")
     }
   }
 


### PR DESCRIPTION
Follow-up for: https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1561