### PR TITLE
Included Modifier Node Text to Show in Dot Files

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -47,6 +47,7 @@ object DotSerializer {
       case param: MethodParameterIn => ("PARAM", param.code).toString
       case local: Local             => (local.label, s"${local.code}: ${local.typeFullName}").toString
       case target: JumpTarget       => (target.label, target.name).toString
+      case modifier: Modifier       => ("MODIFIER", modifier.modifierType)
       case _                        => ""
     })
   }

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/dotgenerator/DotSerializer.scala
@@ -47,7 +47,7 @@ object DotSerializer {
       case param: MethodParameterIn => ("PARAM", param.code).toString
       case local: Local             => (local.label, s"${local.code}: ${local.typeFullName}").toString
       case target: JumpTarget       => (target.label, target.name).toString
-      case modifier: Modifier       => ("MODIFIER", modifier.modifierType)
+      case modifier: Modifier       => ("MODIFIER", modifier.modifierType).toString()
       case _                        => ""
     })
   }


### PR DESCRIPTION
Noticed that modifiers show up as empty nodes in `.dotAst` calls. This should fix it but this program doesn't build on my machine since there appears to be issues with `git-lfs` on M1 Macs and this project.