### PR TITLE
Add MATCH to control structure types

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -348,7 +348,9 @@ object Ast extends SchemaBase {
       Constant(name = "TRY", value = "TRY", valueType = ValueType.String, comment = "Represents a try statement")
         .protoId(10),
       Constant(name = "THROW", value = "THROW", valueType = ValueType.String, comment = "Represents a throw statement")
-        .protoId(11)
+        .protoId(11),
+      Constant(name = "MATCH", value = "MATCH", valueType = ValueType.String, comment = "Represents a match expression")
+        .protoId(12)
     )
 
     val controlStructure: NodeType = builder


### PR DESCRIPTION
The immediate use for this is to support match expressions in PHP, but it's also useful for newer versions of Python.