### PR TITLE
upgrade odb

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.127+1-9038e3ae"
+val overflowdbVersion = "1.127+2-0f10a20c"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.127+3-ba7fb7dc"
+val overflowdbVersion = "1.127+13-fd353d57"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.127"
+val overflowdbVersion = "1.127+1-9038e3ae"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.127+13-fd353d57"
+val overflowdbVersion = "1.127+17-c3436650"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.127+2-0f10a20c"
+val overflowdbVersion = "1.127+2-fc40310b"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.127+17-c3436650"
+val overflowdbVersion = "1.128"
 
 inThisBuild(
   List(

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val overflowdbVersion = "1.127+2-fc40310b"
+val overflowdbVersion = "1.127+3-ba7fb7dc"
 
 inThisBuild(
   List(

--- a/codepropertygraph/build.sbt
+++ b/codepropertygraph/build.sbt
@@ -4,6 +4,7 @@ dependsOn(Projects.protoBindings, Projects.domainClasses)
 
 libraryDependencies ++= Seq(
   "io.shiftleft"          %% "overflowdb-traversal" % Versions.overflowdb,
+  "io.shiftleft"          %% "overflowdb-formats"   % Versions.overflowdb,
   "com.github.scopt"      %% "scopt"                % "4.0.1",
   ("com.github.pathikrit" %% "better-files"         % "3.9.1").cross(CrossVersion.for3Use2_13),
   "org.slf4j"              % "slf4j-api"            % "1.7.30",


### PR DESCRIPTION
note: this also brings in a direct dependency on odb-formats, which is arguably not required, but it helps downstream in the joern build, because we don't need to maintain the overflowdb version there separately...