### PR TITLE
Operator extension cleanup and fixes

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Identifier}
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
-class ArrayAccessTraversal(val traversal: Traversal[opnodes.ArrayAccess]) extends AnyVal {
+class ArrayAccessTraversal(val traversal: Traversal[OpNodes.ArrayAccess]) extends AnyVal {
   def array: Traversal[Expression] = traversal.map(_.array)
   def subscripts: Traversal[Identifier] = traversal.flatMap(_.subscripts)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
@@ -7,14 +7,7 @@ import overflowdb.traversal._
 class ArrayAccessTraversal(val traversal: Traversal[OpNodes.ArrayAccess]) extends AnyVal {
   def array: Traversal[Expression] = traversal.map(_.array)
   def offset: Traversal[Expression] = traversal.map(_.offset)
-  def subscripts: Traversal[Identifier] = traversal.flatMap(_.subscripts)
-
-  /**
-    * Determine all array accesses at constant numeric offsets, e.g.,
-    * `buf[10]` but not `buf[i + 10]`, and for simplicity, not even `buf[1+2]`,
-    * `buf[PROBABLY_A_CONSTANT]` or `buf[PROBABLY_A_CONSTANT + 1]`,
-    * or even `buf[PROBABLY_A_CONSTANT]`.
-    */
+  def subscripts: Traversal[Identifier] = traversal.flatMap(_.subscript)
   def usesConstantOffset: Traversal[OpNodes.ArrayAccess] = traversal.filter(_.usesConstantOffset)
-
+  def simpleName: Traversal[String] = traversal.flatMap(_.simpleName)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/ArrayAccessTraversal.scala
@@ -6,5 +6,15 @@ import overflowdb.traversal._
 
 class ArrayAccessTraversal(val traversal: Traversal[OpNodes.ArrayAccess]) extends AnyVal {
   def array: Traversal[Expression] = traversal.map(_.array)
+  def offset: Traversal[Expression] = traversal.map(_.offset)
   def subscripts: Traversal[Identifier] = traversal.flatMap(_.subscripts)
+
+  /**
+    * Determine all array accesses at constant numeric offsets, e.g.,
+    * `buf[10]` but not `buf[i + 10]`, and for simplicity, not even `buf[1+2]`,
+    * `buf[PROBABLY_A_CONSTANT]` or `buf[PROBABLY_A_CONSTANT + 1]`,
+    * or even `buf[PROBABLY_A_CONSTANT]`.
+    */
+  def usesConstantOffset: Traversal[OpNodes.ArrayAccess] = traversal.filter(_.usesConstantOffset)
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
-class AssignmentTraversal(val traversal: Traversal[opnodes.Assignment]) extends AnyVal {
+class AssignmentTraversal(val traversal: Traversal[OpNodes.Assignment]) extends AnyVal {
   def target: Traversal[Expression] = traversal.map(_.target)
   def source: Traversal[Expression] = traversal.map(_.source)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/AssignmentTraversal.scala
@@ -3,8 +3,13 @@ package io.shiftleft.semanticcpg.language.operatorextension
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
+import overflowdb.traversal.help.Doc
 
 class AssignmentTraversal(val traversal: Traversal[OpNodes.Assignment]) extends AnyVal {
+
+  @Doc(info = "Left-hand sides of assignments")
   def target: Traversal[Expression] = traversal.map(_.target)
+
+  @Doc(info = "Right-hand sides of assignments")
   def source: Traversal[Expression] = traversal.map(_.source)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Implicits.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/Implicits.scala
@@ -7,12 +7,12 @@ import overflowdb.traversal._
 
 trait Implicits {
   implicit def toNodeTypeStartersOperatorExtension(cpg: Cpg): NodeTypeStarters = new NodeTypeStarters(cpg)
-  implicit def toArrayAccessExt(arrayAccess: opnodes.ArrayAccess): ArrayAccessMethods =
+  implicit def toArrayAccessExt(arrayAccess: OpNodes.ArrayAccess): ArrayAccessMethods =
     new ArrayAccessMethods(arrayAccess)
-  implicit def toArrayAccessTrav(steps: Traversal[opnodes.ArrayAccess]): ArrayAccessTraversal =
+  implicit def toArrayAccessTrav(steps: Traversal[OpNodes.ArrayAccess]): ArrayAccessTraversal =
     new ArrayAccessTraversal(steps)
-  implicit def toAssignmentExt(assignment: opnodes.Assignment): AssignmentMethods = new AssignmentMethods(assignment)
-  implicit def toAssignmentTrav(steps: Traversal[opnodes.Assignment]): AssignmentTraversal =
+  implicit def toAssignmentExt(assignment: OpNodes.Assignment): AssignmentMethods = new AssignmentMethods(assignment)
+  implicit def toAssignmentTrav(steps: Traversal[OpNodes.Assignment]): AssignmentTraversal =
     new AssignmentTraversal(steps)
   implicit def toTargetExt(call: Expression): TargetMethods = new TargetMethods(call)
   implicit def toTargetTrav(steps: Traversal[Expression]): TargetTraversal = new TargetTraversal(steps)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -11,6 +11,7 @@ object NodeTypeStarters {
   val assignmentAndArithmetic: Set[String] = Set(
     Operators.assignmentDivision,
     Operators.assignmentExponentiation,
+    Operators.assignmentPlus,
     Operators.assignmentMinus,
     Operators.assignmentModulo,
     Operators.assignmentMultiplication,
@@ -24,7 +25,6 @@ object NodeTypeStarters {
     Operators.assignment,
     Operators.assignmentOr,
     Operators.assignmentAnd,
-    Operators.assignmentPlus,
     Operators.assignmentXor,
     Operators.assignmentArithmeticShiftRight,
     Operators.assignmentLogicalShiftRight,

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -1,65 +1,29 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 import overflowdb.traversal.help.{Doc, TraversalSource}
 
-object NodeTypeStarters {
-
-  val assignmentAndArithmetic: Set[String] = Set(
-    Operators.assignmentDivision,
-    Operators.assignmentExponentiation,
-    Operators.assignmentPlus,
-    Operators.assignmentMinus,
-    Operators.assignmentModulo,
-    Operators.assignmentMultiplication,
-    Operators.preIncrement,
-    Operators.preDecrement,
-    Operators.postIncrement,
-    Operators.postIncrement,
-  )
-
-  val allAssignmentTypes: Set[String] = Set(
-    Operators.assignment,
-    Operators.assignmentOr,
-    Operators.assignmentAnd,
-    Operators.assignmentXor,
-    Operators.assignmentArithmeticShiftRight,
-    Operators.assignmentLogicalShiftRight,
-    Operators.assignmentShiftLeft,
-  ) ++ assignmentAndArithmetic
-
-  val allArithmeticTypes: Set[String] = Set(
-    Operators.addition,
-    Operators.subtraction,
-    Operators.division,
-    Operators.multiplication,
-    Operators.exponentiation,
-    Operators.modulo
-  ) ++ assignmentAndArithmetic
-
-}
-
 @TraversalSource
 class NodeTypeStarters(cpg: Cpg) {
-  import NodeTypeStarters._
 
   @Doc(info = "All assignments, including shorthand assignments that perform arithmetic (e.g., '+=')")
   def assignment: Traversal[opnodes.Assignment] =
-    cpg.call
-      .filter { x =>
-        allAssignmentTypes.contains(x.name)
-      }
+    callsWithNameIn(allAssignmentTypes)
       .map(new opnodes.Assignment(_))
 
   @Doc(info = "All arithmetic operations, including shorthand assignments that perform arithmetic (e.g., '+=')")
   def arithmetic: Traversal[opnodes.Arithmetic] =
-    cpg.call
-      .filter { x =>
-        allArithmeticTypes.contains(x.name)
-      }
+    callsWithNameIn(allArithmeticTypes)
       .map(new opnodes.Arithmetic(_))
+
+  @Doc(info = "All array accesses")
+  def arrayAccess: Traversal[opnodes.ArrayAccess] =
+    callsWithNameIn(allArrayAccessTypes)
+      .map(new opnodes.ArrayAccess(_))
+
+  private def callsWithNameIn(set: Set[String]) =
+    cpg.call.filter(x => set.contains(x.name))
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -9,19 +9,19 @@ import overflowdb.traversal.help.{Doc, TraversalSource}
 class NodeTypeStarters(cpg: Cpg) {
 
   @Doc(info = "All assignments, including shorthand assignments that perform arithmetic (e.g., '+=')")
-  def assignment: Traversal[opnodes.Assignment] =
+  def assignment: Traversal[OpNodes.Assignment] =
     callsWithNameIn(allAssignmentTypes)
-      .map(new opnodes.Assignment(_))
+      .map(new OpNodes.Assignment(_))
 
   @Doc(info = "All arithmetic operations, including shorthand assignments that perform arithmetic (e.g., '+=')")
-  def arithmetic: Traversal[opnodes.Arithmetic] =
+  def arithmetic: Traversal[OpNodes.Arithmetic] =
     callsWithNameIn(allArithmeticTypes)
-      .map(new opnodes.Arithmetic(_))
+      .map(new OpNodes.Arithmetic(_))
 
   @Doc(info = "All array accesses")
-  def arrayAccess: Traversal[opnodes.ArrayAccess] =
+  def arrayAccess: Traversal[OpNodes.ArrayAccess] =
     callsWithNameIn(allArrayAccessTypes)
-      .map(new opnodes.ArrayAccess(_))
+      .map(new OpNodes.ArrayAccess(_))
 
   private def callsWithNameIn(set: Set[String]) =
     cpg.call.filter(x => set.contains(x.name))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/NodeTypeStarters.scala
@@ -1,24 +1,65 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 import overflowdb.traversal.help.{Doc, TraversalSource}
 
 object NodeTypeStarters {
-  val assignmentPattern = "<operator>.(assignment.*)|(.*(increment|decrement))"
-  val arithmeticPattern = "<operator>.(addition|subtraction|division|multiplication|exponentiation|modulo)"
+
+  val assignmentAndArithmetic: Set[String] = Set(
+    Operators.assignmentDivision,
+    Operators.assignmentExponentiation,
+    Operators.assignmentMinus,
+    Operators.assignmentModulo,
+    Operators.assignmentMultiplication,
+    Operators.preIncrement,
+    Operators.preDecrement,
+    Operators.postIncrement,
+    Operators.postIncrement,
+  )
+
+  val allAssignmentTypes: Set[String] = Set(
+    Operators.assignment,
+    Operators.assignmentOr,
+    Operators.assignmentAnd,
+    Operators.assignmentPlus,
+    Operators.assignmentXor,
+    Operators.assignmentArithmeticShiftRight,
+    Operators.assignmentLogicalShiftRight,
+    Operators.assignmentShiftLeft,
+  ) ++ assignmentAndArithmetic
+
+  val allArithmeticTypes: Set[String] = Set(
+    Operators.addition,
+    Operators.subtraction,
+    Operators.division,
+    Operators.multiplication,
+    Operators.exponentiation,
+    Operators.modulo
+  ) ++ assignmentAndArithmetic
+
 }
 
 @TraversalSource
 class NodeTypeStarters(cpg: Cpg) {
   import NodeTypeStarters._
 
-  @Doc(info = "All assignments")
+  @Doc(info = "All assignments, including shorthand assignments that perform arithmetic (e.g., '+=')")
   def assignment: Traversal[opnodes.Assignment] =
-    cpg.call.name(assignmentPattern).map(new opnodes.Assignment(_))
+    cpg.call
+      .filter { x =>
+        allAssignmentTypes.contains(x.name)
+      }
+      .map(new opnodes.Assignment(_))
 
-  @Doc(info = "All arithmetic operations")
+  @Doc(info = "All arithmetic operations, including shorthand assignments that perform arithmetic (e.g., '+=')")
   def arithmetic: Traversal[opnodes.Arithmetic] =
-    cpg.call.name(arithmeticPattern).map(new opnodes.Arithmetic(_))
+    cpg.call
+      .filter { x =>
+        allArithmeticTypes.contains(x.name)
+      }
+      .map(new opnodes.Arithmetic(_))
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNode.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpAstNode.scala
@@ -5,7 +5,7 @@ import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
 
 class OpAstNode[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {
-  def inAssignment: Traversal[opnodes.Assignment] = traversal.flatMap(_.inAssignment)
-  def assignments: Traversal[opnodes.Assignment] = traversal.flatMap(_.assignments)
-  def arithmetics: Traversal[opnodes.Arithmetic] = traversal.flatMap(_.arithmetics)
+  def inAssignment: Traversal[OpNodes.Assignment] = traversal.flatMap(_.inAssignment)
+  def assignments: Traversal[OpNodes.Assignment] = traversal.flatMap(_.assignments)
+  def arithmetics: Traversal[OpNodes.Arithmetic] = traversal.flatMap(_.arithmetics)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpNodes.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/OpNodes.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.nodes.Call
 
-object opnodes {
+object OpNodes {
   class Assignment(call: Call) extends Call(call.graph, call.id)
   class Arithmetic(call: Call) extends Call(call.graph, call.id)
   class ArrayAccess(call: Call) extends Call(call.graph, call.id)

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
@@ -3,12 +3,11 @@ package io.shiftleft.semanticcpg.language.operatorextension
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal._
+import overflowdb.traversal.help.Doc
 
 class TargetTraversal(val traversal: Traversal[Expression]) extends AnyVal {
 
-  /** arrayAccess traverses to all array accesses, including nested array accesses.
-    * For example, for `x = buf[idxs[i]];`, it will return two array accesses.
-    */
+  @Doc(info = "(Top-level) array accesses used as assignment targets")
   def arrayAccess: Traversal[OpNodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
@@ -6,9 +6,8 @@ import overflowdb.traversal._
 
 class TargetTraversal(val traversal: Traversal[Expression]) extends AnyVal {
 
-  /** arrayAccess traverses to all array accesses below in the AST. For example, when called on the assignment
-    *   `x = buf[idxs[i]];``
-    * then it will return two array accesses.
+  /** arrayAccess traverses to all array accesses, including nested array accesses.
+    * For example, for `x = buf[idxs[i]];`, it will return two array accesses.
     */
   def arrayAccess: Traversal[OpNodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/TargetTraversal.scala
@@ -10,8 +10,6 @@ class TargetTraversal(val traversal: Traversal[Expression]) extends AnyVal {
     *   `x = buf[idxs[i]];``
     * then it will return two array accesses.
     */
-  def arrayAccess: Traversal[opnodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
+  def arrayAccess: Traversal[OpNodes.ArrayAccess] = traversal.flatMap(_.arrayAccess)
 
-  @deprecated("isArrayAccess is deprecated in favor if arrayAccess, due to counterintuitive naming")
-  def isArrayAccess: Traversal[opnodes.ArrayAccess] = arrayAccess
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
@@ -9,6 +9,16 @@ class ArrayAccessMethods(val arrayAccess: OpNodes.ArrayAccess) extends AnyVal {
   def array: Expression =
     arrayAccess.argument(1)
 
+  def offset: Expression = arrayAccess.argument(2)
+
   def subscripts: Traversal[Identifier] =
-    arrayAccess.argument(2).ast.isIdentifier
+    offset.ast.isIdentifier
+
+  def usesConstantOffset: Boolean = {
+    (offset.ast.isIdentifier.size > 0) || {
+      val literalIndices = offset.ast.isLiteral.l
+      literalIndices.size == 1
+    }
+  }
+
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
@@ -2,10 +2,10 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Identifier}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.opnodes
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import overflowdb.traversal._
 
-class ArrayAccessMethods(val arrayAccess: opnodes.ArrayAccess) extends AnyVal {
+class ArrayAccessMethods(val arrayAccess: OpNodes.ArrayAccess) extends AnyVal {
   def array: Expression =
     arrayAccess.argument(1)
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
@@ -6,18 +6,44 @@ import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import overflowdb.traversal._
 
 class ArrayAccessMethods(val arrayAccess: OpNodes.ArrayAccess) extends AnyVal {
+
+  /**
+    * The expression representing the array
+    * */
   def array: Expression =
     arrayAccess.argument(1)
 
+  /**
+    * The expression representing the offset at which the array is referenced.
+    * */
   def offset: Expression = arrayAccess.argument(2)
 
-  def subscripts: Traversal[Identifier] =
+  /**
+    * All identifiers that are part of the offset
+    * */
+  def subscript: Traversal[Identifier] =
     offset.ast.isIdentifier
 
+  /**
+    * Determine if array access is at constant numeric offset, e.g.,
+    * `buf[10]` but not `buf[i + 10]`, and for simplicity, not even `buf[1+2]`,
+    * `buf[PROBABLY_A_CONSTANT]` or `buf[PROBABLY_A_CONSTANT + 1]`,
+    * or even `buf[PROBABLY_A_CONSTANT]`.
+    */
   def usesConstantOffset: Boolean = {
     (offset.ast.isIdentifier.size > 0) || {
       val literalIndices = offset.ast.isLiteral.l
       literalIndices.size == 1
+    }
+  }
+
+  /**
+    * If `array` is a lone identifier, return its name
+    */
+  def simpleName: Traversal[String] = {
+    arrayAccess.array match {
+      case id: Identifier => Traversal(id.name)
+      case _              => Traversal()
     }
   }
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
@@ -5,6 +5,15 @@ import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 
 class AssignmentMethods(val assignment: OpNodes.Assignment) extends AnyVal {
+
   def target: Expression = assignment.argument(1)
-  def source: Expression = assignment.argument(2)
+
+  def source: Expression = {
+    val numberOfArguments = assignment.argument.size
+    numberOfArguments match {
+      case 1 => assignment.argument(1)
+      case 2 => assignment.argument(2)
+      case _ => throw new RuntimeException(s"Assignment statement with $numberOfArguments arguments")
+    }
+  }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/AssignmentMethods.scala
@@ -2,9 +2,9 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.opnodes
+import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 
-class AssignmentMethods(val assignment: opnodes.Assignment) extends AnyVal {
+class AssignmentMethods(val assignment: OpNodes.Assignment) extends AnyVal {
   def target: Expression = assignment.argument(1)
   def source: Expression = assignment.argument(2)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
@@ -7,14 +7,20 @@ import overflowdb.traversal._
 
 class OpAstNodeMethods[A <: AstNode](val node: A) extends AnyVal {
   def inAssignment: Traversal[opnodes.Assignment] =
-    node.start.inAstMinusLeaf.isCall.name(ExtStarters.assignmentPattern).map(new opnodes.Assignment(_))
+    node.start.inAstMinusLeaf.isCall
+      .filter { x =>
+        ExtStarters.allAssignmentTypes.contains(x.name)
+      }
+      .map(new opnodes.Assignment(_))
 
   def assignments: Traversal[opnodes.Assignment] =
-    rawTravForPattern(ExtStarters.assignmentPattern).map(new opnodes.Assignment(_))
+    rawTravForPattern(ExtStarters.allAssignmentTypes).map(new opnodes.Assignment(_))
 
   def arithmetics: Traversal[opnodes.Arithmetic] =
-    rawTravForPattern(ExtStarters.arithmeticPattern).map(new opnodes.Arithmetic(_))
+    rawTravForPattern(ExtStarters.allArithmeticTypes).map(new opnodes.Arithmetic(_))
 
-  private def rawTravForPattern(pattern: String): Traversal[Call] =
-    node.ast.isCall.name(pattern)
+  private def rawTravForPattern(strings: Set[String]): Traversal[Call] =
+    node.ast.isCall.filter { x =>
+      strings.contains(x.name)
+    }
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
@@ -2,20 +2,20 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.{allArithmeticTypes, allAssignmentTypes, opnodes}
+import io.shiftleft.semanticcpg.language.operatorextension.{OpNodes, allArithmeticTypes, allAssignmentTypes}
 import overflowdb.traversal._
 
 class OpAstNodeMethods[A <: AstNode](val node: A) extends AnyVal {
-  def inAssignment: Traversal[opnodes.Assignment] =
+  def inAssignment: Traversal[OpNodes.Assignment] =
     node.start.inAstMinusLeaf.isCall
       .filter(x => allAssignmentTypes.contains(x.name))
-      .map(new opnodes.Assignment(_))
+      .map(new OpNodes.Assignment(_))
 
-  def assignments: Traversal[opnodes.Assignment] =
-    rawTravForPattern(allAssignmentTypes).map(new opnodes.Assignment(_))
+  def assignments: Traversal[OpNodes.Assignment] =
+    rawTravForPattern(allAssignmentTypes).map(new OpNodes.Assignment(_))
 
-  def arithmetics: Traversal[opnodes.Arithmetic] =
-    rawTravForPattern(allArithmeticTypes).map(new opnodes.Arithmetic(_))
+  def arithmetics: Traversal[OpNodes.Arithmetic] =
+    rawTravForPattern(allArithmeticTypes).map(new OpNodes.Arithmetic(_))
 
   private def rawTravForPattern(strings: Set[String]): Traversal[Call] =
     node.ast.isCall.filter(x => strings.contains(x.name))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
@@ -2,25 +2,21 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.{NodeTypeStarters => ExtStarters, _}
+import io.shiftleft.semanticcpg.language.operatorextension.{allArithmeticTypes, allAssignmentTypes, opnodes}
 import overflowdb.traversal._
 
 class OpAstNodeMethods[A <: AstNode](val node: A) extends AnyVal {
   def inAssignment: Traversal[opnodes.Assignment] =
     node.start.inAstMinusLeaf.isCall
-      .filter { x =>
-        ExtStarters.allAssignmentTypes.contains(x.name)
-      }
+      .filter(x => allAssignmentTypes.contains(x.name))
       .map(new opnodes.Assignment(_))
 
   def assignments: Traversal[opnodes.Assignment] =
-    rawTravForPattern(ExtStarters.allAssignmentTypes).map(new opnodes.Assignment(_))
+    rawTravForPattern(allAssignmentTypes).map(new opnodes.Assignment(_))
 
   def arithmetics: Traversal[opnodes.Arithmetic] =
-    rawTravForPattern(ExtStarters.allArithmeticTypes).map(new opnodes.Arithmetic(_))
+    rawTravForPattern(allArithmeticTypes).map(new opnodes.Arithmetic(_))
 
   private def rawTravForPattern(strings: Set[String]): Traversal[Call] =
-    node.ast.isCall.filter { x =>
-      strings.contains(x.name)
-    }
+    node.ast.isCall.filter(x => strings.contains(x.name))
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -1,9 +1,8 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.opnodes
+import io.shiftleft.semanticcpg.language.operatorextension.{allArrayAccessTypes, opnodes}
 import overflowdb.traversal._
 
 class TargetMethods(val expr: Expression) extends AnyVal {
@@ -14,10 +13,7 @@ class TargetMethods(val expr: Expression) extends AnyVal {
     */
   def arrayAccess: Traversal[opnodes.ArrayAccess] =
     expr.ast.isCall
-      .nameExact(Operators.computedMemberAccess,
-                 Operators.indirectComputedMemberAccess,
-                 Operators.indexAccess,
-                 Operators.indirectIndexAccess)
+      .filter(x => allArrayAccessTypes.contains(x.name))
       .map(new opnodes.ArrayAccess(_))
 
   @deprecated("isArrayAccess is deprecated in favor if arrayAccess, due to counterintuitive naming")

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -7,13 +7,9 @@ import overflowdb.traversal._
 
 class TargetMethods(val expr: Expression) extends AnyVal {
 
-  /** arrayAccess traverses to all array accesses below in the AST. For example, when called on the assignment
-    *   `x = buf[idxs[i]];``
-    * then it will return two array accesses.
-    */
   def arrayAccess: Traversal[OpNodes.ArrayAccess] =
     expr.ast.isCall
-      .filter(x => allArrayAccessTypes.contains(x.name))
+      .collectFirst { case x if allArrayAccessTypes.contains(x.name) => x }
       .map(new OpNodes.ArrayAccess(_))
 
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -2,7 +2,7 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
 import io.shiftleft.codepropertygraph.generated.nodes.Expression
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.semanticcpg.language.operatorextension.{allArrayAccessTypes, opnodes}
+import io.shiftleft.semanticcpg.language.operatorextension.{OpNodes, allArrayAccessTypes}
 import overflowdb.traversal._
 
 class TargetMethods(val expr: Expression) extends AnyVal {
@@ -11,11 +11,9 @@ class TargetMethods(val expr: Expression) extends AnyVal {
     *   `x = buf[idxs[i]];``
     * then it will return two array accesses.
     */
-  def arrayAccess: Traversal[opnodes.ArrayAccess] =
+  def arrayAccess: Traversal[OpNodes.ArrayAccess] =
     expr.ast.isCall
       .filter(x => allArrayAccessTypes.contains(x.name))
-      .map(new opnodes.ArrayAccess(_))
+      .map(new OpNodes.ArrayAccess(_))
 
-  @deprecated("isArrayAccess is deprecated in favor if arrayAccess, due to counterintuitive naming")
-  def isArrayAccess: Traversal[opnodes.ArrayAccess] = arrayAccess
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/package.scala
@@ -1,0 +1,46 @@
+package io.shiftleft.semanticcpg.language
+
+import io.shiftleft.codepropertygraph.generated.Operators
+
+package object operatorextension {
+
+  val assignmentAndArithmetic: Set[String] = Set(
+    Operators.assignmentDivision,
+    Operators.assignmentExponentiation,
+    Operators.assignmentPlus,
+    Operators.assignmentMinus,
+    Operators.assignmentModulo,
+    Operators.assignmentMultiplication,
+    Operators.preIncrement,
+    Operators.preDecrement,
+    Operators.postIncrement,
+    Operators.postIncrement,
+  )
+
+  val allAssignmentTypes: Set[String] = Set(
+    Operators.assignment,
+    Operators.assignmentOr,
+    Operators.assignmentAnd,
+    Operators.assignmentXor,
+    Operators.assignmentArithmeticShiftRight,
+    Operators.assignmentLogicalShiftRight,
+    Operators.assignmentShiftLeft,
+  ) ++ assignmentAndArithmetic
+
+  val allArithmeticTypes: Set[String] = Set(
+    Operators.addition,
+    Operators.subtraction,
+    Operators.division,
+    Operators.multiplication,
+    Operators.exponentiation,
+    Operators.modulo
+  ) ++ assignmentAndArithmetic
+
+  val allArrayAccessTypes: Set[String] = Set(
+    Operators.computedMemberAccess,
+    Operators.indirectComputedMemberAccess,
+    Operators.indexAccess,
+    Operators.indirectIndexAccess
+  )
+
+}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
@@ -134,11 +134,11 @@ package object testing {
         }
       }
 
-    def withCallInMethod(methodName: String, callName: String): MockCpg =
+    def withCallInMethod(methodName: String, callName: String, code: Option[String] = None): MockCpg =
       withCustom { (graph, cpg) =>
         val methodNode = cpg.method.name(methodName).head
         val blockNode = methodNode.block.head
-        val callNode = NewCall().name(callName).code(callName)
+        val callNode = NewCall().name(callName).code(code.getOrElse(callName))
         graph.addNode(callNode)
         graph.addEdge(blockNode, callNode, EdgeTypes.AST)
         graph.addEdge(methodNode, callNode, EdgeTypes.CONTAINS)
@@ -168,7 +168,6 @@ package object testing {
         graph.addNode(typeDecl)
         graph.addNode(literalNode)
         graph.addEdge(callNode, literalNode, EdgeTypes.AST)
-
         graph.addEdge(methodNode, literalNode, EdgeTypes.CONTAINS)
       }
     }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/testing/package.scala
@@ -172,15 +172,16 @@ package object testing {
       }
     }
 
-    def withIdentifierArgument(callName: String, name: String): MockCpg =
+    def withIdentifierArgument(callName: String, name: String, index: Int = 1): MockCpg =
       withCustom { (graph, cpg) =>
         val callNode = cpg.call.name(callName).head
         val methodNode = callNode.method.head
-        val identifierNode = NewIdentifier().name(name)
+        val identifierNode = NewIdentifier().name(name).argumentIndex(index)
         val typeDecl = NewTypeDecl().name("abc")
         graph.addNode(identifierNode)
         graph.addNode(typeDecl)
         graph.addEdge(callNode, identifierNode, EdgeTypes.AST)
+        graph.addEdge(callNode, identifierNode, EdgeTypes.ARGUMENT)
         graph.addEdge(methodNode, identifierNode, EdgeTypes.CONTAINS)
         graph.addEdge(identifierNode, typeDecl, EdgeTypes.REF)
       }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
@@ -13,41 +13,41 @@ class OperatorExtensionTests extends AnyWordSpec with Matchers {
   "NodeTypeStarters" should {
 
     "allow retrieving assignments" in {
-      val cpg = MockCpg()
-        .withMethod(methodName)
-        .withCallInMethod(methodName, Operators.assignment, Some("x = 10"))
-        .cpg
-
+      val cpg = mockCpgWithCallAndCode(Operators.assignment, "x = 10")
       val List(x: opnodes.Assignment) = cpg.assignment.l
       x.name shouldBe Operators.assignment
       x.code shouldBe "x = 10"
     }
 
     "allow retrieving arithmetic expressions" in {
-      val cpg = MockCpg()
-        .withMethod(methodName)
-        .withCallInMethod(methodName, Operators.addition, Some("10 + 20"))
-        .cpg
-
-      val List(x) = cpg.arithmetic.l
+      val cpg = mockCpgWithCallAndCode(Operators.addition, "10 + 20")
+      val List(x: opnodes.Arithmetic) = cpg.arithmetic.l
       x.name shouldBe Operators.addition
       x.code shouldBe "10 + 20"
     }
 
     "include '+=' in both assignments and arithmetics" in {
-      val cpg = MockCpg()
-        .withMethod(methodName)
-        .withCallInMethod(methodName, Operators.assignmentPlus, Some("x += 10"))
-        .cpg
-
+      val cpg = mockCpgWithCallAndCode(Operators.assignmentPlus, "x += 10")
       val List(y: opnodes.Arithmetic) = cpg.arithmetic.l
       val List(x: opnodes.Assignment) = cpg.assignment.l
-
       x.id shouldBe y.id
       x.name shouldBe Operators.assignmentPlus
       x.code shouldBe "x += 10"
     }
 
+    "allow retrieving array accesses" in {
+      val cpg = mockCpgWithCallAndCode(Operators.indexAccess, "x[i]")
+      val List(x: opnodes.ArrayAccess) = cpg.arrayAccess.l
+      x.name shouldBe Operators.indexAccess
+      x.code shouldBe "x[i]"
+    }
+
   }
+
+  private def mockCpgWithCallAndCode(name: String, code: String) =
+    MockCpg()
+      .withMethod(methodName)
+      .withCallInMethod(methodName, name, Some(code))
+      .cpg
 
 }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
@@ -1,0 +1,38 @@
+package io.shiftleft.semanticcpg.language.operatorextension
+
+import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.testing.MockCpg
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.shiftleft.semanticcpg.language._
+
+class OperatorExtensionTests extends AnyWordSpec with Matchers {
+
+  private val methodName = "method"
+
+  "NodeTypeStarters" should {
+
+    "allow retrieving assignments" in {
+      val cpg = MockCpg()
+        .withMethod(methodName)
+        .withCallInMethod(methodName, Operators.assignment, Some("x = 10"))
+        .cpg
+
+      val List(x: opnodes.Assignment) = cpg.assignment.l
+      x.name shouldBe Operators.assignment
+      x.code shouldBe "x = 10"
+    }
+
+    "allow retrieving arithmetic expressions" in {
+      val cpg = MockCpg()
+        .withMethod(methodName)
+        .withCallInMethod(methodName, Operators.addition, Some("10 + 20"))
+        .cpg
+      val List(x) = cpg.arithmetic.l
+      x.name shouldBe Operators.addition
+      x.code shouldBe "10 + 20"
+    }
+
+  }
+
+}

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
@@ -1,10 +1,10 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
 import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.shiftleft.semanticcpg.language._
 
 class OperatorExtensionTests extends AnyWordSpec with Matchers {
 
@@ -28,9 +28,24 @@ class OperatorExtensionTests extends AnyWordSpec with Matchers {
         .withMethod(methodName)
         .withCallInMethod(methodName, Operators.addition, Some("10 + 20"))
         .cpg
+
       val List(x) = cpg.arithmetic.l
       x.name shouldBe Operators.addition
       x.code shouldBe "10 + 20"
+    }
+
+    "include '+=' in both assignments and arithmetics" in {
+      val cpg = MockCpg()
+        .withMethod(methodName)
+        .withCallInMethod(methodName, Operators.assignmentPlus, Some("x += 10"))
+        .cpg
+
+      val List(y: opnodes.Arithmetic) = cpg.arithmetic.l
+      val List(x: opnodes.Assignment) = cpg.assignment.l
+
+      x.id shouldBe y.id
+      x.name shouldBe Operators.assignmentPlus
+      x.code shouldBe "x += 10"
     }
 
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
@@ -14,22 +14,22 @@ class OperatorExtensionTests extends AnyWordSpec with Matchers {
 
     "allow retrieving assignments" in {
       val cpg = mockCpgWithCallAndCode(Operators.assignment, "x = 10")
-      val List(x: opnodes.Assignment) = cpg.assignment.l
+      val List(x: OpNodes.Assignment) = cpg.assignment.l
       x.name shouldBe Operators.assignment
       x.code shouldBe "x = 10"
     }
 
     "allow retrieving arithmetic expressions" in {
       val cpg = mockCpgWithCallAndCode(Operators.addition, "10 + 20")
-      val List(x: opnodes.Arithmetic) = cpg.arithmetic.l
+      val List(x: OpNodes.Arithmetic) = cpg.arithmetic.l
       x.name shouldBe Operators.addition
       x.code shouldBe "10 + 20"
     }
 
     "include '+=' in both assignments and arithmetics" in {
       val cpg = mockCpgWithCallAndCode(Operators.assignmentPlus, "x += 10")
-      val List(y: opnodes.Arithmetic) = cpg.arithmetic.l
-      val List(x: opnodes.Assignment) = cpg.assignment.l
+      val List(y: OpNodes.Arithmetic) = cpg.arithmetic.l
+      val List(x: OpNodes.Assignment) = cpg.assignment.l
       x.id shouldBe y.id
       x.name shouldBe Operators.assignmentPlus
       x.code shouldBe "x += 10"
@@ -37,7 +37,7 @@ class OperatorExtensionTests extends AnyWordSpec with Matchers {
 
     "allow retrieving array accesses" in {
       val cpg = mockCpgWithCallAndCode(Operators.indexAccess, "x[i]")
-      val List(x: opnodes.ArrayAccess) = cpg.arrayAccess.l
+      val List(x: OpNodes.ArrayAccess) = cpg.arrayAccess.l
       x.name shouldBe Operators.indexAccess
       x.code shouldBe "x[i]"
     }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/operatorextension/OperatorExtensionTests.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.semanticcpg.language.operatorextension
 
-import io.shiftleft.codepropertygraph.generated.Operators
+import io.shiftleft.codepropertygraph.generated.nodes.{Identifier, NewIdentifier}
+import io.shiftleft.codepropertygraph.generated.{EdgeTypes, Operators}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.testing.MockCpg
 import org.scalatest.matchers.should.Matchers
@@ -11,7 +12,6 @@ class OperatorExtensionTests extends AnyWordSpec with Matchers {
   private val methodName = "method"
 
   "NodeTypeStarters" should {
-
     "allow retrieving assignments" in {
       val cpg = mockCpgWithCallAndCode(Operators.assignment, "x = 10")
       val List(x: OpNodes.Assignment) = cpg.assignment.l
@@ -41,7 +41,33 @@ class OperatorExtensionTests extends AnyWordSpec with Matchers {
       x.name shouldBe Operators.indexAccess
       x.code shouldBe "x[i]"
     }
+  }
 
+  "Assignment" should {
+    "allow traversing to target/source for assignment with two arguments" in {
+      val cpg = MockCpg()
+        .withMethod(methodName)
+        .withCallInMethod(methodName, Operators.assignment, Some("x = y"))
+        .withCustom { (graph, cpg) =>
+          val List(call) = cpg.call(Operators.assignment).l
+          val arg1 = NewIdentifier().name("x").argumentIndex(1)
+          val arg2 = NewIdentifier().name("y").argumentIndex(2)
+          graph.addNode(arg1)
+          graph.addNode(arg2)
+          graph.addEdge(call, arg1, EdgeTypes.ARGUMENT)
+          graph.addEdge(call, arg2, EdgeTypes.ARGUMENT)
+        }
+        .cpg
+
+      val List(target: Identifier) = cpg.assignment.target.l
+      target.name shouldBe "x"
+      val List(source: Identifier) = cpg.assignment.source.l
+      source.name shouldBe "y"
+
+      val List((x: Identifier, y: Identifier)) = cpg.assignment.map(x => (x.target, x.source)).l
+      x.name shouldBe "x"
+      y.name shouldBe "y"
+    }
   }
 
   private def mockCpgWithCallAndCode(name: String, code: String) =


### PR DESCRIPTION
As I write more queries for querydb, I am cleaning up and improving the operator extension, bringing in tests so that we've set in stone what it does and does not do. This is a first round of cleanups and tests. Minor downstream adjustment required: `opnodes` is now `OpNodes` in accordance with our convention of naming objects with upper-case letters.