### PR TITLE
Schema: VersionControl Node for VCS Information if Present

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -1,0 +1,100 @@
+package io.shiftleft.codepropertygraph.schema
+
+import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
+
+object VersionControl extends SchemaBase {
+
+  override def docIndex: Int = 21
+
+  override def description: String =
+    """
+      |Version control systems (VCS) are a natural part of software development and, as such, the code property graph
+      |will encode some key details about the VCS in use, if any. These details can help correlate the code version
+      |corresponding to the generated CPG. One can choose to explore the development evolution of a versioned codebase
+      |using the code property graph.
+      |""".stripMargin
+
+  def apply(builder: SchemaBuilder) = new Schema(builder)
+
+  class Schema(builder: SchemaBuilder) {
+    import base._
+
+    implicit private val schemaInfo: SchemaInfo = SchemaInfo.forClass(getClass)
+
+    val vcsSystem = builder
+      .addProperty(
+        name = "VCS_SYSTEM",
+        valueType = ValueType.String,
+        comment =
+          """This field holds the name of the version control system used. This corresponds to the systems that are
+            |supported for being detected e.g. `GIT`.
+            |""".stripMargin
+      )
+      .mandatory(PropertyDefaults.String)
+      .protoId(2151)
+
+    val remote = builder
+      .addProperty(
+        name = "REMOTE",
+        valueType = ValueType.String,
+        comment = "This field holds the URI of the remote host of the repository if one is present."
+      )
+      .protoId(2152)
+
+    val branch = builder
+      .addProperty(
+        name = "BRANCH",
+        valueType = ValueType.String,
+        comment =
+          """This field holds the name of the current branch this version of the code is developed on. This is usually a
+            |branch from a more stable branch.
+            |""".stripMargin
+
+      )
+      .protoId(2153)
+
+    val author = builder
+      .addProperty(
+        name = "AUTHOR",
+        valueType = ValueType.String,
+        comment = "The name or alias of the developer or authored the code change."
+      )
+      .protoId(2154)
+
+    val revisionId = builder
+      .addProperty(
+        name = "REVISION_ID",
+        valueType = ValueType.String,
+        comment = "The unique identifier of the code change revision object."
+      )
+      .protoId(2155)
+
+    val revisionMessage = builder
+      .addProperty(
+        name = "REVISION_MESSAGE",
+        valueType = ValueType.String,
+        comment = "The author's message describing the code change for this revision."
+      )
+      .protoId(2156)
+
+    val modifiedFiles = builder
+      .addProperty(
+        name = "MODIFIED_FILES",
+        valueType = ValueType.String,
+        comment = "Full paths relative to the project root directory of files that were modified during the revision."
+      )
+      .asList()
+      .protoId(2157)
+
+    val vcsNode: NodeType = builder
+      .addNodeType(
+        name = "VERSION_CONTROL",
+        comment = """This node type represents version control system agnostic details about what version of a code base
+                    |generated this code property graph.
+                    |""".stripMargin
+      )
+      .protoId(2150)
+      .addProperties(system, remote, branch, author, revisionId, revisionMessage, modifiedFiles)
+
+  }
+}

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -41,13 +41,13 @@ object VersionControl extends SchemaBase {
         value = "GIT",
         valueType = ValueType.String,
         comment = "Git is a distributed version control system."
-      ).protoId(2158),
+      ).protoId(2152),
       Constant(
         name = "SVN",
         value = "SVN",
         valueType = ValueType.String,
         comment = "Apache Subversion, a centralized version control system."
-      ).protoId(2159)
+      ).protoId(2153)
     )
 
     val remote = builder
@@ -56,7 +56,7 @@ object VersionControl extends SchemaBase {
         valueType = ValueType.String,
         comment = "This field holds the URI of the remote host of the repository if one is present."
       )
-      .protoId(2152)
+      .protoId(2154)
 
     val branch = builder
       .addProperty(
@@ -68,7 +68,7 @@ object VersionControl extends SchemaBase {
             |""".stripMargin
       )
       .mandatory(PropertyDefaults.String)
-      .protoId(2153)
+      .protoId(2155)
 
     val author = builder
       .addProperty(
@@ -77,7 +77,7 @@ object VersionControl extends SchemaBase {
         comment = "The name or alias of the developer or authored the code change."
       )
       .mandatory(PropertyDefaults.String)
-      .protoId(2154)
+      .protoId(2156)
 
     val revisionId = builder
       .addProperty(
@@ -86,7 +86,16 @@ object VersionControl extends SchemaBase {
         comment = "The unique identifier of the code change revision object."
       )
       .mandatory(PropertyDefaults.String)
-      .protoId(2155)
+      .protoId(2157)
+
+    val parentRevisionId = builder
+      .addProperty(
+        name = "PARENT_REVISION_ID",
+        valueType = ValueType.String,
+        comment = "The unique identifier of the parent code change revision object."
+      )
+      .mandatory(PropertyDefaults.String)
+      .protoId(2158)
 
     val revisionMessage = builder
       .addProperty(
@@ -95,7 +104,7 @@ object VersionControl extends SchemaBase {
         comment = "The author's message describing the code change for this revision."
       )
       .mandatory(PropertyDefaults.String)
-      .protoId(2156)
+      .protoId(2159)
 
     val modifiedFiles = builder
       .addProperty(
@@ -104,7 +113,16 @@ object VersionControl extends SchemaBase {
         comment = "Full paths relative to the project root directory of files that were modified during the revision."
       )
       .asList()
-      .protoId(2157)
+      .protoId(2160)
+
+    val tags = builder
+      .addProperty(
+        name = "REVISION_TAGS",
+        valueType = ValueType.String,
+        comment = "The tags associated with this revision. This does not include tags put on by forward commits."
+      )
+      .asList()
+      .protoId(2161)
 
     val vcsNode: NodeType = builder
       .addNodeType(
@@ -114,7 +132,17 @@ object VersionControl extends SchemaBase {
             |""".stripMargin
       )
       .protoId(2150)
-      .addProperties(vcsSystem, remote, branch, author, revisionId, revisionMessage, modifiedFiles)
+      .addProperties(
+        vcsSystem,
+        remote,
+        branch,
+        author,
+        revisionId,
+        parentRevisionId,
+        revisionMessage,
+        modifiedFiles,
+        tags
+      )
 
   }
 }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -28,11 +28,27 @@ object VersionControl extends SchemaBase {
         valueType = ValueType.String,
         comment =
           """This field holds the name of the version control system used. This corresponds to the systems that are
-            |supported for being detected e.g. `GIT`.
+            |supported for being detected e.g. `GIT` or `SVN`.
             |""".stripMargin
       )
       .mandatory(PropertyDefaults.String)
       .protoId(2151)
+
+    val versionControlSystems = builder.addConstants(
+      category = "VersionControlSystems",
+      Constant(
+        name = "GIT",
+        value = "GIT",
+        valueType = ValueType.String,
+        comment = "Git is a distributed version control system."
+      ).protoId(2158),
+      Constant(
+        name = "SVN",
+        value = "SVN",
+        valueType = ValueType.String,
+        comment = "Apache Subversion, a centralized version control system."
+      ).protoId(2159)
+    )
 
     val remote = builder
       .addProperty(
@@ -51,6 +67,7 @@ object VersionControl extends SchemaBase {
             |branch from a more stable branch.
             |""".stripMargin
       )
+      .mandatory(PropertyDefaults.String)
       .protoId(2153)
 
     val author = builder
@@ -59,6 +76,7 @@ object VersionControl extends SchemaBase {
         valueType = ValueType.String,
         comment = "The name or alias of the developer or authored the code change."
       )
+      .mandatory(PropertyDefaults.String)
       .protoId(2154)
 
     val revisionId = builder
@@ -67,6 +85,7 @@ object VersionControl extends SchemaBase {
         valueType = ValueType.String,
         comment = "The unique identifier of the code change revision object."
       )
+      .mandatory(PropertyDefaults.String)
       .protoId(2155)
 
     val revisionMessage = builder
@@ -75,6 +94,7 @@ object VersionControl extends SchemaBase {
         valueType = ValueType.String,
         comment = "The author's message describing the code change for this revision."
       )
+      .mandatory(PropertyDefaults.String)
       .protoId(2156)
 
     val modifiedFiles = builder

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -2,7 +2,7 @@ package io.shiftleft.codepropertygraph.schema
 
 import io.shiftleft.codepropertygraph.schema.CpgSchema.PropertyDefaults
 import overflowdb.schema.Property.ValueType
-import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
+import overflowdb.schema.{Constant, NodeType, SchemaBuilder, SchemaInfo}
 
 object VersionControl extends SchemaBase {
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.codepropertygraph.schema
 
+import overflowdb.schema.Property.ValueType
 import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
 
 object VersionControl extends SchemaBase {
@@ -17,7 +18,6 @@ object VersionControl extends SchemaBase {
   def apply(builder: SchemaBuilder) = new Schema(builder)
 
   class Schema(builder: SchemaBuilder) {
-    import base._
 
     implicit private val schemaInfo: SchemaInfo = SchemaInfo.forClass(getClass)
 
@@ -94,7 +94,7 @@ object VersionControl extends SchemaBase {
                     |""".stripMargin
       )
       .protoId(2150)
-      .addProperties(system, remote, branch, author, revisionId, revisionMessage, modifiedFiles)
+      .addProperties(vcsSystem, remote, branch, author, revisionId, revisionMessage, modifiedFiles)
 
   }
 }

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -90,10 +90,11 @@ object VersionControl extends SchemaBase {
 
     val parentRevisionId = builder
       .addProperty(
-        name = "PARENT_REVISION_ID",
+        name = "PARENT_REVISION_IDS",
         valueType = ValueType.String,
-        comment = "The unique identifier of the parent code change revision object."
+        comment = "A list of unique identifiers of the direct parent code change revision objects."
       )
+      .asList()
       .protoId(2158)
 
     val revisionMessage = builder

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -1,5 +1,6 @@
 package io.shiftleft.codepropertygraph.schema
 
+import io.shiftleft.codepropertygraph.schema.CpgSchema.PropertyDefaults
 import overflowdb.schema.Property.ValueType
 import overflowdb.schema.{NodeType, SchemaBuilder, SchemaInfo}
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -50,7 +50,6 @@ object VersionControl extends SchemaBase {
           """This field holds the name of the current branch this version of the code is developed on. This is usually a
             |branch from a more stable branch.
             |""".stripMargin
-
       )
       .protoId(2153)
 
@@ -90,8 +89,7 @@ object VersionControl extends SchemaBase {
     val vcsNode: NodeType = builder
       .addNodeType(
         name = "VERSION_CONTROL",
-        comment =
-          """This node type represents version control system agnostic details about what version of a code base
+        comment = """This node type represents version control system agnostic details about what version of a code base
             |generated this code property graph.
             |""".stripMargin
       )

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -90,9 +90,10 @@ object VersionControl extends SchemaBase {
     val vcsNode: NodeType = builder
       .addNodeType(
         name = "VERSION_CONTROL",
-        comment = """This node type represents version control system agnostic details about what version of a code base
-                    |generated this code property graph.
-                    |""".stripMargin
+        comment =
+          """This node type represents version control system agnostic details about what version of a code base
+            |generated this code property graph.
+            |""".stripMargin
       )
       .protoId(2150)
       .addProperties(vcsSystem, remote, branch, author, revisionId, revisionMessage, modifiedFiles)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/VersionControl.scala
@@ -94,7 +94,6 @@ object VersionControl extends SchemaBase {
         valueType = ValueType.String,
         comment = "The unique identifier of the parent code change revision object."
       )
-      .mandatory(PropertyDefaults.String)
       .protoId(2158)
 
     val revisionMessage = builder


### PR DESCRIPTION
Added a version control node that describes the following properties:
- VCS_SYSTEM: E.g. Git or SVN
- REMOTE (optional): The remote repository URI
- BRANCH: The branch this code is on
- AUTHOR: Who created the revision
- REVISION_ID: The ID of the code revision, e.g. commit hash
- PARENT_REVISION_IDS: A list of direct parent revision IDs
- REVISION_MESSAGE: The accompanying message of the revision
- MODIFIED_FILES: A list of changed files
- REVISION_TAGS: A list of tags on this commit (no tags from forward commits)