### PR TITLE
Move `IoUtils` from `x2cpg` to `io.shiftleft.utils`

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/IOUtils.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/IOUtils.scala
@@ -1,4 +1,4 @@
-package io.shiftleft.x2cpg
+package io.shiftleft.utils
 
 import java.io.Reader
 import java.nio.charset.{CharsetDecoder, CodingErrorAction}

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/codedumper/CodeDumper.scala
@@ -3,7 +3,7 @@ package io.shiftleft.semanticcpg.codedumper
 import io.shiftleft.codepropertygraph.generated.Languages
 import io.shiftleft.codepropertygraph.generated.nodes.{Expression, Local, Method, NewLocation}
 import io.shiftleft.semanticcpg.language._
-import io.shiftleft.x2cpg.IOUtils
+import io.shiftleft.utils.IOUtils
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.nio.file.Paths


### PR DESCRIPTION
In preparation for moving `x2cpg` into `joern-cli/frontends`, we need to extract `IoUtils` as they are also used by non-frontend code. I have therefore moved `IoUtils` to `io.shiftleft.utils`.

This will require updating imports in frontend code.