### PR TITLE
cleanup imports, mostly to fix intellij squiggles

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Properties}
 import overflowdb._
-import overflowdb.traversal.{Traversal, jIteratortoTraversal}
+import overflowdb.traversal.{jIteratortoTraversal, toElementTraversal, Traversal}
 import overflowdb.traversal.help.{Doc, TraversalSource}
 
 @TraversalSource

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -3,9 +3,8 @@ package io.shiftleft.semanticcpg.language
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Properties}
-import io.shiftleft.semanticcpg.language._
 import overflowdb._
-import overflowdb.traversal._
+import overflowdb.traversal.{Traversal, jIteratortoTraversal}
 import overflowdb.traversal.help.{Doc, TraversalSource}
 
 @TraversalSource
@@ -214,8 +213,7 @@ class NodeTypeStarters(cpg: Cpg) {
     cpg.graph.nodes(NodeTypes.METHOD_REF).cast[MethodRef]
 
   /**
-    * Shorthand for `cpg.methodRef
-    * .filter(_.referencedMethod.name(name))`
+    * Shorthand for `cpg.methodRef.filter(_.referencedMethod.name(name))`
     * */
   def methodRef(name: String): Traversal[MethodRef] =
     methodRef.where(_.referencedMethod.name(name))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/NodeTypeStarters.scala
@@ -4,8 +4,8 @@ import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{NodeTypes, Properties}
 import overflowdb._
-import overflowdb.traversal.{jIteratortoTraversal, toElementTraversal, Traversal}
 import overflowdb.traversal.help.{Doc, TraversalSource}
+import overflowdb.traversal.{Traversal, jIteratortoTraversal, toElementTraversal}
 
 @TraversalSource
 class NodeTypeStarters(cpg: Cpg) {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.callgraphextension
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{PathAwareTraversal, Traversal}
+import overflowdb.traversal.{toNodeTraversal, PathAwareTraversal, Traversal}
 import overflowdb.traversal.help.Doc
 
 class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.callgraphextension
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.{PathAwareTraversal, Traversal}
 import overflowdb.traversal.help.Doc
 
 class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/callgraphextension/MethodTraversal.scala
@@ -3,8 +3,8 @@ package io.shiftleft.semanticcpg.language.callgraphextension
 import io.shiftleft.codepropertygraph.generated.EdgeTypes
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Method}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{toNodeTraversal, PathAwareTraversal, Traversal}
 import overflowdb.traversal.help.Doc
+import overflowdb.traversal.{PathAwareTraversal, Traversal, toNodeTraversal}
 
 class MethodTraversal(val traversal: Traversal[Method]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/AstNodeMethods.scala
@@ -4,7 +4,7 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 
 class AstNodeMethods(val node: AstNode) extends AnyVal with NodeExtension {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -4,7 +4,7 @@ import io.shiftleft.Implicits.JavaIteratorDeco
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{toCfgNode, toCfgNodeMethods}
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 
 import scala.jdk.CollectionConverters._
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -5,7 +5,6 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{toCfgNode, toCfgNodeMethods}
 import overflowdb.traversal.Traversal
-
 import scala.jdk.CollectionConverters._
 
 class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
@@ -131,7 +130,7 @@ class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {
           }
       }
     }
-    controllingNodes
+    Traversal.from(controllingNodes)
   }
 
   def method: Method = node match {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CfgNodeMethods.scala
@@ -5,6 +5,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language.{toCfgNode, toCfgNodeMethods}
 import overflowdb.traversal.Traversal
+
 import scala.jdk.CollectionConverters._
 
 class CfgNodeMethods(val node: CfgNode) extends AnyVal with NodeExtension {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,6 +1,14 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{Block, CfgNode, ControlStructure, Local, Method, NewLocation, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Block,
+  CfgNode,
+  ControlStructure,
+  Local,
+  Method,
+  NewLocation,
+  TypeDecl
+}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
 import overflowdb.traversal.{Traversal, jIteratortoTraversal}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/MethodMethods.scala
@@ -1,17 +1,9 @@
 package io.shiftleft.semanticcpg.language.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  Block,
-  CfgNode,
-  ControlStructure,
-  Local,
-  Method,
-  NewLocation,
-  TypeDecl
-}
+import io.shiftleft.codepropertygraph.generated.nodes.{Block, CfgNode, ControlStructure, Local, Method, NewLocation, TypeDecl}
 import io.shiftleft.semanticcpg.NodeExtension
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.{Traversal, jIteratortoTraversal}
 
 class MethodMethods(val method: Method) extends AnyVal with NodeExtension with HasLocation {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/ArrayAccessMethods.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Identifier}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 
 class ArrayAccessMethods(val arrayAccess: OpNodes.ArrayAccess) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/OpAstNodeMethods.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, Call}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.{OpNodes, allArithmeticTypes, allAssignmentTypes}
-import overflowdb.traversal._
+import overflowdb.traversal.{NodeOps, Traversal}
 
 class OpAstNodeMethods[A <: AstNode](val node: A) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -4,6 +4,7 @@ import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.{OpNodes, allArrayAccessTypes}
+import overflowdb.traversal.Traversal
 
 class TargetMethods(val expr: Expression) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.{OpNodes, allArrayAccessTypes}
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 
 class TargetMethods(val expr: Expression) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/TargetMethods.scala
@@ -4,11 +4,10 @@ import io.shiftleft.codepropertygraph.generated.Operators
 import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.{OpNodes, allArrayAccessTypes}
-import overflowdb.traversal.Traversal
 
 class TargetMethods(val expr: Expression) extends AnyVal {
 
-  def arrayAccess: Traversal[OpNodes.ArrayAccess] =
+  def arrayAccess: Option[OpNodes.ArrayAccess] =
     expr.ast.isCall
       .collectFirst { case x if allArrayAccessTypes.contains(x.name) => x }
       .map(new OpNodes.ArrayAccess(_))

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, ControlStructure, Expression}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal.{toNodeTraversal, toElementTraversal, Traversal}
 import overflowdb.traversal.help.Doc
 
 object ControlStructureTraversal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -3,8 +3,8 @@ package io.shiftleft.semanticcpg.language.types.expressions
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, ControlStructure, Expression}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{toNodeTraversal, toElementTraversal, Traversal}
 import overflowdb.traversal.help.Doc
+import overflowdb.traversal.{Traversal, toElementTraversal, toNodeTraversal}
 
 object ControlStructureTraversal {
   val secondChildIndex = 2

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/ControlStructureTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions
 import io.shiftleft.codepropertygraph.generated.nodes.{AstNode, ControlStructure, Expression}
 import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, EdgeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 import overflowdb.traversal.help.Doc
 
 object ControlStructureTraversal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -3,8 +3,8 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{help, iterableToTraversal, toNodeTraversal, toElementTraversal, Traversal}
 import overflowdb.traversal.help.Doc
+import overflowdb.traversal.{Traversal, help, iterableToTraversal, toElementTraversal, toNodeTraversal}
 
 @help.Traversal(elementType = classOf[AstNode])
 class AstNodeTraversal[A <: AstNode](val traversal: Traversal[A]) extends AnyVal {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.{help, Traversal}
 import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[AstNode])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/generalizations/AstNodeTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.expressions.generalizations
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{help, Traversal}
+import overflowdb.traversal.{help, iterableToTraversal, toNodeTraversal, toElementTraversal, Traversal}
 import overflowdb.traversal.help.Doc
 
 @help.Traversal(elementType = classOf[AstNode])

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -4,8 +4,8 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import overflowdb._
-import overflowdb.traversal.{help, toNodeTraversal, toElementTraversal, Traversal}
 import overflowdb.traversal.help.Doc
+import overflowdb.traversal.{Traversal, help, toElementTraversal, toNodeTraversal}
 
 /**
   * A method, function, or procedure

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import overflowdb._
-import overflowdb.traversal.{Traversal, help}
+import overflowdb.traversal.{help, toNodeTraversal, toElementTraversal, Traversal}
 import overflowdb.traversal.help.Doc
 
 /**

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/MethodTraversal.scala
@@ -4,14 +4,14 @@ import io.shiftleft.codepropertygraph.generated._
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.semanticcpg.language._
 import overflowdb._
-import overflowdb.traversal._
+import overflowdb.traversal.{Traversal, help}
 import overflowdb.traversal.help.Doc
 
 /**
   * A method, function, or procedure
   * */
 @help.Traversal(elementType = classOf[Method])
-class MethodTraversal(val traversal: IterableOnce[Method]) extends AnyVal {
+class MethodTraversal(val iterableOnce: IterableOnce[Method]) extends AnyVal {
 
   /**
     * All control structures of this method
@@ -172,4 +172,5 @@ class MethodTraversal(val traversal: IterableOnce[Method]) extends AnyVal {
 
   def numberOfLines: Traversal[Int] = traversal.map(_.numberOfLines)
 
+  private def traversal = Traversal.from(iterableOnce)
 }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{toNodeTraversal, toElementTraversal, Traversal}
+import overflowdb.traversal.{Traversal, toElementTraversal, toNodeTraversal}
 
 /**
   * A namespace, e.g., Java package or C# namespace

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 
 /**
   * A namespace, e.g., Java package or C# namespace

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/NamespaceTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal.{toNodeTraversal, toElementTraversal, Traversal}
 
 /**
   * A namespace, e.g., Java package or C# namespace

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
 import overflowdb._
-import overflowdb.traversal.{toNodeTraversal, toElementTraversal, Traversal}
+import overflowdb.traversal.{Traversal, toElementTraversal, toNodeTraversal}
 
 /**
   * Type declaration - possibly a template that requires instantiation

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
 import overflowdb._
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 
 /**
   * Type declaration - possibly a template that requires instantiation

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -4,7 +4,7 @@ import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes, Properties}
 import io.shiftleft.semanticcpg.language._
 import overflowdb._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal.{toNodeTraversal, toElementTraversal, Traversal}
 
 /**
   * Type declaration - possibly a template that requires instantiation

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.Traversal
+import overflowdb.traversal.{toNodeTraversal, toElementTraversal, Traversal}
 
 class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 
 class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.language.types.structure
 import io.shiftleft.codepropertygraph.generated.nodes._
 import io.shiftleft.codepropertygraph.generated.{EdgeTypes, NodeTypes}
 import io.shiftleft.semanticcpg.language._
-import overflowdb.traversal.{toNodeTraversal, toElementTraversal, Traversal}
+import overflowdb.traversal.{Traversal, toElementTraversal, toNodeTraversal}
 
 class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/controlflow/cfgcreation/CfgCreator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/controlflow/cfgcreation/CfgCreator.scala
@@ -5,7 +5,7 @@ import io.shiftleft.codepropertygraph.generated.{ControlStructureTypes, Dispatch
 import io.shiftleft.passes.DiffGraph
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.passes.controlflow.cfgcreation.Cfg.CfgEdgeType
-import overflowdb.traversal._
+import overflowdb.traversal.Traversal
 
 /**
   * Translation of abstract syntax trees into control flow graphs

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -8,7 +8,7 @@ import org.json4s._
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.traversal._
+import overflowdb.traversal.{Traversal, jIteratortoTraversal}
 
 class StepsTest extends AnyWordSpec with Matchers {
 
@@ -57,7 +57,7 @@ class StepsTest extends AnyWordSpec with Matchers {
         val results: List[Method] = cpg.method.id(methods.map(_.id): _*).toList
 
         results.size shouldBe 2
-        results.toSetMutable shouldBe methods.toSetMutable
+        results.toSet shouldBe methods.toSet
       }
     }
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -8,7 +8,7 @@ import org.json4s._
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.traversal.{Traversal, jIteratortoTraversal}
+import overflowdb.traversal.{jIteratortoTraversal, toElementTraversal, toNodeTraversal, Traversal}
 
 class StepsTest extends AnyWordSpec with Matchers {
 
@@ -281,13 +281,13 @@ class StepsTest extends AnyWordSpec with Matchers {
     methodRef.referencedMethod
     methodRef.headOption.map(_.referencedMethod)
 
-    def expression: Traversal[Expression] = cpg.identifier.name("anidentifier")
+    def expression: Traversal[Expression] = cpg.identifier.name("anidentifier").cast[Expression]
     expression.expressionUp.isCall.size shouldBe 1
     expression.head.expressionUp.isCall.size shouldBe 1
 
 //    def cfg: Traversal[CfgNode] = cpg.method.name("add")
 
-    def ast: Traversal[AstNode] = cpg.method.name("foo")
+    def ast: Traversal[AstNode] = cpg.method.name("foo").cast[AstNode]
     ast.astParent.property(Properties.NAME).head shouldBe "AClass"
     ast.head.astParent.property(Properties.NAME) shouldBe "AClass"
 

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -8,7 +8,7 @@ import org.json4s._
 import org.json4s.native.JsonMethods.parse
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import overflowdb.traversal.{jIteratortoTraversal, toElementTraversal, toNodeTraversal, Traversal}
+import overflowdb.traversal.{Traversal, jIteratortoTraversal, toElementTraversal, toNodeTraversal}
 
 class StepsTest extends AnyWordSpec with Matchers {
 


### PR DESCRIPTION
@mal-tee triggered an investigation that led us to figure out that some 
implicit imports break intellij's scalac presentation compiler, 
specifically `import overflowdb.traversal.iterableToTraversal`

While this was never an issue for scalac, it's straightforward to fix and
gives everyone a better experience with intellij.

https://discord.com/channels/832209896089976854/832214243230744626/928317907576946739 
https://github.com/mal-tee/intellij-cpg-problems-example

before:
![before](https://user-images.githubusercontent.com/506752/148529158-1b8ac9ee-93c9-48e4-9cb7-4bb7aadb5387.png)

after:
![after](https://user-images.githubusercontent.com/506752/148529172-09a9a798-e41d-41cb-9a6b-e8033e201eb7.png)

