### PR TITLE
FieldAccessMethods: use REF edges for member traversal

### DIFF
--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
@@ -1,10 +1,17 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, FieldIdentifier, Identifier, Literal, Member, TypeDecl}
+import io.shiftleft.codepropertygraph.generated.nodes.{
+  Call,
+  Expression,
+  FieldIdentifier,
+  Identifier,
+  Literal,
+  Member,
+  TypeDecl
+}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
 import overflowdb.traversal.{NodeOps, Traversal, jIteratortoTraversal}
-
 
 class FieldAccessMethods(val arrayAccess: OpNodes.FieldAccess) extends AnyVal {
 

--- a/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
+++ b/semanticcpg/src/main/scala/io/shiftleft/semanticcpg/language/operatorextension/nodemethods/FieldAccessMethods.scala
@@ -1,17 +1,10 @@
 package io.shiftleft.semanticcpg.language.operatorextension.nodemethods
 
-import io.shiftleft.codepropertygraph.generated.nodes.{
-  Call,
-  Expression,
-  FieldIdentifier,
-  Identifier,
-  Literal,
-  Member,
-  TypeDecl
-}
+import io.shiftleft.codepropertygraph.generated.nodes.{Call, Expression, FieldIdentifier, Identifier, Literal, Member, TypeDecl}
 import io.shiftleft.semanticcpg.language._
 import io.shiftleft.semanticcpg.language.operatorextension.OpNodes
-import overflowdb.traversal.{NodeOps, Traversal}
+import overflowdb.traversal.{NodeOps, Traversal, jIteratortoTraversal}
+
 
 class FieldAccessMethods(val arrayAccess: OpNodes.FieldAccess) extends AnyVal {
 
@@ -26,17 +19,8 @@ class FieldAccessMethods(val arrayAccess: OpNodes.FieldAccess) extends AnyVal {
     }
   }
 
-  def fieldIdentifier: Traversal[FieldIdentifier] =
-    arrayAccess.start.argument(2).isFieldIdentifier
+  def fieldIdentifier: Traversal[FieldIdentifier] = arrayAccess.start.argument(2).isFieldIdentifier
 
-  def member: Option[Member] = {
-    val base = typeDecl.headOption
-    val name = fieldIdentifier.map(_.canonicalName).headOption
-    (base, name) match {
-      case (Some(b), Some(n)) =>
-        b.member.nameExact(n).headOption
-      case _ => None
-    }
-  }
+  def member: Option[Member] = arrayAccess._refOut.to(Traversal).collectAll[Member].headOption
 
 }


### PR DESCRIPTION
the old code doesn't work for inherited members, and maybe more things