### PR TITLE
Dedup edges in CFG dot generation

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/CfgGenerator.scala
@@ -28,18 +28,18 @@ class CfgGenerator {
       }
     }
 
-    val edges = verticesToDisplay.map { v =>
+    val edges = verticesToDisplay.flatMap { v =>
       edgesToDisplay(v)
-    }
+    }.distinct
 
-    val allIdsReferencedByEdges = edges.flatten.flatMap { edge =>
+    val allIdsReferencedByEdges = edges.flatMap { edge =>
       Set(edge.src.id, edge.dst.id)
     }
 
     Graph(
       verticesToDisplay
         .filter(node => allIdsReferencedByEdges.contains(node.id)),
-      edges.flatten
+      edges
     )
   }
 


### PR DESCRIPTION
Because we do not dot Identifiers we may end up with duplicated edges from certain Calls
with these Identifiers as CFG prev. During the recursive call to `edgesToDisplay` these Calls
are then connected twice (or more) to their respective CFG prev node.

This is for https://github.com/joernio/joern/issues/969