### PR TITLE
allow to tag metaData node

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/CpgSchema.scala
@@ -24,7 +24,7 @@ class CpgSchema(builder: SchemaBuilder) {
   val shortcuts = Shortcuts(builder, base, method, ast, typeSchema, fs)
 
   val sourceSpecific  = Comment(builder, ast, fs)
-  val tagsAndLocation = TagsAndLocation(builder, base, typeSchema, method, ast, fs, callGraph)
+  val tagsAndLocation = TagsAndLocation(builder, base, typeSchema, method, ast, fs, callGraph, metaData)
   val binding         = Binding(builder, base, typeSchema, method, callGraph)
   val annotation      = Annotation(builder, base, method, typeSchema, ast, shortcuts)
   val finding         = Finding(builder, base)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/TagsAndLocation.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/TagsAndLocation.scala
@@ -23,9 +23,10 @@ object TagsAndLocation extends SchemaBase {
     methodSchema: Method.Schema,
     ast: Ast.Schema,
     fs: FileSystem.Schema,
-    callGraph: CallGraph.Schema
+    callGraph: CallGraph.Schema,
+    metaData: MetaData.Schema
   ) =
-    new Schema(builder, base, typeSchema, methodSchema, ast, fs, callGraph)
+    new Schema(builder, base, typeSchema, methodSchema, ast, fs, callGraph, metaData)
 
   class Schema(
     builder: SchemaBuilder,
@@ -34,7 +35,8 @@ object TagsAndLocation extends SchemaBase {
     methodSchema: Method.Schema,
     ast: Ast.Schema,
     fs: FileSystem.Schema,
-    callGraph: CallGraph.Schema
+    callGraph: CallGraph.Schema,
+    metaData: MetaData.Schema
   ) {
     import base._
     import typeSchema._
@@ -132,6 +134,8 @@ object TagsAndLocation extends SchemaBase {
     jumpTarget.addOutEdge(edge = taggedBy, inNode = tag)
     file.addOutEdge(edge = taggedBy, inNode = tag)
     methodParameterOut.addOutEdge(edge = taggedBy, inNode = tag)
+    /*tags attached to metaData contain global information about the cpg, in ad-hoc structured way*/
+    metaData.metaData.addOutEdge(edge = taggedBy, inNode = tag)
   }
 
 }


### PR DESCRIPTION
As discussed in https://github.com/ShiftLeftSecurity/codescience/pull/6191 and linked issues, we need a way to stash some global data about a cpg, in ad-hoc internal structures.

One way we came up with is to attach TAG nodes to the metadata node. This PR permits to tag metadata nodes.

This part of the feature is very much open to bike-shedding. The only requirements are:

1. Don't clutter the graph schema
2. Don't overload the FINDING node even further
3. Don't attempt to spec the actual data format or contents. People over in teams CS/UI want space to experiment now; after customer feedback is in, we can then eventually figure out a schema for whatever this turns out to be used for. Until then, we just need a dumpster for ad-hoc structured blobs.

The question of where to place such stuff in the graph is mostly independent from the other considerations (passes that produce this data during scans, binary protocol + proto hackage to transmit this, handling in the web-services side, slick UI that displays this data).