### PR TITLE
Add METHOD_FULL_NAME property to BINDING node.

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
@@ -25,7 +25,7 @@ class CpgSchema(builder: SchemaBuilder) {
 
   val sourceSpecific = Comment(builder, ast, fs)
   val tagsAndLocation = TagsAndLocation(builder, base, typeSchema, method, ast, fs, callGraph)
-  val binding = Binding(builder, base, typeSchema, method)
+  val binding = Binding(builder, base, typeSchema, method, callGraph)
   val finding = Finding(builder, base)
   val hidden = Hidden(builder, base, method, typeSchema, ast, cfg, fs, callGraph)
   val protoSerialize = ProtoSerialize(builder, ast)


### PR DESCRIPTION
The METHOD_FULL_NAME property is an alternative way to specify a method
bound to a TYPE_DECL which does not require the frontend to stub the
method.