### PR TITLE
adding Solidity to metadata

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -124,6 +124,6 @@ object MetaData extends SchemaBase {
         valueType = ValueType.String,
         comment = "Solidity language frontend"
       ).protoId(16)
-      )
+    )
   }
 }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -117,8 +117,13 @@ object MetaData extends SchemaBase {
         value = "JSSRC",
         valueType = ValueType.String,
         comment = "Source-based JS frontend based on Babel"
-      ).protoId(15)
-    )
+      ).protoId(15),
+      Constant(
+        name = "SOLIDITY",
+        value = "SOLIDITY",
+        valueType = ValueType.String,
+        comment = "Solidity language frontend"
+      ).protoId(16)
+      )
   }
-
 }


### PR DESCRIPTION
### Description:
Adding Solidity to `MetaData.scala`.

### Why I need this:
I am creating a frontend for Solidity in Joern ,https://github.com/joernio/joern/tree/solidity2cpg, and I am creating queries to find vulnerabilities, and I would like to add Solidity to `io.shiftleft.codepropertygraph.generated.Languages`, to use `Joern-scan` with this new frontend.

### Example usage:
`./Joern-scan <PathToSolidityCode>`