### PR TITLE
Alternative improved documentation for FULL_NAME property on ANNOTATION nodes.

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Annotation.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Annotation.scala
@@ -39,7 +39,15 @@ object Annotation extends SchemaBase {
 
     implicit private val schemaInfo: SchemaInfo = SchemaInfo.forClass(getClass)
     val annotation: NodeType = builder
-      .addNodeType(name = "ANNOTATION", comment = "A method annotation")
+      .addNodeType(name = "ANNOTATION", comment =
+        """A method annotation.
+          |
+          |Even though ANNOTATION nodes have a FULL_NAME, they are not global linkage-level objects, and there is no
+          |expectation of uniqueness of FULL_NAMEs. This is a mistake / inconsistency in the schema that is unfortunately
+          |too late to fix.
+          |
+          |Formally, ANNOTATION extends EXPRESSION. This is plain wrong in most languages, and is a mistake in the
+          |schema that is unfortunately too late to fix.""".stripMargin)
       .protoId(5)
       .addProperties(name, fullName)
       .extendz(expression)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Base.scala
@@ -92,6 +92,15 @@ object Base extends SchemaBase {
         comment = """This is the fully-qualified name of an entity, e.g., the fully-qualified
                     |name of a method or type. The details of what constitutes a fully-qualified
                     |name are language specific. This field SHOULD be human readable.
+                    |
+                    |This can be considered like a linkage name, and is used for the same purpose.
+                    |Hence, there should not be multiple nodes with the same LABEL / FULL_NAME
+                    |combination, on pain of silent linker failures. Ensuring uniqueness may well
+                    |require name-mangling.
+                    |
+                    |An exception is the ANNOTATION node. These are not global linkage-level objects,
+                    |and there is not expectation that their FULL_NAMEs are unique. This is a mistake
+                    | / inconsistency in the schema that is unfortunately too late to fix.
                     |""".stripMargin
       )
       .mandatory(PropertyDefaults.String)


### PR DESCRIPTION
Alternative to https://github.com/ShiftLeftSecurity/codepropertygraph/pull/1660

I wrote it at the same time, but @ml86 was faster with opening the PR ;)

