### PR TITLE
refactor: TypeDeclTraversal: unravelAlias/canonicalType

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Shortcuts.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Shortcuts.scala
@@ -113,7 +113,12 @@ object Shortcuts extends SchemaBase {
       .addOutEdge(edge = evalType, inNode = tpe)
 
     typeRef.addOutEdge(edge = evalType, inNode = tpe)
-    tpe.addOutEdge(edge = ref, inNode = typeDecl)
+    tpe.addOutEdge(
+      edge = ref,
+      inNode = typeDecl,
+      stepNameOut = "referencedTypeDecl",
+      stepNameOutDoc = "Type declaration which is referenced by this type."
+    )
     typeDecl.addOutEdge(edge = contains, inNode = method)
     member.addOutEdge(edge = evalType, inNode = tpe, stepNameOut = "typ", stepNameOutDoc = "Traverse to member type")
     literal.addOutEdge(edge = evalType, inNode = tpe)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Type.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Type.scala
@@ -187,7 +187,13 @@ object Type extends SchemaBase {
 
     typeDecl
       .addOutEdge(edge = inheritsFrom, inNode = tpe)
-      .addOutEdge(edge = aliasOf, inNode = tpe)
+      .addOutEdge(
+        edge = aliasOf,
+        inNode = tpe,
+        stepNameOut = "aliasedType",
+        stepNameIn = "aliasTypeDecl",
+        stepNameInDoc = "Direct alias type declarations."
+      )
       .addOutEdge(edge = sourceFile, inNode = file, stepNameIn = "typeDecl")
 
     typeArgument

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -97,22 +97,8 @@ class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
 
   /** Traverse to canonical type which means unravel aliases until we find a non alias type declaration.
     */
-  def canonicalType: Traversal[TypeDecl] = {
-    // We cannot use this compact form because the gremlin implementation at least
-    // in some case seems to have problems with nested "repeat" steps. Since this
-    // step is used in other repeat steps we do not use it here.
-    // until(_.isCanonical).repeat(_.unravelAlias)
-
-    traversal.map { typeDecl =>
-      var currentTypeDecl       = typeDecl
-      var aliasExpansionCounter = 0
-      while (currentTypeDecl.aliasTypeFullName.isDefined && aliasExpansionCounter < maxAliasExpansions) {
-        currentTypeDecl = currentTypeDecl._typeViaAliasOfOut.next()._typeDeclViaRefOut.next()
-        aliasExpansionCounter += 1
-      }
-      currentTypeDecl
-    }
-  }
+  def canonicalType: Traversal[TypeDecl] =
+    traversal.repeat(_.unravelAlias)(_.until(_.isCanonical).times(maxAliasExpansions))
 
   /** Direct alias type declarations.
     */

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -83,16 +83,15 @@ class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
   /** If this is an alias type declaration, go to its underlying type declaration else unchanged.
     */
   def unravelAlias: Traversal[TypeDecl] = {
-     traversal.map { typeDecl =>
-       val alias = for {
-         _ <- typeDecl.aliasTypeFullName
-         tpe <- typeDecl._typeViaAliasOfOut.nextOption()
-         tpeDecl <- tpe._typeDeclViaRefOut.nextOption()
-         // TODO MP define named steps in schema ^^^
-       } yield tpeDecl
+    traversal.map { typeDecl =>
+      val alias = for {
+        _        <- typeDecl.aliasTypeFullName
+        tpe      <- typeDecl.aliasedType.nextOption()
+        typeDecl <- tpe.referencedTypeDecl.nextOption()
+      } yield typeDecl
 
-       alias.getOrElse(typeDecl)
-     }
+      alias.getOrElse(typeDecl)
+    }
   }
 
   /** Traverse to canonical type which means unravel aliases until we find a non alias type declaration.

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeDeclTraversal.scala
@@ -85,7 +85,6 @@ class TypeDeclTraversal(val traversal: Traversal[TypeDecl]) extends AnyVal {
   def unravelAlias: Traversal[TypeDecl] = {
     traversal.map { typeDecl =>
       val alias = for {
-        _        <- typeDecl.aliasTypeFullName
         tpe      <- typeDecl.aliasedType.nextOption()
         typeDecl <- tpe.referencedTypeDecl.nextOption()
       } yield typeDecl

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/types/structure/TypeTraversal.scala
@@ -10,12 +10,12 @@ class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
   /** Namespaces in which the corresponding type declaration is defined.
     */
   def namespace: Traversal[Namespace] =
-    referencedTypeDecl.namespace
+    traversal.referencedTypeDecl.namespace
 
   /** Methods defined on the corresponding type declaration.
     */
   def method: Traversal[Method] =
-    referencedTypeDecl.method
+    traversal.referencedTypeDecl.method
 
   /** Filter for types whos corresponding type declaration is in the analyzed jar.
     */
@@ -30,12 +30,12 @@ class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
   /** Member variables of the corresponding type declaration.
     */
   def member: Traversal[Member] =
-    referencedTypeDecl.member
+    traversal.referencedTypeDecl.member
 
   /** Direct base types of the corresponding type declaration in the inheritance graph.
     */
   def baseType: Traversal[Type] =
-    referencedTypeDecl.baseType
+    traversal.referencedTypeDecl.baseType
 
   /** Direct and transitive base types of the corresponding type declaration.
     */
@@ -52,25 +52,15 @@ class TypeTraversal(val traversal: Traversal[Type]) extends AnyVal {
   def derivedTypeTransitive: Traversal[Type] =
     traversal.repeat(_.derivedType)(_.emitAllButFirst)
 
-  /** Type declaration which is referenced by this type.
-    */
-  def referencedTypeDecl: Traversal[TypeDecl] =
-    traversal.out(EdgeTypes.REF).cast[TypeDecl]
-
   /** Type declarations which derive from this type.
     */
   def derivedTypeDecl: Traversal[TypeDecl] =
     traversal.in(EdgeTypes.INHERITS_FROM).cast[TypeDecl]
 
-  /** Direct alias type declarations.
-    */
-  def aliasTypeDecl: Traversal[TypeDecl] =
-    traversal.in(EdgeTypes.ALIAS_OF).cast[TypeDecl]
-
   /** Direct alias types.
     */
   def aliasType: Traversal[Type] =
-    aliasTypeDecl.referencingType
+    traversal.aliasTypeDecl.referencingType
 
   /** Direct and transitive alias types.
     */


### PR DESCRIPTION
* unravelAlias: traverse more defensive
* simplify TypeDecl.canonicalType via repeat step
* name steps in schema