### PR TITLE
Add yield control structure type

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Ast.scala
@@ -350,7 +350,9 @@ object Ast extends SchemaBase {
       Constant(name = "THROW", value = "THROW", valueType = ValueType.String, comment = "Represents a throw statement")
         .protoId(11),
       Constant(name = "MATCH", value = "MATCH", valueType = ValueType.String, comment = "Represents a match expression")
-        .protoId(12)
+        .protoId(12),
+      Constant(name = "YIELD", value = "YIELD", valueType = ValueType.String, comment = "Represents a yield expression")
+        .protoId(13)
     )
 
     val controlStructure: NodeType = builder


### PR DESCRIPTION
I'm not sure if controlstructure is a good fit for yield (since yield is closer to return that we have a specific node type for), but it seems like the best option for it that doesn't require new node types.