### PR TITLE
Replace StringBuilder's append with appendAll

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/IOUtils.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/IOUtils.scala
@@ -75,7 +75,7 @@ object IOUtils {
       val read   = reader.read(buffer)
       productive = read > 0
       if (productive) {
-        stringBuilder.append(buffer)
+        stringBuilder.appendAll(buffer, 0, read)
       }
     }
 


### PR DESCRIPTION
My bad: of course (!), without controlling for amount of bytes to copy we may introduce garbage.