### PR TITLE
fix broken default for VALUE of TAG nodes

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -99,7 +99,7 @@ object Base extends SchemaBase {
         valueType = ValueType.String,
         comment = "This property denotes a string value as used in a key-value pair."
       )
-      .mandatory(PropertyDefaults.String)
+      .mandatory("")
       .protoId(8)
 
     val content = builder


### PR DESCRIPTION
The correct default VALUE for TAG nodes is empty-string `""`, not `"<empty>"`.

This did not explode before, because most of our code generates TAG nodes through a bewildering collection of implicit-based APIs that substitute their own hard-coded empty-string default, instead of directly calling `NewTag()`. Now that we deprecate all the legacy diffgraph / implicit `.store()` stuff, this comes up.