### PR TITLE
Make ANNOTATION an EXPRESSION.

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Annotation.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Annotation.scala
@@ -42,7 +42,7 @@ object Annotation extends SchemaBase {
       .addNodeType(name = "ANNOTATION", comment = "A method annotation")
       .protoId(5)
       .addProperties(name, fullName)
-      .extendz(astNode)
+      .extendz(expression)
 
     val annotationParameterAssign: NodeType = builder
       .addNodeType(


### PR DESCRIPTION
This is necessary to for constructs like the following where annotations
appear in expression position. For all the previously already supported
"top level annotations" nothing changes.
@SomeAnnoation(value = @OtherAnnotation)
int someMethod() {}