### PR TITLE
Add root path to meta data node and make FILENAME relative

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/FileSystem.scala
@@ -27,11 +27,11 @@ object FileSystem extends SchemaBase {
       .addProperty(
         name = "FILENAME",
         valueType = ValueType.String,
-        comment = """The absolute path of the source file this node was generated from. This field
-            |must be set but may be set to the value `<unknown>` to indicate that no source
-            |file can be associated with the node, e.g., because the node represents an
-            |entity known to exist because it is referenced, but for which the file that
-            |is is declared in is unknown.
+        comment = """The path of the source file this node was generated from, relative to the root
+            |path in the meta data node. This field must be set but may be set to the value `<unknown>` to
+            |indicate that no source file can be associated with the node, e.g., because the node represents
+            |an entity known to exist because it is referenced, but for which the file that is is declared in
+            |is unknown.
             |""".stripMargin
       )
       .mandatory(PropertyDefaults.String)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -51,6 +51,15 @@ object MetaData extends SchemaBase {
       .mandatory(PropertyDefaults.String)
       .protoId(19)
 
+    val root = builder
+      .addProperty(
+        name = "ROOT",
+        valueType = ValueType.String,
+        comment = "The path to the root directory of the source/binary this CPG is generated from."
+      )
+      .protoId(1199)
+      .mandatory(PropertyDefaults.String)
+
     val metaData: NodeType = builder
       .addNodeType(
         name = "META_DATA",
@@ -64,7 +73,7 @@ object MetaData extends SchemaBase {
                     | """.stripMargin
       )
       .protoId(39)
-      .addProperties(language, version, overlays, hash)
+      .addProperties(language, version, overlays, hash, root)
 
     val languages = builder.addConstants(
       category = "Languages",


### PR DESCRIPTION
The spec currently asks frontend developers to store absolute paths in the `FILENAME` property. Some frontends do that, others do not. The `.dump` feature will currently only work with absolute paths. Unfortunately, sptests and ngsast require relative paths. To fix this problem, this PR introduces a schema change: we store relative paths, but we store the project root path in the meta data block so that `.dump` can reconstruct the full path.