### PR TITLE
Dynamic Call Linker Fallback More Lenient

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/passes/callgraph/DynamicCallLinker.scala
@@ -76,7 +76,7 @@ class DynamicCallLinker(cpg: Cpg) extends CpgPass(cpg) {
   }
 
   /** Recursively returns all the sub-types of the given type declaration. Does not account for circular hierarchies.
-   */
+    */
   def allSubclasses(typDeclFullName: String): mutable.LinkedHashSet[String] = {
     subclassCache.get(typDeclFullName) match {
       case Some(value) => value


### PR DESCRIPTION
Right now if a call isn't resolved via the type/inheritance tree it is simply logged as unable to solve. This may not be completely desirable especially when resolving dynamic calls to external method stubs which do not often form part of these trees in the same way internal types do. 

This change will let a failed lookup then try link to a method directly (which typically won't happen with internal types/methods) and should more often than not link to an external method stub successfully. Only when this fallback fails a failure will be printed.