### PR TITLE
Revert "Scala 3.3.0, drop cross build and fixup build properties"

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Compile and run tests
       run: sbt +test
     - name: Check formatting
-      run: sbt scalafmtCheck Test/scalafmtCheck
+      run: sbt ++2.13.8 scalafmtCheck Test/scalafmtCheck
     - run: echo "Previous step failed because code is not formatted. Run 'sbt scalafmt'"
       if: ${{ failure() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: 19
-    - name: Check formatting
-      run: sbt scalafmtCheck Test/scalafmtCheck
-    - run: echo "Previous step failed because code is not formatted. Run 'sbt scalafmt'"
-      if: ${{ failure() }}
     - name: Compile and run tests
       run: sbt +test
+    - name: Check formatting
+      run: sbt ++2.13.8 scalafmtCheck Test/scalafmtCheck
+    - run: echo "Previous step failed because code is not formatted. Run 'sbt scalafmt'"
+      if: ${{ failure() }}
 
   release:
     concurrency: release

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ val overflowdbCodegenVersion = "2.97"
 inThisBuild(
   List(
     organization       := "io.shiftleft",
-    scalaVersion       := "3.3.0",
+    scalaVersion       := "2.13.8",
+    crossScalaVersions := Seq("2.13.8", "3.3.0"),
     resolvers ++= Seq(Resolver.mavenLocal, "Sonatype OSS" at "https://oss.sonatype.org/content/repositories/public"),
     packageDoc / publishArtifact := true,
     packageSrc / publishArtifact := true,
@@ -55,9 +56,6 @@ lazy val protoBindings     = Projects.protoBindings
 lazy val codepropertygraph = Projects.codepropertygraph
 lazy val schema2json       = Projects.schema2json
 
-// Once sbt-scalafmt is at version > 2.x, use scalafmtAll
-addCommandAlias("format", ";scalafmt;Test/scalafmt")
-
 ThisBuild / scalacOptions ++= Seq(
   "-release", "8",
   "-deprecation",
@@ -65,6 +63,16 @@ ThisBuild / scalacOptions ++= Seq(
   // "-Xfatal-warnings",
   "-Wconf:cat=deprecation:w,any:e",
   "-language:implicitConversions"
+) ++ (
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((3, _)) => Seq()
+    case _ =>
+      Seq(
+        "-Ycache-macro-class-loader:last-modified",
+        "-Ybackend-parallelism",
+        "4"
+      )
+  }
 )
 
 ThisBuild / javacOptions ++= Seq(


### PR DESCRIPTION
Reverts ShiftLeftSecurity/codepropertygraph#1702

Upgrading Joern to Scala 3.3.0 is getting delayed because
1) the `testDistro.sh` part of the PR run is red, even though locally (for more than just me) it's green, so debugging this is hard: https://github.com/joernio/joern/pull/2595/
2) joern-website cannot be updated at the moment, see https://github.com/joernio/website/pull/81#issuecomment-1597102139