### PR TITLE
RETURN --- CFG --> METHOD_RETURN: Cardinality n:1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ ThisBuild / Test / javaOptions += s"-Dlog4j2.configurationFile=file:${(ThisBuild
 ThisBuild / Test / javaOptions += s"-Duser.dir=${(ThisBuild/baseDirectory).value}"
 
 ThisBuild / libraryDependencies ++= Seq(
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.17.0" % Test
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.17.1" % Test
 )
 
 // Scalafix / imports check setup

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -85,10 +85,14 @@ object Cfg extends SchemaBase {
     typeRef.addOutEdge(edge = cfg, inNode = cfgNode)
     unknown.addOutEdge(edge = cfg, inNode = cfgNode)
 
+    /** Each METHOD has exactly one METHOD_RETURN (the formal return value), but
+      * each METHOD_RETURN can have multiple RETURN nodes. This way, we can represent
+      * a method with multiple return statements.
+      */
     ret.addOutEdge(edge = cfg,
                    inNode = methodReturn,
                    cardinalityOut = Cardinality.One,
-                   cardinalityIn = Cardinality.ZeroOrOne,
+                   cardinalityIn = Cardinality.List,
                    stepNameIn = "toReturn")
 
     methodRef.addOutEdge(edge = cfg, inNode = methodReturn)


### PR DESCRIPTION
Each METHOD has exactly one METHOD_RETURN (the formal return value), but 
each METHOD_RETURN can have multiple RETURN nodes. This way, we can
represent a method with multiple return statements.

re https://github.com/joernio/joern/issues/947
re https://github.com/joernio/joern/pull/948