### PR TITLE
Dont use implicit in `toCall` implicit.

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/nodemethods/CallMethods.scala
@@ -6,6 +6,9 @@ import io.shiftleft.semanticcpg.language.{HasLocation, LocationCreator, _}
 import overflowdb.traversal._
 
 class CallMethods(val node: Call) extends AnyVal with NodeExtension with HasLocation {
+  def receiver: Traversal[Expression] =
+    node.receiverOut
+
   def arguments(index: Int): Traversal[Expression] =
     node._argumentOut
       .collect {

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/package.scala
@@ -82,7 +82,7 @@ package object language extends operatorextension.Implicits with LowPrioImplicit
   implicit def toType[A](a: A)(implicit f: A => Traversal[Type]): TypeTraversal = new TypeTraversal(f(a))
   implicit def toTypeDecl[A](a: A)(implicit f: A => Traversal[TypeDecl]): TypeDeclTraversal =
     new TypeDeclTraversal(f(a))
-  implicit def toCall[A](a: A)(implicit f: A => Traversal[Call]): OriginalCall = new OriginalCall(f(a))
+  implicit def toCall(traversal: IterableOnce[Call]): OriginalCall = new OriginalCall(traversal)
   implicit def toControlStructure[A](a: A)(implicit f: A => Traversal[ControlStructure]): ControlStructureTraversal =
     new ControlStructureTraversal(f(a))
   implicit def toIdentifier[A](a: A)(implicit f: A => Traversal[Identifier]): IdentifierTraversal =

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/expressions/CallTraversal.scala
@@ -26,7 +26,7 @@ class CallTraversal(val traversal: Traversal[Call]) extends AnyVal {
     The receiver of a call if the call has a receiver associated.
     */
   def receiver: Traversal[Expression] =
-    traversal.out(EdgeTypes.RECEIVER).cast[Expression]
+    traversal.flatMap(_.receiver)
 
   /**
     Arguments of the call


### PR DESCRIPTION
It may seem a little bit odd to only do this for the `toCall`
implicit but this is the only blocker to build javasrc2cpg with Scala 3.