### PR TITLE
specify additional .help search packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.84"
+val overflowdbVersion = "1.88+1-174ff189+20220110-1606"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.90"
+val overflowdbVersion = "1.95"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.88+1-174ff189+20220110-1606"
+val overflowdbVersion = "1.90"
 
 inThisBuild(
   List(

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/Cpg.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/Cpg.scala
@@ -1,7 +1,6 @@
 package io.shiftleft.codepropertygraph
 
 import overflowdb.Graph
-import overflowdb.traversal.help.TraversalHelp
 
 /** TODO this is now being generated as well - for now we'll just forward calls to `generated.Cpg`
   * next step is to remove this class and move remove the `generated` part from the generated package
@@ -37,24 +36,4 @@ object Cpg {
   def emptyGraph: Graph =
     generated.Cpg.emptyGraph
 
-}
-
-/**
-  * Traversal starting point.
-  * This is the starting point of all traversals. A variable of this
-  * type named `cpg` is made available in the REPL.
-  *
-  * @param graph the underlying graph. An empty graph is created if this parameter is omitted.
-  */
-class Cpg(val graph: Graph = generated.Cpg.emptyGraph) extends AutoCloseable {
-
-  lazy val help: String =
-    new TraversalHelp("io.shiftleft").forTraversalSources
-
-  /**
-    * Closes code property graph.
-    * No further operations can be performed on it.
-    */
-  override def close(): Unit =
-    graph.close
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/package.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/codepropertygraph/package.scala
@@ -1,0 +1,5 @@
+package io.shiftleft
+
+package object codepropertygraph {
+  type Cpg = io.shiftleft.codepropertygraph.generated.Cpg
+}

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,6 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.19+1-fdda119b"
+libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.19+2-d9dad062"
 
 Compile / generateDomainClasses / classWithSchema := "io.shiftleft.codepropertygraph.schema.CpgSchema$"
 Compile / generateDomainClasses / fieldName := "instance"

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,6 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.19+2-d9dad062"
+libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.20"
 
 Compile / generateDomainClasses / classWithSchema := "io.shiftleft.codepropertygraph.schema.CpgSchema$"
 Compile / generateDomainClasses / fieldName := "instance"

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,6 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.16"
+libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % "2.19+1-fdda119b"
 
 Compile / generateDomainClasses / classWithSchema := "io.shiftleft.codepropertygraph.schema.CpgSchema$"
 Compile / generateDomainClasses / fieldName := "instance"

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
@@ -33,7 +33,9 @@ class CpgSchema(builder: SchemaBuilder) {
 
 object CpgSchema {
   val instance: Schema = {
-    val builder = new SchemaBuilder(domainShortName = "Cpg", basePackage = "io.shiftleft.codepropertygraph.generated", additionalTraversalsPackages = Seq("io.shiftleft"))
+    val builder = new SchemaBuilder(domainShortName = "Cpg",
+                                    basePackage = "io.shiftleft.codepropertygraph.generated",
+                                    additionalTraversalsPackages = Seq("io.shiftleft"))
     new CpgSchema(builder)
     builder.build
   }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
@@ -33,7 +33,7 @@ class CpgSchema(builder: SchemaBuilder) {
 
 object CpgSchema {
   val instance: Schema = {
-    val builder = new SchemaBuilder(domainShortName = "Cpg", basePackage = "io.shiftleft.codepropertygraph.generated")
+    val builder = new SchemaBuilder(domainShortName = "Cpg", basePackage = "io.shiftleft.codepropertygraph.generated", additionalTraversalsPackages = Seq("io.shiftleft"))
     new CpgSchema(builder)
     builder.build
   }

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -167,14 +167,15 @@ class StepsTest extends AnyWordSpec with Matchers {
   ".help step" should {
 
     "show domain overview" in {
-      val cpg = Cpg.emptyCpg
-      cpg.help should include(".comment")
-      cpg.help should include("All comments in source-based CPGs")
-      cpg.help should include(".arithmetic")
-      cpg.help should include("All arithmetic operations")
+      val domainStartersHelp = Cpg.emptyCpg.help
+      domainStartersHelp should include(".comment")
+      domainStartersHelp should include("All comments in source-based CPGs")
+      domainStartersHelp should include(".arithmetic")
+      domainStartersHelp should include("All arithmetic operations")
     }
 
     "provide node-specific overview" in {
+      // TODO drop start
       val methodSteps = new Steps[Method](null)
       methodSteps.help should include("Available steps for Method")
       methodSteps.help should include(".namespace")
@@ -182,13 +183,20 @@ class StepsTest extends AnyWordSpec with Matchers {
 
       methodSteps.helpVerbose should include("traversal name")
       methodSteps.helpVerbose should include("io.shiftleft.semanticcpg.language.types.structure.Method")
+      // TODO drop end
 
-      val methodStepsHelp = Cpg.emptyCpg.method.help
-      methodStepsHelp should include("Available steps for Method")
-      methodStepsHelp should include(".namespace")
-
-      val assignmentStepsHelp = Cpg.emptyCpg.assignment.help
-      assignmentStepsHelp should include("Left-hand sides of assignments")
+      // TODO use this in future instead
+//      val methodStepsHelp = Cpg.emptyCpg.method.help
+//      methodStepsHelp should include("Available steps for Method")
+//      methodStepsHelp should include(".namespace")
+//      methodStepsHelp should include(".depth") //from AstNode
+//
+//      val methodStepsHelpVerbose = Cpg.emptyCpg.method.helpVerbose
+//      methodStepsHelpVerbose should include("traversal name")
+//      methodStepsHelpVerbose should include("io.shiftleft.semanticcpg.language.types.structure.Method")
+//
+//      val assignmentStepsHelp = Cpg.emptyCpg.assignment.help
+//      assignmentStepsHelp should include("Left-hand sides of assignments")
     }
 
     "provides generic help" when {

--- a/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
+++ b/semanticcpg/src/test/scala/io/shiftleft/semanticcpg/language/StepsTest.scala
@@ -182,6 +182,13 @@ class StepsTest extends AnyWordSpec with Matchers {
 
       methodSteps.helpVerbose should include("traversal name")
       methodSteps.helpVerbose should include("io.shiftleft.semanticcpg.language.types.structure.Method")
+
+      val methodStepsHelp = Cpg.emptyCpg.method.help
+      methodStepsHelp should include("Available steps for Method")
+      methodStepsHelp should include(".namespace")
+
+      val assignmentStepsHelp = Cpg.emptyCpg.assignment.help
+      assignmentStepsHelp should include("Left-hand sides of assignments")
     }
 
     "provides generic help" when {


### PR DESCRIPTION
also: use simple type alias instead of duplicating the implementation