### PR TITLE
Import Node Tag & Remove Points To

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -260,21 +260,12 @@ object Hidden extends SchemaBase {
       .protoId(23664)
 
     importNode.addOutEdge(edge = imports, inNode = dependency)
+    importNode.addOutEdge(edge = taggedBy, inNode = tag)
     callNode.addOutEdge(edge = isCallForImport, inNode = importNode)
 
     block.addOutEdge(edge = ast, inNode = importNode)
     file.addOutEdge(edge = ast, inNode = importNode)
     typeDecl.addOutEdge(edge = ast, inNode = importNode)
-
-    val pointsTo = builder
-      .addEdgeType(
-        name = "POINTS_TO",
-        comment = """Used for calculating points-to sets for resolving object aliasing.
-                    |""".stripMargin
-      )
-      .protoId(12345)
-
-    cfgSchema.cfgNode.addOutEdge(edge = pointsTo, inNode = cfgSchema.cfgNode)
   }
 
 }


### PR DESCRIPTION
* In Joern's new import resolution, descriptions of entities referred to by imports are described by `Tag` nodes. Since `Import` nodes cannot be tagged, their optional call node is tagged instead. Not all languages use call imports so this excludes languages like Java. This allows import nodes to be tagged to avoid this exclusion.
* Removed the `POINTS_TO` edge as it is no longer used, this was initially brought in as an experimental alias analysis edge but realistically this would likely be done on-the-fly or via `Tag` nodes until a better motivation for this edge is given.

See https://github.com/joernio/joern/issues/2163