### PR TITLE
Fixed file reading for non-UTF8 encodings

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/IOUtils.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/x2cpg/IOUtils.scala
@@ -1,0 +1,83 @@
+package io.shiftleft.x2cpg
+
+import java.io.Reader
+import java.math.BigInteger
+import java.nio.charset.{CharsetDecoder, CodingErrorAction}
+import java.nio.file.Path
+import scala.io.{BufferedSource, Codec, Source}
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+import scala.util.Using
+
+object IOUtils {
+
+  /**
+    * Creates a new UTF-8 decoder.
+    * Sadly, instances of CharsetDecoder are not thread-safe as the doc states:
+    * 'Instances of this class are not safe for use by multiple concurrent threads.'
+    * (copied from: [[java.nio.charset.CharsetDecoder]])
+    *
+    * As we are using it in a [[io.shiftleft.passes.ParallelCpgPass]] it needs to be thread-safe.
+    * Hence, we make sure to create a new instance everytime.
+    */
+  private def createDecoder(): CharsetDecoder =
+    Codec.UTF8.decoder
+      .onMalformedInput(CodingErrorAction.REPLACE)
+      .onUnmappableCharacter(CodingErrorAction.REPLACE)
+
+  private val validUnicodeRegex = """([a-zA-Z0-9]){4}""".r
+
+  private val boms = Set(
+    '\uefbb', // UTF-8
+    '\ufeff', // UTF-16 (BE)
+    '\ufffe' // UTF-16 (LE)
+  )
+
+  private def skipBOMIfPresent(reader: Reader): Unit = {
+    reader.mark(1)
+    val possibleBOM = new Array[Char](1)
+    reader.read(possibleBOM)
+    if (!boms.contains(possibleBOM(0))) {
+      reader.reset()
+    }
+  }
+
+  private def removeUnpairedSurrogates(input: String): String = {
+    var result = input
+    """(\\u)""".r.findAllMatchIn(input).foreach { pos =>
+      val matchedString = input.substring(pos.start + 2, pos.start + 6)
+      if (validUnicodeRegex.matches(matchedString)) {
+        val c = new BigInteger(matchedString, 16).intValue().asInstanceOf[Char]
+        if (Character.isLowSurrogate(c) || Character.isHighSurrogate(c)) {
+          // removing them including leading '\' (needs escapes for backslash itself + for the regex construction)
+          result = result.replaceAll("(\\\\)*\\\\u" + matchedString, "")
+        }
+      }
+    }
+    result
+  }
+
+  private def contentFromBufferedSource(bufferedSource: BufferedSource): Seq[String] = {
+    val reader = bufferedSource.bufferedReader()
+    skipBOMIfPresent(reader)
+    reader.lines().iterator().asScala.map(removeUnpairedSurrogates).toSeq
+  }
+
+  private def bufferedSourceFromFile(path: Path): BufferedSource = {
+    Source.fromFile(path.toFile)(createDecoder())
+  }
+
+  /**
+    * Reads a file at the given path and:
+    *  - skips BOM if present
+    *  - removes unpaired surrogates
+    *  - uses UTF-8 encoding (replacing malformed and unmappable characters)
+    *
+    * @param path the file path
+    * @return a Seq with all lines in the given file as Strings
+    */
+  def readLinesInFile(path: Path): Seq[String] =
+    Using.resource(bufferedSourceFromFile(path)) { bufferedSource =>
+      contentFromBufferedSource(bufferedSource)
+    }
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.semanticcpg.codedumper
 
-import better.files.File
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Method, NewLocation}
 import io.shiftleft.semanticcpg.language._

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -4,8 +4,10 @@ import better.files.File
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Method, NewLocation}
 import io.shiftleft.semanticcpg.language._
+import io.shiftleft.x2cpg.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
+import java.nio.file.Paths
 import scala.util.Try
 
 object CodeDumper {
@@ -64,7 +66,7 @@ object CodeDumper {
     * an arrow (as a source code comment) is included right before that line.
     * */
   def code(filename: String, startLine: Integer, endLine: Integer, lineToHighlight: Option[Integer] = None): String = {
-    val lines = Try(File(filename).lines.toList).getOrElse {
+    val lines = Try(IOUtils.readLinesInFile(Paths.get(filename))).getOrElse {
       logger.warn("error reading from: " + filename);
       List()
     }


### PR DESCRIPTION
Also:
Added IOUtils. Reads a file at the given path and:
 - skips BOM if present
 - removes unpaired surrogates
 - uses UTF-8 encoding (replacing malformed and unmappable characters)

We want to use this in all frontends as soon as this is released.