### PR TITLE
Choose different proto id for`index`

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -74,7 +74,7 @@ object Base extends SchemaBase {
                     |""".stripMargin
       )
       .mandatory(PropertyDefaults.Int)
-      .protoId(222)
+      .protoId(2223)
 
     val name = builder
       .addProperty(


### PR DESCRIPTION
... to avoid collision with a proto id in the commercial schema.