### PR TITLE
Get rid of NonLocalReturns usage

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/ProjectRoot.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/ProjectRoot.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.utils
 
 import better.files.File
+import scala.annotation.tailrec
 
 /** Finds the relative location of the project root.
   *
@@ -23,14 +24,14 @@ object ProjectRoot {
   def findRelativePath: String = {
     val fileThatOnlyExistsInRoot = ".git"
 
-    for (depth <- 0 to SEARCH_DEPTH) {
+    @tailrec def loop(depth: Int): String = {
       val pathPrefix = "./" + "../" * depth
-      if (File(s"$pathPrefix$fileThatOnlyExistsInRoot").exists) {
-        return pathPrefix
-      }
+      if (File(s"$pathPrefix$fileThatOnlyExistsInRoot").exists) pathPrefix
+      else if (depth < SEARCH_DEPTH) loop(depth + 1)
+      else throw SearchDepthExceededError
     }
 
-    throw SearchDepthExceededError
+    loop(0)
   }
 
   def find: File =

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/ProjectRoot.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/ProjectRoot.scala
@@ -1,6 +1,7 @@
 package io.shiftleft.utils
 
 import better.files.File
+
 import scala.annotation.tailrec
 
 /** Finds the relative location of the project root.


### PR DESCRIPTION
The project would not compile with Scala 3.2.x due to the usage of NonLocalReturn which is deprecated in that version. 
This PR fixes that issue by replacing it with tail-recursive loop

Link to logs of failing 3.2.x build https://scala3.westeurope.cloudapp.azure.com/blue/organizations/jenkins/buildCommunityProject/detail/buildCommunityProject/557/pipeline/