### PR TITLE
Use scala 2.13 by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val overflowdbVersion = "1.84"
 inThisBuild(
   List(
     organization := "io.shiftleft",
-    scalaVersion := "3.1.0",
+    scalaVersion := "2.13.7",
     crossScalaVersions := Seq("2.13.7", "3.1.0"),
     resolvers ++= Seq(
       Resolver.mavenLocal,


### PR DESCRIPTION
While our code is now ready for scala 3, Intellij's support is still marked as experimental. After attempting to debug various Intellij issues related to the switch to scala 3, I'd like us to at least move the default build back to scala 2.13 until Intellij's support has further matured.
