### PR TITLE
Some more utilities for diffgraph/batchedUpdate migration

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -281,10 +281,15 @@ trait CpgPassBase {
     */
   def name: String = getClass.getName
 
-  /* Runs the cpg pass, adding changes to the passed builder. Use with caution -- API is unstable.
-     Returns number of parallel parts. Includes setup and finish logic.*/
+  /** Runs the cpg pass, adding changes to the passed builder. Use with caution -- API is unstable. Returns max(nParts,
+    * 1), where nParts is either the number of parallel parts, or the number of iterarator elements in case of legacy
+    * passes. Includes init() and finish() logic.
+    */
   def runWithBuilder(builder: overflowdb.BatchedUpdate.DiffGraphBuilder): Int
 
+  /** Wraps runWithBuilder with logging, and swallows raised exceptions. Use with caution -- API is unstable. A return
+    * value of -1 indicates failure, otherwise the return value of runWithBuilder is passed through.
+    */
   def runWithBuilderLogged(builder: overflowdb.BatchedUpdate.DiffGraphBuilder): Int = {
     baseLogger.info(s"Start of pass: $name")
     val nanoStart = System.nanoTime()

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -59,6 +59,19 @@ sealed trait DiffGraph {
     iterator.collect { case Change.SetEdgeProperty(edge, key, value) =>
       DiffGraph.EdgeProperty(edge, key, value)
     }.toVector
+
+  def convertToOdbStyle(cpg: Cpg, builder: overflowdb.BatchedUpdate.DiffGraphBuilder):Unit = {
+    for(change <- iterator) change match {
+      case Change.RemoveNode(nodeId) => builder.removeNode(cpg.graph.node(nodeId))
+      case Change.RemoveNodeProperty(nodeId, propertyKey) => builder.setNodeProperty(cpg.graph.node(nodeId), propertyKey, null)
+      case Change.RemoveEdge(edge) => builder.removeEdge(edge)
+      case Change.RemoveEdgeProperty(_,_) => ???
+      case Change.CreateNode(node) => builder.addNode(node)
+      case Change.SetNodeProperty(node, key, value) => builder.setNodeProperty(node, key, value)
+      case Change.SetEdgeProperty(_,_,_) => ???
+      case Change.CreateEdge(src, dst, label, packedProperties) => builder.addEdge(src, dst, label, packedProperties:_*)
+    }
+  }
 }
 
 object DiffGraph {

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/DiffGraph.scala
@@ -60,16 +60,18 @@ sealed trait DiffGraph {
       DiffGraph.EdgeProperty(edge, key, value)
     }.toVector
 
-  def convertToOdbStyle(cpg: Cpg, builder: overflowdb.BatchedUpdate.DiffGraphBuilder):Unit = {
-    for(change <- iterator) change match {
+  def convertToOdbStyle(cpg: Cpg, builder: overflowdb.BatchedUpdate.DiffGraphBuilder): Unit = {
+    for (change <- iterator) change match {
       case Change.RemoveNode(nodeId) => builder.removeNode(cpg.graph.node(nodeId))
-      case Change.RemoveNodeProperty(nodeId, propertyKey) => builder.setNodeProperty(cpg.graph.node(nodeId), propertyKey, null)
-      case Change.RemoveEdge(edge) => builder.removeEdge(edge)
-      case Change.RemoveEdgeProperty(_,_) => ???
-      case Change.CreateNode(node) => builder.addNode(node)
+      case Change.RemoveNodeProperty(nodeId, propertyKey) =>
+        builder.setNodeProperty(cpg.graph.node(nodeId), propertyKey, null)
+      case Change.RemoveEdge(edge)                  => builder.removeEdge(edge)
+      case Change.RemoveEdgeProperty(_, _)          => ???
+      case Change.CreateNode(node)                  => builder.addNode(node)
       case Change.SetNodeProperty(node, key, value) => builder.setNodeProperty(node, key, value)
-      case Change.SetEdgeProperty(_,_,_) => ???
-      case Change.CreateEdge(src, dst, label, packedProperties) => builder.addEdge(src, dst, label, packedProperties:_*)
+      case Change.SetEdgeProperty(_, _, _)          => ???
+      case Change.CreateEdge(src, dst, label, packedProperties) =>
+        builder.addEdge(src, dst, label, packedProperties: _*)
     }
   }
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -297,7 +297,8 @@ abstract class ConcurrentWriterCpgPass[T <: AnyRef](cpg: Cpg, outName: String = 
     override def run(): Unit = {
       try {
         nDiffT = 0
-        MDC.setContextMap(mdc)
+        //logback chokes on null context maps
+        if(mdc != null) MDC.setContextMap(mdc)
         var terminate   = false
         var index: Int  = 0
         val doSerialize = serializedCpg != null && !serializedCpg.isEmpty

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -27,11 +27,11 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "", keyPools: Opti
 
   override def runWithBuilder(builder: BatchedUpdate.DiffGraphBuilder): Int = {
     var nParts = 0
-    for(part <- partIterator){
+    for (part <- partIterator) {
       val res = runOnPart(part)
-      if(!res.hasNext) nParts += 1
-      else{
-        for(diff <- res){
+      if (!res.hasNext) nParts += 1
+      else {
+        for (diff <- res) {
           diff.convertToOdbStyle(cpg, builder)
           nParts += 1
         }
@@ -141,8 +141,8 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "", keyPools: Opti
 
     override def run(): Unit = {
       try {
-        //logback chokes on null context maps
-        if(mdc != null) MDC.setContextMap(mdc)
+        // logback chokes on null context maps
+        if (mdc != null) MDC.setContextMap(mdc)
         var terminate  = false
         var index: Int = 0
         while (!terminate) {
@@ -297,8 +297,8 @@ abstract class ConcurrentWriterCpgPass[T <: AnyRef](cpg: Cpg, outName: String = 
     override def run(): Unit = {
       try {
         nDiffT = 0
-        //logback chokes on null context maps
-        if(mdc != null) MDC.setContextMap(mdc)
+        // logback chokes on null context maps
+        if (mdc != null) MDC.setContextMap(mdc)
         var terminate   = false
         var index: Int  = 0
         val doSerialize = serializedCpg != null && !serializedCpg.isEmpty

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -3,6 +3,7 @@ import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
 import io.shiftleft.utils.ExecutionContextProvider
 import org.slf4j.MDC
+import overflowdb.BatchedUpdate
 
 import java.util.concurrent.LinkedBlockingQueue
 import scala.collection.mutable
@@ -23,6 +24,21 @@ abstract class ParallelCpgPass[T](cpg: Cpg, outName: String = "", keyPools: Opti
   def runOnPart(part: T): Iterator[DiffGraph]
 
   implicit val executionContext: ExecutionContext = ExecutionContextProvider.getExecutionContext
+
+  override def runWithBuilder(builder: BatchedUpdate.DiffGraphBuilder): Int = {
+    var nParts = 0
+    for(part <- partIterator){
+      val res = runOnPart(part)
+      if(!res.hasNext) nParts += 1
+      else{
+        for(diff <- res){
+          diff.convertToOdbStyle(cpg, builder)
+          nParts += 1
+        }
+      }
+    }
+    nParts
+  }
 
   override def createAndApply(): Unit = {
     withWriter() { writer =>
@@ -176,17 +192,9 @@ object ConcurrentWriterCpgPass {
   private val producerQueueCapacity = 2 + 4 * Runtime.getRuntime().availableProcessors()
 }
 abstract class ConcurrentWriterCpgPass[T <: AnyRef](cpg: Cpg, outName: String = "", keyPool: Option[KeyPool] = None)
-    extends CpgPassBase {
-  type DiffGraphBuilder = overflowdb.BatchedUpdate.DiffGraphBuilder
+    extends NewStyleCpgPassBase[T] {
 
   @volatile var nDiffT = -1
-
-  // generate Array of parts that can be processed in parallel
-  def generateParts(): Array[_ <: AnyRef] = Array[AnyRef](null)
-  // setup large data structures, acquire external resources
-  def init(): Unit = {}
-  // release large data structures and external resources
-  def finish(): Unit = {}
 
   /** WARNING: runOnPart is executed in parallel to committing of graph modifications. The upshot is that it is unsafe
     * to read ANY data from cpg, on pain of bad race conditions
@@ -195,10 +203,6 @@ abstract class ConcurrentWriterCpgPass[T <: AnyRef](cpg: Cpg, outName: String = 
     *
     * E.g. adding a CFG edge to node X races with reading an AST edge of node X.
     */
-  def runOnPart(builder: DiffGraphBuilder, part: T): Unit
-
-  override def createAndApply(): Unit = createApplySerializeAndStore(null)
-
   override def createApplySerializeAndStore(
     serializedCpg: SerializedCpg,
     inverse: Boolean = false,
@@ -272,7 +276,7 @@ abstract class ConcurrentWriterCpgPass[T <: AnyRef](cpg: Cpg, outName: String = 
         if (inverse) " Inverse serialized and stored." else " Diff serialized and stored."
       } else ""
       baseLogger.info(
-        f"Enhancement $name completed in ${(nanosStop - nanosStart) * 1e-6}%.0f ms. ${nDiff}%d  + ${nDiffT - nDiff}%d changes commited from ${nParts}%d parts.${serializationString}%s"
+        f"Enhancement $name completed in ${(nanosStop - nanosStart) * 1e-6}%.0f ms. ${nDiff}%d  + ${nDiffT - nDiff}%d changes committed from ${nParts}%d parts.${serializationString}%s"
       )
     }
   }


### PR DESCRIPTION
Add conversion from legacy diffgraph -> new diffgraph API and restructures the new-style cpgpass hierarchy. Furthermore, it adds an API to CpgPassBase to genererate a batchedUpdate-style diff.

The conversion of diffgraphs allows us to indefinitely delay migration of passes.

The new API to generate new-style diffs from a pass, together with the logging facilities, allows us to create "compound passes" that collect diffs from many different passes, and applies them together. This is exactly how the framework-passes are run in codescience (PR will be linked).

The restructuring of the class hierarchy, i.e. the new shared super of ForkJoinParallelCpgPass and ConcurrentWriterCpgPass, allows us to share some code and allows users to look into the internals more easily -- the API between both is intentionally identical, so let's formalize that fact.

I am very open to naming and API discussions and especially suggestions on that front -- my names for the new stuff suck.