### PR TITLE
Update ProtobufConfig/version to 3.18.0

### DIFF
--- a/proto-bindings/build.sbt
+++ b/proto-bindings/build.sbt
@@ -6,7 +6,7 @@ enablePlugins(ProtobufPlugin)
 val protocLocalDir   = "protoc"
 val protocBinaryPath = s"$protocLocalDir/bin/protoc"
 ProtobufConfig / protobufProtoc := protocBinaryPath
-ProtobufConfig / version        := "3.10.0"
+ProtobufConfig / version        := "3.18.0"
 ProtobufConfig / sourceDirectories += (ProtobufConfig / protobufExternalIncludePath).value
 ProtobufConfig / protobufGenerate := (ProtobufConfig / protobufGenerate)
   .dependsOn(copyLatestCpgProto)


### PR DESCRIPTION
By process of elimination, version 3.18 is the lowest version (after 3.10) that resolves #1713.