### PR TITLE
Rename `PARAMETER_INDEX` to `INDEX`

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Annotation.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Annotation.scala
@@ -3,7 +3,7 @@ package io.shiftleft.codepropertygraph.schema
 import overflowdb.schema._
 
 object Annotation extends SchemaBase {
-  def index: Int = 20
+  def docIndex: Int = 20
 
   override def providedByFrontend: Boolean = true
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -8,7 +8,7 @@ import overflowdb.storage.ValueTypes
 
 object Ast extends SchemaBase {
 
-  def docIndex: Int                           = 7
+  def docIndex: Int                        = 7
   override def providedByFrontend: Boolean = true
 
   override def description: String =

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -8,7 +8,7 @@ import overflowdb.storage.ValueTypes
 
 object Ast extends SchemaBase {
 
-  def index: Int                           = 7
+  def docIndex: Int                           = 7
   override def providedByFrontend: Boolean = true
 
   override def description: String =

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -6,7 +6,7 @@ import overflowdb.schema._
 
 object Base extends SchemaBase {
 
-  def index: Int                           = Int.MaxValue
+  def docIndex: Int                           = Int.MaxValue
   override def providedByFrontend: Boolean = true
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -63,6 +63,18 @@ object Base extends SchemaBase {
       .mandatory(false)
       .protoId(7)
 
+    val index = builder
+      .addProperty(
+        name = "INDEX",
+        valueType = ValueType.Int,
+        comment = """
+                    |Specifies an index, e.g., for a parameter.
+                    |""".stripMargin
+      )
+      .mandatory(PropertyDefaults.Int)
+      .protoId(222)
+
+
     val name = builder
       .addProperty(
         name = "NAME",

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -6,7 +6,7 @@ import overflowdb.schema._
 
 object Base extends SchemaBase {
 
-  def docIndex: Int                           = Int.MaxValue
+  def docIndex: Int                        = Int.MaxValue
   override def providedByFrontend: Boolean = true
   override def description: String =
     """
@@ -68,12 +68,13 @@ object Base extends SchemaBase {
         name = "INDEX",
         valueType = ValueType.Int,
         comment = """
-                    |Specifies an index, e.g., for a parameter.
+                    |Specifies an index, e.g., for a parameter or argument.
+                    | Explicit parameters are numbered from 1 to N, while index 0 is reserved for implicit
+                    | self / this parameter.
                     |""".stripMargin
       )
       .mandatory(PropertyDefaults.Int)
       .protoId(222)
-
 
     val name = builder
       .addProperty(

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Binding.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Binding.scala
@@ -13,7 +13,7 @@ object Binding extends SchemaBase {
   ) =
     new Schema(builder, base, typeSchema, methodSchema, callGraphSchema)
 
-  override def index: Int = 19
+  override def docIndex: Int = 19
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CallGraph.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CallGraph.scala
@@ -8,7 +8,7 @@ import overflowdb.storage.ValueTypes
 
 object CallGraph extends SchemaBase {
 
-  def index: Int = 8
+  def docIndex: Int = 8
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Cfg.scala
@@ -5,7 +5,7 @@ import overflowdb.schema.{SchemaBuilder, SchemaInfo}
 
 object Cfg extends SchemaBase {
 
-  def index: Int = 9
+  def docIndex: Int = 9
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Comment.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Comment.scala
@@ -3,7 +3,7 @@ package io.shiftleft.codepropertygraph.schema
 import overflowdb.schema._
 
 object Comment extends SchemaBase {
-  def docIndex                       = 12
+  def docIndex                    = 12
   override def providedByFrontend = true
 
   override def description = ""

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Comment.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Comment.scala
@@ -3,7 +3,7 @@ package io.shiftleft.codepropertygraph.schema
 import overflowdb.schema._
 
 object Comment extends SchemaBase {
-  def index                       = 12
+  def docIndex                       = 12
   override def providedByFrontend = true
 
   override def description = ""

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Configuration.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Configuration.scala
@@ -4,7 +4,7 @@ import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
 
 object Configuration extends SchemaBase {
 
-  override def index: Int = 18
+  override def docIndex: Int = 18
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Dominators.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Dominators.scala
@@ -4,7 +4,7 @@ import overflowdb.schema.{SchemaBuilder, SchemaInfo}
 
 object Dominators extends SchemaBase {
 
-  def index: Int = 10
+  def docIndex: Int = 10
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
@@ -6,7 +6,7 @@ import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
 
 object FileSystem extends SchemaBase {
 
-  def index: Int = 3
+  def docIndex: Int = 3
   override def description: String =
     """
       |CPGs are created from sets of files and the File System Layer describes the layout of

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Finding.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Finding.scala
@@ -6,7 +6,7 @@ import overflowdb.schema._
 
 object Finding extends SchemaBase {
 
-  def index: Int = 15
+  def docIndex: Int = 15
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -4,7 +4,7 @@ import overflowdb.schema.Property.ValueType
 import overflowdb.schema.{EdgeType, NodeType, SchemaBuilder, SchemaInfo}
 
 object Hidden extends SchemaBase {
-  override def index: Int = -1
+  override def docIndex: Int = -1
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -7,7 +7,7 @@ import overflowdb.storage.ValueTypes
 
 object MetaData extends SchemaBase {
 
-  def docIndex: Int                           = 2
+  def docIndex: Int                        = 2
   override def providedByFrontend: Boolean = true
 
   override def description: String =

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -7,7 +7,7 @@ import overflowdb.storage.ValueTypes
 
 object MetaData extends SchemaBase {
 
-  def index: Int                           = 2
+  def docIndex: Int                           = 2
   override def providedByFrontend: Boolean = true
 
   override def description: String =

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -1,6 +1,5 @@
 package io.shiftleft.codepropertygraph.schema
 
-import io.shiftleft.codepropertygraph.schema.CpgSchema.PropertyDefaults
 import overflowdb.schema.Property.ValueType
 import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
 
@@ -86,17 +85,6 @@ object Method extends SchemaBase {
       .mandatory(false)
       .protoId(221)
 
-    val parameterIndex = builder
-      .addProperty(
-        name = "PARAMETER_INDEX",
-        valueType = ValueType.Int,
-        comment = """
-            |Specifies the parameter's number. For the `this` parameter, the parameter index `0` is used.
-            |""".stripMargin
-      )
-      .mandatory(PropertyDefaults.Int)
-      .protoId(222)
-
     val methodParameterIn: NodeType = builder
       .addNodeType(
         name = "METHOD_PARAMETER_IN",
@@ -106,7 +94,7 @@ object Method extends SchemaBase {
             |""".stripMargin
       )
       .protoId(34)
-      .addProperties(typeFullName, isVariadic, parameterIndex)
+      .addProperties(typeFullName, isVariadic, index)
       .extendz(declaration)
 
     val methodParameterOut: NodeType = builder

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -8,7 +8,7 @@ object Method extends SchemaBase {
   def apply(builder: SchemaBuilder, base: Base.Schema, typeSchema: Type.Schema, fs: FileSystem.Schema) =
     new Schema(builder, base, typeSchema, fs)
 
-  def docIndex: Int                           = 5
+  def docIndex: Int                        = 5
   override def providedByFrontend: Boolean = true
 
   override def description: String =

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Method.scala
@@ -9,7 +9,7 @@ object Method extends SchemaBase {
   def apply(builder: SchemaBuilder, base: Base.Schema, typeSchema: Type.Schema, fs: FileSystem.Schema) =
     new Schema(builder, base, typeSchema, fs)
 
-  def index: Int                           = 5
+  def docIndex: Int                           = 5
   override def providedByFrontend: Boolean = true
 
   override def description: String =

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Namespace.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Namespace.scala
@@ -4,7 +4,7 @@ import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
 
 object Namespace extends SchemaBase {
 
-  def index: Int = 4
+  def docIndex: Int = 4
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Operators.scala
@@ -5,7 +5,7 @@ import overflowdb.storage.ValueTypes
 
 object Operators extends SchemaBase {
 
-  override def index: Int = 17
+  override def docIndex: Int = 17
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Pdg.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Pdg.scala
@@ -6,7 +6,7 @@ import overflowdb.schema.{SchemaBuilder, SchemaInfo}
 
 object Pdg extends SchemaBase {
 
-  def index: Int = 11
+  def docIndex: Int = 11
   override def description: String =
     """
       The Program Dependence Graph Layer contains a program dependence graph for

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/ProtoSerialize.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/ProtoSerialize.scala
@@ -6,7 +6,7 @@ import overflowdb.schema.{SchemaBuilder, SchemaInfo}
 
 object ProtoSerialize extends SchemaBase {
 
-  override def index: Int = Int.MaxValue
+  override def docIndex: Int = Int.MaxValue
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/SchemaBase.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/SchemaBase.scala
@@ -2,7 +2,7 @@ package io.shiftleft.codepropertygraph.schema
 
 trait SchemaBase {
   // Used for ordering in the documentation. Smallest index shows up first.
-  def index: Int
+  def docIndex: Int
   def description: String
   def providedByFrontend: Boolean = false
 }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Shortcuts.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Shortcuts.scala
@@ -5,7 +5,7 @@ import overflowdb.schema._
 
 object Shortcuts extends SchemaBase {
 
-  def index: Int = 16
+  def docIndex: Int = 16
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/TagsAndLocation.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/TagsAndLocation.scala
@@ -6,7 +6,7 @@ import overflowdb.schema._
 
 object TagsAndLocation extends SchemaBase {
 
-  override def index: Int = 17
+  override def docIndex: Int = 17
 
   override def description: String =
     """

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Type.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Type.scala
@@ -9,7 +9,7 @@ object Type extends SchemaBase {
   def apply(builder: SchemaBuilder, base: Base.Schema, fs: FileSystem.Schema) =
     new Schema(builder, base, fs)
 
-  def docIndex: Int                           = 6
+  def docIndex: Int                        = 6
   override def providedByFrontend: Boolean = true
 
   override def description: String =

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Type.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Type.scala
@@ -9,7 +9,7 @@ object Type extends SchemaBase {
   def apply(builder: SchemaBuilder, base: Base.Schema, fs: FileSystem.Schema) =
     new Schema(builder, base, fs)
 
-  def index: Int                           = 6
+  def docIndex: Int                           = 6
   override def providedByFrontend: Boolean = true
 
   override def description: String =


### PR DESCRIPTION
This is a follow-up for PR #1622. As I started using `parameterIndex`, I noticed that `parameter.parameterIndex` is redundant. In fact, this is the same index that we use for `argumentIndex` - also a rather long name. My short term suggestion is that it's `parameter.index`. The long term suggestion is that we also replace `argumentIndex` with `index`, so that we end up with `parameter.index` and `argument.index`. Notice that the same rules apply for these two indices as we need to match them.