### PR TITLE
Introduces `RUBYSRC` language

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -123,7 +123,13 @@ object MetaData extends SchemaBase {
         value = "SOLIDITY",
         valueType = ValueType.String,
         comment = "Solidity language frontend"
-      ).protoId(16)
+      ).protoId(16),
+      Constant(
+        name = "RUBYSRC",
+        value = "RUBYSRC",
+        valueType = ValueType.String,
+        comment = "Source-based frontend for Ruby"
+      ).protoId(17)
     )
   }
 }


### PR DESCRIPTION
...as an intermediate step to kickstarting a ruby frontend for Joern.

I was internally debating whether to name it `RUBY` or `RUBYSRC`, and in the end opted for the suffixed choice. As far as I know, bytecode distribution is not really thing in this realm, but I guess it could eventually be...