### PR TITLE
Introduce `POSSIBLE_TYPES` property for approximate type recovery

### DIFF
--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/Properties.java
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/Properties.java
@@ -89,7 +89,7 @@ runtime as it may depend on the type of an object (as is the case for virtual me
 calls) or calculation of an offset. */
 public static final overflowdb.PropertyKey<String> DISPATCH_TYPE = new overflowdb.PropertyKey<>("DISPATCH_TYPE");
 
-/** Type hint for the dynamic type */
+/** Type hint for the dynamic type. These are observed to be verifiable at runtime. */
 public static final overflowdb.PropertyKey<scala.collection.IndexedSeq<String>> DYNAMIC_TYPE_HINT_FULL_NAME = new overflowdb.PropertyKey<>("DYNAMIC_TYPE_HINT_FULL_NAME");
 
 /** For formal method input parameters, output parameters, and return parameters,
@@ -219,6 +219,9 @@ public static final overflowdb.PropertyKey<String> PACKAGE_NAME = new overflowdb
 /** AST node type name emitted by parser. */
 public static final overflowdb.PropertyKey<String> PARSER_TYPE_NAME = new overflowdb.PropertyKey<>("PARSER_TYPE_NAME");
 
+/** Similar to `DYNAMIC_TYPE_HINT_FULL_NAME`, but that this makes no guarantee that types within this property are correct. This property is used to capture observations between node interactions during a 'may-analysis'. */
+public static final overflowdb.PropertyKey<scala.collection.IndexedSeq<String>> POSSIBLE_TYPES = new overflowdb.PropertyKey<>("POSSIBLE_TYPES");
+
 /** The path to the root directory of the source/binary this CPG is generated from. */
 public static final overflowdb.PropertyKey<String> ROOT = new overflowdb.PropertyKey<>("ROOT");
 
@@ -301,6 +304,7 @@ add(ORDER);
 add(OVERLAYS);
 add(PACKAGE_NAME);
 add(PARSER_TYPE_NAME);
+add(POSSIBLE_TYPES);
 add(ROOT);
 add(SIGNATURE);
 add(SYMBOL);

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/PropertyNames.java
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/PropertyNames.java
@@ -89,7 +89,7 @@ runtime as it may depend on the type of an object (as is the case for virtual me
 calls) or calculation of an offset. */
 public static final String DISPATCH_TYPE = "DISPATCH_TYPE";
 
-/** Type hint for the dynamic type */
+/** Type hint for the dynamic type. These are observed to be verifiable at runtime. */
 public static final String DYNAMIC_TYPE_HINT_FULL_NAME = "DYNAMIC_TYPE_HINT_FULL_NAME";
 
 /** For formal method input parameters, output parameters, and return parameters,
@@ -219,6 +219,9 @@ public static final String PACKAGE_NAME = "PACKAGE_NAME";
 /** AST node type name emitted by parser. */
 public static final String PARSER_TYPE_NAME = "PARSER_TYPE_NAME";
 
+/** Similar to `DYNAMIC_TYPE_HINT_FULL_NAME`, but that this makes no guarantee that types within this property are correct. This property is used to capture observations between node interactions during a 'may-analysis'. */
+public static final String POSSIBLE_TYPES = "POSSIBLE_TYPES";
+
 /** The path to the root directory of the source/binary this CPG is generated from. */
 public static final String ROOT = "ROOT";
 
@@ -301,6 +304,7 @@ add(ORDER);
 add(OVERLAYS);
 add(PACKAGE_NAME);
 add(PARSER_TYPE_NAME);
+add(POSSIBLE_TYPES);
 add(ROOT);
 add(SIGNATURE);
 add(SYMBOL);

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Block.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Block.scala
@@ -16,9 +16,19 @@ object Block {
     val DynamicTypeHintFullName = "DYNAMIC_TYPE_HINT_FULL_NAME"
     val LineNumber              = "LINE_NUMBER"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
-    val all: Set[String] =
-      Set(ArgumentIndex, ArgumentName, Code, ColumnNumber, DynamicTypeHintFullName, LineNumber, Order, TypeFullName)
+    val all: Set[String] = Set(
+      ArgumentIndex,
+      ArgumentName,
+      Code,
+      ColumnNumber,
+      DynamicTypeHintFullName,
+      LineNumber,
+      Order,
+      PossibleTypes,
+      TypeFullName
+    )
     val allAsJava: java.util.Set[String] = all.asJava
   }
 
@@ -30,6 +40,7 @@ object Block {
     val DynamicTypeHintFullName = new overflowdb.PropertyKey[IndexedSeq[String]]("DYNAMIC_TYPE_HINT_FULL_NAME")
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -106,6 +117,7 @@ trait BlockBase extends AbstractNode with ExpressionBase {
   def dynamicTypeHintFullName: IndexedSeq[String]
   def lineNumber: Option[Integer]
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -122,6 +134,7 @@ class Block(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/i
   override def dynamicTypeHintFullName: IndexedSeq[String] = get().dynamicTypeHintFullName
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -652,7 +665,8 @@ class Block(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/i
       case 5 => "dynamicTypeHintFullName"
       case 6 => "lineNumber"
       case 7 => "order"
-      case 8 => "typeFullName"
+      case 8 => "possibleTypes"
+      case 9 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -665,11 +679,12 @@ class Block(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/i
       case 5 => dynamicTypeHintFullName
       case 6 => lineNumber
       case 7 => order
-      case 8 => typeFullName
+      case 8 => possibleTypes
+      case 9 => typeFullName
     }
 
   override def productPrefix = "Block"
-  override def productArity  = 9
+  override def productArity  = 10
 }
 
 class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Expression with BlockBase {
@@ -690,6 +705,8 @@ class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Exp
   def lineNumber: Option[Integer]                          = Option(_lineNumber)
   private var _order: scala.Int                            = Block.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = Block.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -705,6 +722,7 @@ class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Exp
     }
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -722,6 +740,7 @@ class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Exp
     }
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -930,7 +949,8 @@ class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Exp
       case 5 => "dynamicTypeHintFullName"
       case 6 => "lineNumber"
       case 7 => "order"
-      case 8 => "typeFullName"
+      case 8 => "possibleTypes"
+      case 9 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -943,11 +963,12 @@ class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Exp
       case 5 => dynamicTypeHintFullName
       case 6 => lineNumber
       case 7 => order
-      case 8 => typeFullName
+      case 8 => possibleTypes
+      case 9 => typeFullName
     }
 
   override def productPrefix = "Block"
-  override def productArity  = 9
+  override def productArity  = 10
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[BlockDb]
 
@@ -960,6 +981,7 @@ class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Exp
       case "DYNAMIC_TYPE_HINT_FULL_NAME" => this._dynamicTypeHintFullName
       case "LINE_NUMBER"                 => this._lineNumber
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -990,8 +1012,26 @@ class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Exp
               collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
             } else collection.immutable.ArraySeq.empty
         }
-      case "LINE_NUMBER"    => this._lineNumber = value.asInstanceOf[Integer]
-      case "ORDER"          => this._order = value.asInstanceOf[scala.Int]
+      case "LINE_NUMBER" => this._lineNumber = value.asInstanceOf[Integer]
+      case "ORDER"       => this._order = value.asInstanceOf[scala.Int]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
       case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
@@ -1018,6 +1058,9 @@ class BlockDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Exp
       else collection.immutable.ArraySeq.empty
     this._lineNumber = newNode.asInstanceOf[NewBlock].lineNumber.orNull
     this._order = newNode.asInstanceOf[NewBlock].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewBlock].possibleTypes != null) newNode.asInstanceOf[NewBlock].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewBlock].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Call.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Call.scala
@@ -19,6 +19,7 @@ object Call {
     val MethodFullName          = "METHOD_FULL_NAME"
     val Name                    = "NAME"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val Signature               = "SIGNATURE"
     val TypeFullName            = "TYPE_FULL_NAME"
     val all: Set[String] = Set(
@@ -32,6 +33,7 @@ object Call {
       MethodFullName,
       Name,
       Order,
+      PossibleTypes,
       Signature,
       TypeFullName
     )
@@ -49,6 +51,7 @@ object Call {
     val MethodFullName          = new overflowdb.PropertyKey[String]("METHOD_FULL_NAME")
     val Name                    = new overflowdb.PropertyKey[String]("NAME")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val Signature               = new overflowdb.PropertyKey[String]("SIGNATURE")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
@@ -150,6 +153,7 @@ trait CallBase extends AbstractNode with CallReprBase with ExpressionBase {
   def methodFullName: String
   def name: String
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def signature: String
   def typeFullName: String
 
@@ -171,6 +175,7 @@ class Call(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/is
   override def methodFullName: String                      = get().methodFullName
   override def name: String                                = get().name
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def signature: String                           = get().signature
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
@@ -827,8 +832,9 @@ class Call(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/is
       case 8  => "methodFullName"
       case 9  => "name"
       case 10 => "order"
-      case 11 => "signature"
-      case 12 => "typeFullName"
+      case 11 => "possibleTypes"
+      case 12 => "signature"
+      case 13 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -844,12 +850,13 @@ class Call(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/is
       case 8  => methodFullName
       case 9  => name
       case 10 => order
-      case 11 => signature
-      case 12 => typeFullName
+      case 11 => possibleTypes
+      case 12 => signature
+      case 13 => typeFullName
     }
 
   override def productPrefix = "Call"
-  override def productArity  = 13
+  override def productArity  = 14
 }
 
 class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with CallRepr with Expression with CallBase {
@@ -876,6 +883,8 @@ class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Call
   def name: String                                         = _name
   private var _order: scala.Int                            = Call.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _signature: String                           = Call.PropertyDefaults.Signature
   def signature: String                                    = _signature
   private var _typeFullName: String                        = Call.PropertyDefaults.TypeFullName
@@ -896,6 +905,7 @@ class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Call
     properties.put("METHOD_FULL_NAME", methodFullName)
     properties.put("NAME", name)
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("SIGNATURE", signature)
     properties.put("TYPE_FULL_NAME", typeFullName)
 
@@ -917,6 +927,7 @@ class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Call
     if (!(("<empty>") == methodFullName)) { properties.put("METHOD_FULL_NAME", methodFullName) }
     if (!(("<empty>") == name)) { properties.put("NAME", name) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("") == signature)) { properties.put("SIGNATURE", signature) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
@@ -1165,8 +1176,9 @@ class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Call
       case 8  => "methodFullName"
       case 9  => "name"
       case 10 => "order"
-      case 11 => "signature"
-      case 12 => "typeFullName"
+      case 11 => "possibleTypes"
+      case 12 => "signature"
+      case 13 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -1182,12 +1194,13 @@ class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Call
       case 8  => methodFullName
       case 9  => name
       case 10 => order
-      case 11 => signature
-      case 12 => typeFullName
+      case 11 => possibleTypes
+      case 12 => signature
+      case 13 => typeFullName
     }
 
   override def productPrefix = "Call"
-  override def productArity  = 13
+  override def productArity  = 14
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[CallDb]
 
@@ -1203,6 +1216,7 @@ class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Call
       case "METHOD_FULL_NAME"            => this._methodFullName
       case "NAME"                        => this._name
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "SIGNATURE"                   => this._signature
       case "TYPE_FULL_NAME"              => this._typeFullName
 
@@ -1239,8 +1253,26 @@ class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Call
       case "METHOD_FULL_NAME" => this._methodFullName = value.asInstanceOf[String]
       case "NAME"             => this._name = value.asInstanceOf[String]
       case "ORDER"            => this._order = value.asInstanceOf[scala.Int]
-      case "SIGNATURE"        => this._signature = value.asInstanceOf[String]
-      case "TYPE_FULL_NAME"   => this._typeFullName = value.asInstanceOf[String]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
+      case "SIGNATURE"      => this._signature = value.asInstanceOf[String]
+      case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
     }
@@ -1269,6 +1301,9 @@ class CallDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Call
     this._methodFullName = newNode.asInstanceOf[NewCall].methodFullName
     this._name = newNode.asInstanceOf[NewCall].name
     this._order = newNode.asInstanceOf[NewCall].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewCall].possibleTypes != null) newNode.asInstanceOf[NewCall].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._signature = newNode.asInstanceOf[NewCall].signature
     this._typeFullName = newNode.asInstanceOf[NewCall].typeFullName
 

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Identifier.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Identifier.scala
@@ -17,6 +17,7 @@ object Identifier {
     val LineNumber              = "LINE_NUMBER"
     val Name                    = "NAME"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
     val all: Set[String] = Set(
       ArgumentIndex,
@@ -27,6 +28,7 @@ object Identifier {
       LineNumber,
       Name,
       Order,
+      PossibleTypes,
       TypeFullName
     )
     val allAsJava: java.util.Set[String] = all.asJava
@@ -41,6 +43,7 @@ object Identifier {
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Name                    = new overflowdb.PropertyKey[String]("NAME")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -119,6 +122,7 @@ trait IdentifierBase extends AbstractNode with ExpressionBase {
   def lineNumber: Option[Integer]
   def name: String
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -136,6 +140,7 @@ class Identifier(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def name: String                                = get().name
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -652,34 +657,36 @@ class Identifier(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/
 
   override def productElementName(n: Int): String =
     n match {
-      case 0 => "id"
-      case 1 => "argumentIndex"
-      case 2 => "argumentName"
-      case 3 => "code"
-      case 4 => "columnNumber"
-      case 5 => "dynamicTypeHintFullName"
-      case 6 => "lineNumber"
-      case 7 => "name"
-      case 8 => "order"
-      case 9 => "typeFullName"
+      case 0  => "id"
+      case 1  => "argumentIndex"
+      case 2  => "argumentName"
+      case 3  => "code"
+      case 4  => "columnNumber"
+      case 5  => "dynamicTypeHintFullName"
+      case 6  => "lineNumber"
+      case 7  => "name"
+      case 8  => "order"
+      case 9  => "possibleTypes"
+      case 10 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
     n match {
-      case 0 => id
-      case 1 => argumentIndex
-      case 2 => argumentName
-      case 3 => code
-      case 4 => columnNumber
-      case 5 => dynamicTypeHintFullName
-      case 6 => lineNumber
-      case 7 => name
-      case 8 => order
-      case 9 => typeFullName
+      case 0  => id
+      case 1  => argumentIndex
+      case 2  => argumentName
+      case 3  => code
+      case 4  => columnNumber
+      case 5  => dynamicTypeHintFullName
+      case 6  => lineNumber
+      case 7  => name
+      case 8  => order
+      case 9  => possibleTypes
+      case 10 => typeFullName
     }
 
   override def productPrefix = "Identifier"
-  override def productArity  = 10
+  override def productArity  = 11
 }
 
 class IdentifierDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Expression with IdentifierBase {
@@ -702,6 +709,8 @@ class IdentifierDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode wit
   def name: String                                         = _name
   private var _order: scala.Int                            = Identifier.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = Identifier.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -718,6 +727,7 @@ class IdentifierDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode wit
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("NAME", name)
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -736,6 +746,7 @@ class IdentifierDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode wit
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!(("<empty>") == name)) { properties.put("NAME", name) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -923,34 +934,36 @@ class IdentifierDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode wit
 
   override def productElementName(n: Int): String =
     n match {
-      case 0 => "id"
-      case 1 => "argumentIndex"
-      case 2 => "argumentName"
-      case 3 => "code"
-      case 4 => "columnNumber"
-      case 5 => "dynamicTypeHintFullName"
-      case 6 => "lineNumber"
-      case 7 => "name"
-      case 8 => "order"
-      case 9 => "typeFullName"
+      case 0  => "id"
+      case 1  => "argumentIndex"
+      case 2  => "argumentName"
+      case 3  => "code"
+      case 4  => "columnNumber"
+      case 5  => "dynamicTypeHintFullName"
+      case 6  => "lineNumber"
+      case 7  => "name"
+      case 8  => "order"
+      case 9  => "possibleTypes"
+      case 10 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
     n match {
-      case 0 => id
-      case 1 => argumentIndex
-      case 2 => argumentName
-      case 3 => code
-      case 4 => columnNumber
-      case 5 => dynamicTypeHintFullName
-      case 6 => lineNumber
-      case 7 => name
-      case 8 => order
-      case 9 => typeFullName
+      case 0  => id
+      case 1  => argumentIndex
+      case 2  => argumentName
+      case 3  => code
+      case 4  => columnNumber
+      case 5  => dynamicTypeHintFullName
+      case 6  => lineNumber
+      case 7  => name
+      case 8  => order
+      case 9  => possibleTypes
+      case 10 => typeFullName
     }
 
   override def productPrefix = "Identifier"
-  override def productArity  = 10
+  override def productArity  = 11
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[IdentifierDb]
 
@@ -964,6 +977,7 @@ class IdentifierDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode wit
       case "LINE_NUMBER"                 => this._lineNumber
       case "NAME"                        => this._name
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -994,9 +1008,27 @@ class IdentifierDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode wit
               collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
             } else collection.immutable.ArraySeq.empty
         }
-      case "LINE_NUMBER"    => this._lineNumber = value.asInstanceOf[Integer]
-      case "NAME"           => this._name = value.asInstanceOf[String]
-      case "ORDER"          => this._order = value.asInstanceOf[scala.Int]
+      case "LINE_NUMBER" => this._lineNumber = value.asInstanceOf[Integer]
+      case "NAME"        => this._name = value.asInstanceOf[String]
+      case "ORDER"       => this._order = value.asInstanceOf[scala.Int]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
       case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
@@ -1024,6 +1056,9 @@ class IdentifierDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode wit
     this._lineNumber = newNode.asInstanceOf[NewIdentifier].lineNumber.orNull
     this._name = newNode.asInstanceOf[NewIdentifier].name
     this._order = newNode.asInstanceOf[NewIdentifier].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewIdentifier].possibleTypes != null) newNode.asInstanceOf[NewIdentifier].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewIdentifier].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Literal.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Literal.scala
@@ -16,9 +16,19 @@ object Literal {
     val DynamicTypeHintFullName = "DYNAMIC_TYPE_HINT_FULL_NAME"
     val LineNumber              = "LINE_NUMBER"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
-    val all: Set[String] =
-      Set(ArgumentIndex, ArgumentName, Code, ColumnNumber, DynamicTypeHintFullName, LineNumber, Order, TypeFullName)
+    val all: Set[String] = Set(
+      ArgumentIndex,
+      ArgumentName,
+      Code,
+      ColumnNumber,
+      DynamicTypeHintFullName,
+      LineNumber,
+      Order,
+      PossibleTypes,
+      TypeFullName
+    )
     val allAsJava: java.util.Set[String] = all.asJava
   }
 
@@ -30,6 +40,7 @@ object Literal {
     val DynamicTypeHintFullName = new overflowdb.PropertyKey[IndexedSeq[String]]("DYNAMIC_TYPE_HINT_FULL_NAME")
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -105,6 +116,7 @@ trait LiteralBase extends AbstractNode with ExpressionBase {
   def dynamicTypeHintFullName: IndexedSeq[String]
   def lineNumber: Option[Integer]
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -121,6 +133,7 @@ class Literal(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
   override def dynamicTypeHintFullName: IndexedSeq[String] = get().dynamicTypeHintFullName
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -633,7 +646,8 @@ class Literal(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
       case 5 => "dynamicTypeHintFullName"
       case 6 => "lineNumber"
       case 7 => "order"
-      case 8 => "typeFullName"
+      case 8 => "possibleTypes"
+      case 9 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -646,11 +660,12 @@ class Literal(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
       case 5 => dynamicTypeHintFullName
       case 6 => lineNumber
       case 7 => order
-      case 8 => typeFullName
+      case 8 => possibleTypes
+      case 9 => typeFullName
     }
 
   override def productPrefix = "Literal"
-  override def productArity  = 9
+  override def productArity  = 10
 }
 
 class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Expression with LiteralBase {
@@ -671,6 +686,8 @@ class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
   def lineNumber: Option[Integer]                          = Option(_lineNumber)
   private var _order: scala.Int                            = Literal.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = Literal.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -686,6 +703,7 @@ class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
     }
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -703,6 +721,7 @@ class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
     }
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -900,7 +919,8 @@ class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case 5 => "dynamicTypeHintFullName"
       case 6 => "lineNumber"
       case 7 => "order"
-      case 8 => "typeFullName"
+      case 8 => "possibleTypes"
+      case 9 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -913,11 +933,12 @@ class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case 5 => dynamicTypeHintFullName
       case 6 => lineNumber
       case 7 => order
-      case 8 => typeFullName
+      case 8 => possibleTypes
+      case 9 => typeFullName
     }
 
   override def productPrefix = "Literal"
-  override def productArity  = 9
+  override def productArity  = 10
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[LiteralDb]
 
@@ -930,6 +951,7 @@ class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case "DYNAMIC_TYPE_HINT_FULL_NAME" => this._dynamicTypeHintFullName
       case "LINE_NUMBER"                 => this._lineNumber
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -960,8 +982,26 @@ class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
               collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
             } else collection.immutable.ArraySeq.empty
         }
-      case "LINE_NUMBER"    => this._lineNumber = value.asInstanceOf[Integer]
-      case "ORDER"          => this._order = value.asInstanceOf[scala.Int]
+      case "LINE_NUMBER" => this._lineNumber = value.asInstanceOf[Integer]
+      case "ORDER"       => this._order = value.asInstanceOf[scala.Int]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
       case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
@@ -988,6 +1028,9 @@ class LiteralDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       else collection.immutable.ArraySeq.empty
     this._lineNumber = newNode.asInstanceOf[NewLiteral].lineNumber.orNull
     this._order = newNode.asInstanceOf[NewLiteral].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewLiteral].possibleTypes != null) newNode.asInstanceOf[NewLiteral].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewLiteral].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Local.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Local.scala
@@ -16,9 +16,19 @@ object Local {
     val LineNumber              = "LINE_NUMBER"
     val Name                    = "NAME"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
-    val all: Set[String] =
-      Set(ClosureBindingId, Code, ColumnNumber, DynamicTypeHintFullName, LineNumber, Name, Order, TypeFullName)
+    val all: Set[String] = Set(
+      ClosureBindingId,
+      Code,
+      ColumnNumber,
+      DynamicTypeHintFullName,
+      LineNumber,
+      Name,
+      Order,
+      PossibleTypes,
+      TypeFullName
+    )
     val allAsJava: java.util.Set[String] = all.asJava
   }
 
@@ -30,6 +40,7 @@ object Local {
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Name                    = new overflowdb.PropertyKey[String]("NAME")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -80,6 +91,7 @@ trait LocalBase extends AbstractNode with AstNodeBase with DeclarationBase {
   def lineNumber: Option[Integer]
   def name: String
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -97,6 +109,7 @@ class Local(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/i
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def name: String                                = get().name
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -191,7 +204,8 @@ class Local(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/i
       case 5 => "lineNumber"
       case 6 => "name"
       case 7 => "order"
-      case 8 => "typeFullName"
+      case 8 => "possibleTypes"
+      case 9 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -204,11 +218,12 @@ class Local(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/i
       case 5 => lineNumber
       case 6 => name
       case 7 => order
-      case 8 => typeFullName
+      case 8 => possibleTypes
+      case 9 => typeFullName
     }
 
   override def productPrefix = "Local"
-  override def productArity  = 9
+  override def productArity  = 10
 }
 
 class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with AstNode with Declaration with LocalBase {
@@ -229,6 +244,8 @@ class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Ast
   def name: String                                         = _name
   private var _order: scala.Int                            = Local.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = Local.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -244,6 +261,7 @@ class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Ast
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("NAME", name)
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -261,6 +279,7 @@ class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Ast
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!(("<empty>") == name)) { properties.put("NAME", name) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -306,7 +325,8 @@ class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Ast
       case 5 => "lineNumber"
       case 6 => "name"
       case 7 => "order"
-      case 8 => "typeFullName"
+      case 8 => "possibleTypes"
+      case 9 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -319,11 +339,12 @@ class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Ast
       case 5 => lineNumber
       case 6 => name
       case 7 => order
-      case 8 => typeFullName
+      case 8 => possibleTypes
+      case 9 => typeFullName
     }
 
   override def productPrefix = "Local"
-  override def productArity  = 9
+  override def productArity  = 10
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[LocalDb]
 
@@ -336,6 +357,7 @@ class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Ast
       case "LINE_NUMBER"                 => this._lineNumber
       case "NAME"                        => this._name
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -365,9 +387,27 @@ class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Ast
               collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
             } else collection.immutable.ArraySeq.empty
         }
-      case "LINE_NUMBER"    => this._lineNumber = value.asInstanceOf[Integer]
-      case "NAME"           => this._name = value.asInstanceOf[String]
-      case "ORDER"          => this._order = value.asInstanceOf[scala.Int]
+      case "LINE_NUMBER" => this._lineNumber = value.asInstanceOf[Integer]
+      case "NAME"        => this._name = value.asInstanceOf[String]
+      case "ORDER"       => this._order = value.asInstanceOf[scala.Int]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
       case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
@@ -394,6 +434,9 @@ class LocalDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Ast
     this._lineNumber = newNode.asInstanceOf[NewLocal].lineNumber.orNull
     this._name = newNode.asInstanceOf[NewLocal].name
     this._order = newNode.asInstanceOf[NewLocal].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewLocal].possibleTypes != null) newNode.asInstanceOf[NewLocal].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewLocal].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Member.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Member.scala
@@ -15,8 +15,10 @@ object Member {
     val LineNumber              = "LINE_NUMBER"
     val Name                    = "NAME"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
-    val all: Set[String] = Set(Code, ColumnNumber, DynamicTypeHintFullName, LineNumber, Name, Order, TypeFullName)
+    val all: Set[String] =
+      Set(Code, ColumnNumber, DynamicTypeHintFullName, LineNumber, Name, Order, PossibleTypes, TypeFullName)
     val allAsJava: java.util.Set[String] = all.asJava
   }
 
@@ -27,6 +29,7 @@ object Member {
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Name                    = new overflowdb.PropertyKey[String]("NAME")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -76,6 +79,7 @@ trait MemberBase extends AbstractNode with AstNodeBase with DeclarationBase {
   def lineNumber: Option[Integer]
   def name: String
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -92,6 +96,7 @@ class Member(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def name: String                                = get().name
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -174,7 +179,8 @@ class Member(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/
       case 4 => "lineNumber"
       case 5 => "name"
       case 6 => "order"
-      case 7 => "typeFullName"
+      case 7 => "possibleTypes"
+      case 8 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -186,11 +192,12 @@ class Member(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug/
       case 4 => lineNumber
       case 5 => name
       case 6 => order
-      case 7 => typeFullName
+      case 7 => possibleTypes
+      case 8 => typeFullName
     }
 
   override def productPrefix = "Member"
-  override def productArity  = 8
+  override def productArity  = 9
 }
 
 class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with AstNode with Declaration with MemberBase {
@@ -209,6 +216,8 @@ class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with As
   def name: String                                         = _name
   private var _order: scala.Int                            = Member.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = Member.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -223,6 +232,7 @@ class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with As
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("NAME", name)
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -239,6 +249,7 @@ class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with As
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!(("<empty>") == name)) { properties.put("NAME", name) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -287,7 +298,8 @@ class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with As
       case 4 => "lineNumber"
       case 5 => "name"
       case 6 => "order"
-      case 7 => "typeFullName"
+      case 7 => "possibleTypes"
+      case 8 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -299,11 +311,12 @@ class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with As
       case 4 => lineNumber
       case 5 => name
       case 6 => order
-      case 7 => typeFullName
+      case 7 => possibleTypes
+      case 8 => typeFullName
     }
 
   override def productPrefix = "Member"
-  override def productArity  = 8
+  override def productArity  = 9
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[MemberDb]
 
@@ -315,6 +328,7 @@ class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with As
       case "LINE_NUMBER"                 => this._lineNumber
       case "NAME"                        => this._name
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -343,9 +357,27 @@ class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with As
               collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
             } else collection.immutable.ArraySeq.empty
         }
-      case "LINE_NUMBER"    => this._lineNumber = value.asInstanceOf[Integer]
-      case "NAME"           => this._name = value.asInstanceOf[String]
-      case "ORDER"          => this._order = value.asInstanceOf[scala.Int]
+      case "LINE_NUMBER" => this._lineNumber = value.asInstanceOf[Integer]
+      case "NAME"        => this._name = value.asInstanceOf[String]
+      case "ORDER"       => this._order = value.asInstanceOf[scala.Int]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
       case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
@@ -371,6 +403,9 @@ class MemberDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with As
     this._lineNumber = newNode.asInstanceOf[NewMember].lineNumber.orNull
     this._name = newNode.asInstanceOf[NewMember].name
     this._order = newNode.asInstanceOf[NewMember].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewMember].possibleTypes != null) newNode.asInstanceOf[NewMember].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewMember].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/MethodParameterIn.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/MethodParameterIn.scala
@@ -18,6 +18,7 @@ object MethodParameterIn {
     val LineNumber              = "LINE_NUMBER"
     val Name                    = "NAME"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
     val all: Set[String] = Set(
       Code,
@@ -29,6 +30,7 @@ object MethodParameterIn {
       LineNumber,
       Name,
       Order,
+      PossibleTypes,
       TypeFullName
     )
     val allAsJava: java.util.Set[String] = all.asJava
@@ -44,6 +46,7 @@ object MethodParameterIn {
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Name                    = new overflowdb.PropertyKey[String]("NAME")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -103,6 +106,7 @@ trait MethodParameterInBase extends AbstractNode with AstNodeBase with CfgNodeBa
   def lineNumber: Option[Integer]
   def name: String
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -123,6 +127,7 @@ class MethodParameterIn(graph_4762: Graph, id_4762: Long /*cf https://github.com
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def name: String                                = get().name
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -264,7 +269,8 @@ class MethodParameterIn(graph_4762: Graph, id_4762: Long /*cf https://github.com
       case 7  => "lineNumber"
       case 8  => "name"
       case 9  => "order"
-      case 10 => "typeFullName"
+      case 10 => "possibleTypes"
+      case 11 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -279,11 +285,12 @@ class MethodParameterIn(graph_4762: Graph, id_4762: Long /*cf https://github.com
       case 7  => lineNumber
       case 8  => name
       case 9  => order
-      case 10 => typeFullName
+      case 10 => possibleTypes
+      case 11 => typeFullName
     }
 
   override def productPrefix = "MethodParameterIn"
-  override def productArity  = 11
+  override def productArity  = 12
 }
 
 class MethodParameterInDb(ref: NodeRef[NodeDb])
@@ -314,6 +321,8 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
   def name: String                                         = _name
   private var _order: scala.Int                            = MethodParameterIn.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = MethodParameterIn.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -331,6 +340,7 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("NAME", name)
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -350,6 +360,7 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!(("<empty>") == name)) { properties.put("NAME", name) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -430,7 +441,8 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
       case 7  => "lineNumber"
       case 8  => "name"
       case 9  => "order"
-      case 10 => "typeFullName"
+      case 10 => "possibleTypes"
+      case 11 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -445,11 +457,12 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
       case 7  => lineNumber
       case 8  => name
       case 9  => order
-      case 10 => typeFullName
+      case 10 => possibleTypes
+      case 11 => typeFullName
     }
 
   override def productPrefix = "MethodParameterIn"
-  override def productArity  = 11
+  override def productArity  = 12
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[MethodParameterInDb]
 
@@ -464,6 +477,7 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
       case "LINE_NUMBER"                 => this._lineNumber
       case "NAME"                        => this._name
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -498,7 +512,25 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
       case "LINE_NUMBER"         => this._lineNumber = value.asInstanceOf[Integer]
       case "NAME"                => this._name = value.asInstanceOf[String]
       case "ORDER"               => this._order = value.asInstanceOf[scala.Int]
-      case "TYPE_FULL_NAME"      => this._typeFullName = value.asInstanceOf[String]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
+      case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
     }
@@ -526,6 +558,10 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
     this._lineNumber = newNode.asInstanceOf[NewMethodParameterIn].lineNumber.orNull
     this._name = newNode.asInstanceOf[NewMethodParameterIn].name
     this._order = newNode.asInstanceOf[NewMethodParameterIn].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewMethodParameterIn].possibleTypes != null)
+        newNode.asInstanceOf[NewMethodParameterIn].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewMethodParameterIn].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/MethodRef.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/MethodRef.scala
@@ -17,6 +17,7 @@ object MethodRef {
     val LineNumber              = "LINE_NUMBER"
     val MethodFullName          = "METHOD_FULL_NAME"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
     val all: Set[String] = Set(
       ArgumentIndex,
@@ -27,6 +28,7 @@ object MethodRef {
       LineNumber,
       MethodFullName,
       Order,
+      PossibleTypes,
       TypeFullName
     )
     val allAsJava: java.util.Set[String] = all.asJava
@@ -41,6 +43,7 @@ object MethodRef {
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val MethodFullName          = new overflowdb.PropertyKey[String]("METHOD_FULL_NAME")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -130,6 +133,7 @@ trait MethodRefBase extends AbstractNode with ExpressionBase {
   def lineNumber: Option[Integer]
   def methodFullName: String
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -147,6 +151,7 @@ class MethodRef(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/b
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def methodFullName: String                      = get().methodFullName
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -668,34 +673,36 @@ class MethodRef(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/b
 
   override def productElementName(n: Int): String =
     n match {
-      case 0 => "id"
-      case 1 => "argumentIndex"
-      case 2 => "argumentName"
-      case 3 => "code"
-      case 4 => "columnNumber"
-      case 5 => "dynamicTypeHintFullName"
-      case 6 => "lineNumber"
-      case 7 => "methodFullName"
-      case 8 => "order"
-      case 9 => "typeFullName"
+      case 0  => "id"
+      case 1  => "argumentIndex"
+      case 2  => "argumentName"
+      case 3  => "code"
+      case 4  => "columnNumber"
+      case 5  => "dynamicTypeHintFullName"
+      case 6  => "lineNumber"
+      case 7  => "methodFullName"
+      case 8  => "order"
+      case 9  => "possibleTypes"
+      case 10 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
     n match {
-      case 0 => id
-      case 1 => argumentIndex
-      case 2 => argumentName
-      case 3 => code
-      case 4 => columnNumber
-      case 5 => dynamicTypeHintFullName
-      case 6 => lineNumber
-      case 7 => methodFullName
-      case 8 => order
-      case 9 => typeFullName
+      case 0  => id
+      case 1  => argumentIndex
+      case 2  => argumentName
+      case 3  => code
+      case 4  => columnNumber
+      case 5  => dynamicTypeHintFullName
+      case 6  => lineNumber
+      case 7  => methodFullName
+      case 8  => order
+      case 9  => possibleTypes
+      case 10 => typeFullName
     }
 
   override def productPrefix = "MethodRef"
-  override def productArity  = 10
+  override def productArity  = 11
 }
 
 class MethodRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Expression with MethodRefBase {
@@ -718,6 +725,8 @@ class MethodRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with
   def methodFullName: String                               = _methodFullName
   private var _order: scala.Int                            = MethodRef.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = MethodRef.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -734,6 +743,7 @@ class MethodRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("METHOD_FULL_NAME", methodFullName)
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -752,6 +762,7 @@ class MethodRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!(("<empty>") == methodFullName)) { properties.put("METHOD_FULL_NAME", methodFullName) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -957,34 +968,36 @@ class MethodRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with
 
   override def productElementName(n: Int): String =
     n match {
-      case 0 => "id"
-      case 1 => "argumentIndex"
-      case 2 => "argumentName"
-      case 3 => "code"
-      case 4 => "columnNumber"
-      case 5 => "dynamicTypeHintFullName"
-      case 6 => "lineNumber"
-      case 7 => "methodFullName"
-      case 8 => "order"
-      case 9 => "typeFullName"
+      case 0  => "id"
+      case 1  => "argumentIndex"
+      case 2  => "argumentName"
+      case 3  => "code"
+      case 4  => "columnNumber"
+      case 5  => "dynamicTypeHintFullName"
+      case 6  => "lineNumber"
+      case 7  => "methodFullName"
+      case 8  => "order"
+      case 9  => "possibleTypes"
+      case 10 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
     n match {
-      case 0 => id
-      case 1 => argumentIndex
-      case 2 => argumentName
-      case 3 => code
-      case 4 => columnNumber
-      case 5 => dynamicTypeHintFullName
-      case 6 => lineNumber
-      case 7 => methodFullName
-      case 8 => order
-      case 9 => typeFullName
+      case 0  => id
+      case 1  => argumentIndex
+      case 2  => argumentName
+      case 3  => code
+      case 4  => columnNumber
+      case 5  => dynamicTypeHintFullName
+      case 6  => lineNumber
+      case 7  => methodFullName
+      case 8  => order
+      case 9  => possibleTypes
+      case 10 => typeFullName
     }
 
   override def productPrefix = "MethodRef"
-  override def productArity  = 10
+  override def productArity  = 11
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[MethodRefDb]
 
@@ -998,6 +1011,7 @@ class MethodRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with
       case "LINE_NUMBER"                 => this._lineNumber
       case "METHOD_FULL_NAME"            => this._methodFullName
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -1031,7 +1045,25 @@ class MethodRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with
       case "LINE_NUMBER"      => this._lineNumber = value.asInstanceOf[Integer]
       case "METHOD_FULL_NAME" => this._methodFullName = value.asInstanceOf[String]
       case "ORDER"            => this._order = value.asInstanceOf[scala.Int]
-      case "TYPE_FULL_NAME"   => this._typeFullName = value.asInstanceOf[String]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
+      case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
     }
@@ -1058,6 +1090,9 @@ class MethodRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with
     this._lineNumber = newNode.asInstanceOf[NewMethodRef].lineNumber.orNull
     this._methodFullName = newNode.asInstanceOf[NewMethodRef].methodFullName
     this._order = newNode.asInstanceOf[NewMethodRef].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewMethodRef].possibleTypes != null) newNode.asInstanceOf[NewMethodRef].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewMethodRef].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/MethodReturn.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/MethodReturn.scala
@@ -15,9 +15,18 @@ object MethodReturn {
     val EvaluationStrategy      = "EVALUATION_STRATEGY"
     val LineNumber              = "LINE_NUMBER"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
-    val all: Set[String] =
-      Set(Code, ColumnNumber, DynamicTypeHintFullName, EvaluationStrategy, LineNumber, Order, TypeFullName)
+    val all: Set[String] = Set(
+      Code,
+      ColumnNumber,
+      DynamicTypeHintFullName,
+      EvaluationStrategy,
+      LineNumber,
+      Order,
+      PossibleTypes,
+      TypeFullName
+    )
     val allAsJava: java.util.Set[String] = all.asJava
   }
 
@@ -28,6 +37,7 @@ object MethodReturn {
     val EvaluationStrategy      = new overflowdb.PropertyKey[String]("EVALUATION_STRATEGY")
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -80,6 +90,7 @@ trait MethodReturnBase extends AbstractNode with CfgNodeBase {
   def evaluationStrategy: String
   def lineNumber: Option[Integer]
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -95,6 +106,7 @@ class MethodReturn(graph_4762: Graph, id_4762: Long /*cf https://github.com/scal
   override def evaluationStrategy: String                  = get().evaluationStrategy
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -310,7 +322,8 @@ class MethodReturn(graph_4762: Graph, id_4762: Long /*cf https://github.com/scal
       case 4 => "evaluationStrategy"
       case 5 => "lineNumber"
       case 6 => "order"
-      case 7 => "typeFullName"
+      case 7 => "possibleTypes"
+      case 8 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -322,11 +335,12 @@ class MethodReturn(graph_4762: Graph, id_4762: Long /*cf https://github.com/scal
       case 4 => evaluationStrategy
       case 5 => lineNumber
       case 6 => order
-      case 7 => typeFullName
+      case 7 => possibleTypes
+      case 8 => typeFullName
     }
 
   override def productPrefix = "MethodReturn"
-  override def productArity  = 8
+  override def productArity  = 9
 }
 
 class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with CfgNode with MethodReturnBase {
@@ -345,6 +359,8 @@ class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode w
   def lineNumber: Option[Integer]                          = Option(_lineNumber)
   private var _order: scala.Int                            = MethodReturn.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = MethodReturn.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -359,6 +375,7 @@ class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode w
     properties.put("EVALUATION_STRATEGY", evaluationStrategy)
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -375,6 +392,7 @@ class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode w
     if (!(("<empty>") == evaluationStrategy)) { properties.put("EVALUATION_STRATEGY", evaluationStrategy) }
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -467,7 +485,8 @@ class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode w
       case 4 => "evaluationStrategy"
       case 5 => "lineNumber"
       case 6 => "order"
-      case 7 => "typeFullName"
+      case 7 => "possibleTypes"
+      case 8 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -479,11 +498,12 @@ class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode w
       case 4 => evaluationStrategy
       case 5 => lineNumber
       case 6 => order
-      case 7 => typeFullName
+      case 7 => possibleTypes
+      case 8 => typeFullName
     }
 
   override def productPrefix = "MethodReturn"
-  override def productArity  = 8
+  override def productArity  = 9
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[MethodReturnDb]
 
@@ -495,6 +515,7 @@ class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode w
       case "EVALUATION_STRATEGY"         => this._evaluationStrategy
       case "LINE_NUMBER"                 => this._lineNumber
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -526,7 +547,25 @@ class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode w
       case "EVALUATION_STRATEGY" => this._evaluationStrategy = value.asInstanceOf[String]
       case "LINE_NUMBER"         => this._lineNumber = value.asInstanceOf[Integer]
       case "ORDER"               => this._order = value.asInstanceOf[scala.Int]
-      case "TYPE_FULL_NAME"      => this._typeFullName = value.asInstanceOf[String]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
+      case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
     }
@@ -551,6 +590,10 @@ class MethodReturnDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode w
     this._evaluationStrategy = newNode.asInstanceOf[NewMethodReturn].evaluationStrategy
     this._lineNumber = newNode.asInstanceOf[NewMethodReturn].lineNumber.orNull
     this._order = newNode.asInstanceOf[NewMethodReturn].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewMethodReturn].possibleTypes != null)
+        newNode.asInstanceOf[NewMethodReturn].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewMethodReturn].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/NewNodes.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/NewNodes.scala
@@ -582,6 +582,7 @@ class NewBlock extends NewNode with BlockBase with ExpressionNew {
   type StoredType = Block
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var lineNumber: Option[Integer]                 = None
   var dynamicTypeHintFullName: IndexedSeq[String] = collection.immutable.ArraySeq.empty
@@ -601,6 +602,7 @@ class NewBlock extends NewNode with BlockBase with ExpressionNew {
     newInstance.dynamicTypeHintFullName = this.dynamicTypeHintFullName
     newInstance.lineNumber = this.lineNumber
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -646,6 +648,11 @@ class NewBlock extends NewNode with BlockBase with ExpressionNew {
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -662,6 +669,7 @@ class NewBlock extends NewNode with BlockBase with ExpressionNew {
     }
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
@@ -669,31 +677,33 @@ class NewBlock extends NewNode with BlockBase with ExpressionNew {
   override def productElement(n: Int): Any =
     n match {
       case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.lineNumber
-      case 3 => this.dynamicTypeHintFullName
-      case 4 => this.columnNumber
-      case 5 => this.code
-      case 6 => this.argumentName
-      case 7 => this.argumentIndex
+      case 1 => this.possibleTypes
+      case 2 => this.order
+      case 3 => this.lineNumber
+      case 4 => this.dynamicTypeHintFullName
+      case 5 => this.columnNumber
+      case 6 => this.code
+      case 7 => this.argumentName
+      case 8 => this.argumentIndex
       case _ => null
     }
 
   override def productElementName(n: Int): String =
     n match {
       case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "lineNumber"
-      case 3 => "dynamicTypeHintFullName"
-      case 4 => "columnNumber"
-      case 5 => "code"
-      case 6 => "argumentName"
-      case 7 => "argumentIndex"
+      case 1 => "possibleTypes"
+      case 2 => "order"
+      case 3 => "lineNumber"
+      case 4 => "dynamicTypeHintFullName"
+      case 5 => "columnNumber"
+      case 6 => "code"
+      case 7 => "argumentName"
+      case 8 => "argumentIndex"
       case _ => ""
     }
 
   override def productPrefix = "NewBlock"
-  override def productArity  = 8
+  override def productArity  = 9
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewBlock]
 }
@@ -707,6 +717,7 @@ class NewCall extends NewNode with CallBase with CallReprNew with ExpressionNew 
 
   var typeFullName: String                        = "<empty>"
   var signature: String                           = ""
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var name: String                                = "<empty>"
   var methodFullName: String                      = "<empty>"
@@ -732,6 +743,7 @@ class NewCall extends NewNode with CallBase with CallReprNew with ExpressionNew 
     newInstance.methodFullName = this.methodFullName
     newInstance.name = this.name
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.signature = this.signature
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
@@ -793,6 +805,11 @@ class NewCall extends NewNode with CallBase with CallReprNew with ExpressionNew 
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def signature(value: String): this.type = {
     this.signature = value
     this
@@ -817,6 +834,7 @@ class NewCall extends NewNode with CallBase with CallReprNew with ExpressionNew 
     if (!(("<empty>") == methodFullName)) { res += "METHOD_FULL_NAME" -> methodFullName }
     if (!(("<empty>") == name)) { res += "NAME" -> name }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("") == signature)) { res += "SIGNATURE" -> signature }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
@@ -826,16 +844,17 @@ class NewCall extends NewNode with CallBase with CallReprNew with ExpressionNew 
     n match {
       case 0  => this.typeFullName
       case 1  => this.signature
-      case 2  => this.order
-      case 3  => this.name
-      case 4  => this.methodFullName
-      case 5  => this.lineNumber
-      case 6  => this.dynamicTypeHintFullName
-      case 7  => this.dispatchType
-      case 8  => this.columnNumber
-      case 9  => this.code
-      case 10 => this.argumentName
-      case 11 => this.argumentIndex
+      case 2  => this.possibleTypes
+      case 3  => this.order
+      case 4  => this.name
+      case 5  => this.methodFullName
+      case 6  => this.lineNumber
+      case 7  => this.dynamicTypeHintFullName
+      case 8  => this.dispatchType
+      case 9  => this.columnNumber
+      case 10 => this.code
+      case 11 => this.argumentName
+      case 12 => this.argumentIndex
       case _  => null
     }
 
@@ -843,21 +862,22 @@ class NewCall extends NewNode with CallBase with CallReprNew with ExpressionNew 
     n match {
       case 0  => "typeFullName"
       case 1  => "signature"
-      case 2  => "order"
-      case 3  => "name"
-      case 4  => "methodFullName"
-      case 5  => "lineNumber"
-      case 6  => "dynamicTypeHintFullName"
-      case 7  => "dispatchType"
-      case 8  => "columnNumber"
-      case 9  => "code"
-      case 10 => "argumentName"
-      case 11 => "argumentIndex"
+      case 2  => "possibleTypes"
+      case 3  => "order"
+      case 4  => "name"
+      case 5  => "methodFullName"
+      case 6  => "lineNumber"
+      case 7  => "dynamicTypeHintFullName"
+      case 8  => "dispatchType"
+      case 9  => "columnNumber"
+      case 10 => "code"
+      case 11 => "argumentName"
+      case 12 => "argumentIndex"
       case _  => ""
     }
 
   override def productPrefix = "NewCall"
-  override def productArity  = 12
+  override def productArity  = 13
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewCall]
 }
@@ -1546,6 +1566,7 @@ class NewIdentifier extends NewNode with IdentifierBase with ExpressionNew {
   type StoredType = Identifier
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var name: String                                = "<empty>"
   var lineNumber: Option[Integer]                 = None
@@ -1567,6 +1588,7 @@ class NewIdentifier extends NewNode with IdentifierBase with ExpressionNew {
     newInstance.lineNumber = this.lineNumber
     newInstance.name = this.name
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -1617,6 +1639,11 @@ class NewIdentifier extends NewNode with IdentifierBase with ExpressionNew {
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -1634,6 +1661,7 @@ class NewIdentifier extends NewNode with IdentifierBase with ExpressionNew {
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!(("<empty>") == name)) { res += "NAME" -> name }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
@@ -1641,33 +1669,35 @@ class NewIdentifier extends NewNode with IdentifierBase with ExpressionNew {
   override def productElement(n: Int): Any =
     n match {
       case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.name
-      case 3 => this.lineNumber
-      case 4 => this.dynamicTypeHintFullName
-      case 5 => this.columnNumber
-      case 6 => this.code
-      case 7 => this.argumentName
-      case 8 => this.argumentIndex
+      case 1 => this.possibleTypes
+      case 2 => this.order
+      case 3 => this.name
+      case 4 => this.lineNumber
+      case 5 => this.dynamicTypeHintFullName
+      case 6 => this.columnNumber
+      case 7 => this.code
+      case 8 => this.argumentName
+      case 9 => this.argumentIndex
       case _ => null
     }
 
   override def productElementName(n: Int): String =
     n match {
       case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "name"
-      case 3 => "lineNumber"
-      case 4 => "dynamicTypeHintFullName"
-      case 5 => "columnNumber"
-      case 6 => "code"
-      case 7 => "argumentName"
-      case 8 => "argumentIndex"
+      case 1 => "possibleTypes"
+      case 2 => "order"
+      case 3 => "name"
+      case 4 => "lineNumber"
+      case 5 => "dynamicTypeHintFullName"
+      case 6 => "columnNumber"
+      case 7 => "code"
+      case 8 => "argumentName"
+      case 9 => "argumentIndex"
       case _ => ""
     }
 
   override def productPrefix = "NewIdentifier"
-  override def productArity  = 9
+  override def productArity  = 10
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewIdentifier]
 }
@@ -2086,6 +2116,7 @@ class NewLiteral extends NewNode with LiteralBase with ExpressionNew {
   type StoredType = Literal
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var lineNumber: Option[Integer]                 = None
   var dynamicTypeHintFullName: IndexedSeq[String] = collection.immutable.ArraySeq.empty
@@ -2105,6 +2136,7 @@ class NewLiteral extends NewNode with LiteralBase with ExpressionNew {
     newInstance.dynamicTypeHintFullName = this.dynamicTypeHintFullName
     newInstance.lineNumber = this.lineNumber
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -2150,6 +2182,11 @@ class NewLiteral extends NewNode with LiteralBase with ExpressionNew {
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -2166,6 +2203,7 @@ class NewLiteral extends NewNode with LiteralBase with ExpressionNew {
     }
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
@@ -2173,31 +2211,33 @@ class NewLiteral extends NewNode with LiteralBase with ExpressionNew {
   override def productElement(n: Int): Any =
     n match {
       case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.lineNumber
-      case 3 => this.dynamicTypeHintFullName
-      case 4 => this.columnNumber
-      case 5 => this.code
-      case 6 => this.argumentName
-      case 7 => this.argumentIndex
+      case 1 => this.possibleTypes
+      case 2 => this.order
+      case 3 => this.lineNumber
+      case 4 => this.dynamicTypeHintFullName
+      case 5 => this.columnNumber
+      case 6 => this.code
+      case 7 => this.argumentName
+      case 8 => this.argumentIndex
       case _ => null
     }
 
   override def productElementName(n: Int): String =
     n match {
       case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "lineNumber"
-      case 3 => "dynamicTypeHintFullName"
-      case 4 => "columnNumber"
-      case 5 => "code"
-      case 6 => "argumentName"
-      case 7 => "argumentIndex"
+      case 1 => "possibleTypes"
+      case 2 => "order"
+      case 3 => "lineNumber"
+      case 4 => "dynamicTypeHintFullName"
+      case 5 => "columnNumber"
+      case 6 => "code"
+      case 7 => "argumentName"
+      case 8 => "argumentIndex"
       case _ => ""
     }
 
   override def productPrefix = "NewLiteral"
-  override def productArity  = 8
+  override def productArity  = 9
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewLiteral]
 }
@@ -2210,6 +2250,7 @@ class NewLocal extends NewNode with LocalBase with AstNodeNew with DeclarationNe
   type StoredType = Local
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var name: String                                = "<empty>"
   var lineNumber: Option[Integer]                 = None
@@ -2229,6 +2270,7 @@ class NewLocal extends NewNode with LocalBase with AstNodeNew with DeclarationNe
     newInstance.lineNumber = this.lineNumber
     newInstance.name = this.name
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -2274,6 +2316,11 @@ class NewLocal extends NewNode with LocalBase with AstNodeNew with DeclarationNe
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -2290,6 +2337,7 @@ class NewLocal extends NewNode with LocalBase with AstNodeNew with DeclarationNe
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!(("<empty>") == name)) { res += "NAME" -> name }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
@@ -2297,31 +2345,33 @@ class NewLocal extends NewNode with LocalBase with AstNodeNew with DeclarationNe
   override def productElement(n: Int): Any =
     n match {
       case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.name
-      case 3 => this.lineNumber
-      case 4 => this.dynamicTypeHintFullName
-      case 5 => this.columnNumber
-      case 6 => this.code
-      case 7 => this.closureBindingId
+      case 1 => this.possibleTypes
+      case 2 => this.order
+      case 3 => this.name
+      case 4 => this.lineNumber
+      case 5 => this.dynamicTypeHintFullName
+      case 6 => this.columnNumber
+      case 7 => this.code
+      case 8 => this.closureBindingId
       case _ => null
     }
 
   override def productElementName(n: Int): String =
     n match {
       case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "name"
-      case 3 => "lineNumber"
-      case 4 => "dynamicTypeHintFullName"
-      case 5 => "columnNumber"
-      case 6 => "code"
-      case 7 => "closureBindingId"
+      case 1 => "possibleTypes"
+      case 2 => "order"
+      case 3 => "name"
+      case 4 => "lineNumber"
+      case 5 => "dynamicTypeHintFullName"
+      case 6 => "columnNumber"
+      case 7 => "code"
+      case 8 => "closureBindingId"
       case _ => ""
     }
 
   override def productPrefix = "NewLocal"
-  override def productArity  = 8
+  override def productArity  = 9
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewLocal]
 }
@@ -2474,6 +2524,7 @@ class NewMember extends NewNode with MemberBase with AstNodeNew with Declaration
   type StoredType = Member
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var name: String                                = "<empty>"
   var lineNumber: Option[Integer]                 = None
@@ -2491,6 +2542,7 @@ class NewMember extends NewNode with MemberBase with AstNodeNew with Declaration
     newInstance.lineNumber = this.lineNumber
     newInstance.name = this.name
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -2529,6 +2581,11 @@ class NewMember extends NewNode with MemberBase with AstNodeNew with Declaration
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -2544,6 +2601,7 @@ class NewMember extends NewNode with MemberBase with AstNodeNew with Declaration
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!(("<empty>") == name)) { res += "NAME" -> name }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
@@ -2551,29 +2609,31 @@ class NewMember extends NewNode with MemberBase with AstNodeNew with Declaration
   override def productElement(n: Int): Any =
     n match {
       case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.name
-      case 3 => this.lineNumber
-      case 4 => this.dynamicTypeHintFullName
-      case 5 => this.columnNumber
-      case 6 => this.code
+      case 1 => this.possibleTypes
+      case 2 => this.order
+      case 3 => this.name
+      case 4 => this.lineNumber
+      case 5 => this.dynamicTypeHintFullName
+      case 6 => this.columnNumber
+      case 7 => this.code
       case _ => null
     }
 
   override def productElementName(n: Int): String =
     n match {
       case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "name"
-      case 3 => "lineNumber"
-      case 4 => "dynamicTypeHintFullName"
-      case 5 => "columnNumber"
-      case 6 => "code"
+      case 1 => "possibleTypes"
+      case 2 => "order"
+      case 3 => "name"
+      case 4 => "lineNumber"
+      case 5 => "dynamicTypeHintFullName"
+      case 6 => "columnNumber"
+      case 7 => "code"
       case _ => ""
     }
 
   override def productPrefix = "NewMember"
-  override def productArity  = 7
+  override def productArity  = 8
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewMember]
 }
@@ -2865,6 +2925,7 @@ class NewMethodParameterIn
   type StoredType = MethodParameterIn
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var name: String                                = "<empty>"
   var lineNumber: Option[Integer]                 = None
@@ -2888,6 +2949,7 @@ class NewMethodParameterIn
     newInstance.lineNumber = this.lineNumber
     newInstance.name = this.name
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -2941,6 +3003,11 @@ class NewMethodParameterIn
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -2959,42 +3026,45 @@ class NewMethodParameterIn
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!(("<empty>") == name)) { res += "NAME" -> name }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
 
   override def productElement(n: Int): Any =
     n match {
-      case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.name
-      case 3 => this.lineNumber
-      case 4 => this.isVariadic
-      case 5 => this.index
-      case 6 => this.evaluationStrategy
-      case 7 => this.dynamicTypeHintFullName
-      case 8 => this.columnNumber
-      case 9 => this.code
-      case _ => null
+      case 0  => this.typeFullName
+      case 1  => this.possibleTypes
+      case 2  => this.order
+      case 3  => this.name
+      case 4  => this.lineNumber
+      case 5  => this.isVariadic
+      case 6  => this.index
+      case 7  => this.evaluationStrategy
+      case 8  => this.dynamicTypeHintFullName
+      case 9  => this.columnNumber
+      case 10 => this.code
+      case _  => null
     }
 
   override def productElementName(n: Int): String =
     n match {
-      case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "name"
-      case 3 => "lineNumber"
-      case 4 => "isVariadic"
-      case 5 => "index"
-      case 6 => "evaluationStrategy"
-      case 7 => "dynamicTypeHintFullName"
-      case 8 => "columnNumber"
-      case 9 => "code"
-      case _ => ""
+      case 0  => "typeFullName"
+      case 1  => "possibleTypes"
+      case 2  => "order"
+      case 3  => "name"
+      case 4  => "lineNumber"
+      case 5  => "isVariadic"
+      case 6  => "index"
+      case 7  => "evaluationStrategy"
+      case 8  => "dynamicTypeHintFullName"
+      case 9  => "columnNumber"
+      case 10 => "code"
+      case _  => ""
     }
 
   override def productPrefix = "NewMethodParameterIn"
-  override def productArity  = 10
+  override def productArity  = 11
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewMethodParameterIn]
 }
@@ -3142,6 +3212,7 @@ class NewMethodRef extends NewNode with MethodRefBase with ExpressionNew {
   type StoredType = MethodRef
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var methodFullName: String                      = "<empty>"
   var lineNumber: Option[Integer]                 = None
@@ -3163,6 +3234,7 @@ class NewMethodRef extends NewNode with MethodRefBase with ExpressionNew {
     newInstance.lineNumber = this.lineNumber
     newInstance.methodFullName = this.methodFullName
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -3213,6 +3285,11 @@ class NewMethodRef extends NewNode with MethodRefBase with ExpressionNew {
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -3230,6 +3307,7 @@ class NewMethodRef extends NewNode with MethodRefBase with ExpressionNew {
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!(("<empty>") == methodFullName)) { res += "METHOD_FULL_NAME" -> methodFullName }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
@@ -3237,33 +3315,35 @@ class NewMethodRef extends NewNode with MethodRefBase with ExpressionNew {
   override def productElement(n: Int): Any =
     n match {
       case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.methodFullName
-      case 3 => this.lineNumber
-      case 4 => this.dynamicTypeHintFullName
-      case 5 => this.columnNumber
-      case 6 => this.code
-      case 7 => this.argumentName
-      case 8 => this.argumentIndex
+      case 1 => this.possibleTypes
+      case 2 => this.order
+      case 3 => this.methodFullName
+      case 4 => this.lineNumber
+      case 5 => this.dynamicTypeHintFullName
+      case 6 => this.columnNumber
+      case 7 => this.code
+      case 8 => this.argumentName
+      case 9 => this.argumentIndex
       case _ => null
     }
 
   override def productElementName(n: Int): String =
     n match {
       case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "methodFullName"
-      case 3 => "lineNumber"
-      case 4 => "dynamicTypeHintFullName"
-      case 5 => "columnNumber"
-      case 6 => "code"
-      case 7 => "argumentName"
-      case 8 => "argumentIndex"
+      case 1 => "possibleTypes"
+      case 2 => "order"
+      case 3 => "methodFullName"
+      case 4 => "lineNumber"
+      case 5 => "dynamicTypeHintFullName"
+      case 6 => "columnNumber"
+      case 7 => "code"
+      case 8 => "argumentName"
+      case 9 => "argumentIndex"
       case _ => ""
     }
 
   override def productPrefix = "NewMethodRef"
-  override def productArity  = 9
+  override def productArity  = 10
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewMethodRef]
 }
@@ -3276,6 +3356,7 @@ class NewMethodReturn extends NewNode with MethodReturnBase with CfgNodeNew {
   type StoredType = MethodReturn
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var lineNumber: Option[Integer]                 = None
   var evaluationStrategy: String                  = "<empty>"
@@ -3293,6 +3374,7 @@ class NewMethodReturn extends NewNode with MethodReturnBase with CfgNodeNew {
     newInstance.evaluationStrategy = this.evaluationStrategy
     newInstance.lineNumber = this.lineNumber
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -3331,6 +3413,11 @@ class NewMethodReturn extends NewNode with MethodReturnBase with CfgNodeNew {
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -3346,6 +3433,7 @@ class NewMethodReturn extends NewNode with MethodReturnBase with CfgNodeNew {
     if (!(("<empty>") == evaluationStrategy)) { res += "EVALUATION_STRATEGY" -> evaluationStrategy }
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
@@ -3353,29 +3441,31 @@ class NewMethodReturn extends NewNode with MethodReturnBase with CfgNodeNew {
   override def productElement(n: Int): Any =
     n match {
       case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.lineNumber
-      case 3 => this.evaluationStrategy
-      case 4 => this.dynamicTypeHintFullName
-      case 5 => this.columnNumber
-      case 6 => this.code
+      case 1 => this.possibleTypes
+      case 2 => this.order
+      case 3 => this.lineNumber
+      case 4 => this.evaluationStrategy
+      case 5 => this.dynamicTypeHintFullName
+      case 6 => this.columnNumber
+      case 7 => this.code
       case _ => null
     }
 
   override def productElementName(n: Int): String =
     n match {
       case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "lineNumber"
-      case 3 => "evaluationStrategy"
-      case 4 => "dynamicTypeHintFullName"
-      case 5 => "columnNumber"
-      case 6 => "code"
+      case 1 => "possibleTypes"
+      case 2 => "order"
+      case 3 => "lineNumber"
+      case 4 => "evaluationStrategy"
+      case 5 => "dynamicTypeHintFullName"
+      case 6 => "columnNumber"
+      case 7 => "code"
       case _ => ""
     }
 
   override def productPrefix = "NewMethodReturn"
-  override def productArity  = 7
+  override def productArity  = 8
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewMethodReturn]
 }
@@ -4404,6 +4494,7 @@ class NewTypeRef extends NewNode with TypeRefBase with ExpressionNew {
   type StoredType = TypeRef
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var order: scala.Int                            = -1: Int
   var lineNumber: Option[Integer]                 = None
   var dynamicTypeHintFullName: IndexedSeq[String] = collection.immutable.ArraySeq.empty
@@ -4423,6 +4514,7 @@ class NewTypeRef extends NewNode with TypeRefBase with ExpressionNew {
     newInstance.dynamicTypeHintFullName = this.dynamicTypeHintFullName
     newInstance.lineNumber = this.lineNumber
     newInstance.order = this.order
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -4468,6 +4560,11 @@ class NewTypeRef extends NewNode with TypeRefBase with ExpressionNew {
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -4484,6 +4581,7 @@ class NewTypeRef extends NewNode with TypeRefBase with ExpressionNew {
     }
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
@@ -4491,31 +4589,33 @@ class NewTypeRef extends NewNode with TypeRefBase with ExpressionNew {
   override def productElement(n: Int): Any =
     n match {
       case 0 => this.typeFullName
-      case 1 => this.order
-      case 2 => this.lineNumber
-      case 3 => this.dynamicTypeHintFullName
-      case 4 => this.columnNumber
-      case 5 => this.code
-      case 6 => this.argumentName
-      case 7 => this.argumentIndex
+      case 1 => this.possibleTypes
+      case 2 => this.order
+      case 3 => this.lineNumber
+      case 4 => this.dynamicTypeHintFullName
+      case 5 => this.columnNumber
+      case 6 => this.code
+      case 7 => this.argumentName
+      case 8 => this.argumentIndex
       case _ => null
     }
 
   override def productElementName(n: Int): String =
     n match {
       case 0 => "typeFullName"
-      case 1 => "order"
-      case 2 => "lineNumber"
-      case 3 => "dynamicTypeHintFullName"
-      case 4 => "columnNumber"
-      case 5 => "code"
-      case 6 => "argumentName"
-      case 7 => "argumentIndex"
+      case 1 => "possibleTypes"
+      case 2 => "order"
+      case 3 => "lineNumber"
+      case 4 => "dynamicTypeHintFullName"
+      case 5 => "columnNumber"
+      case 6 => "code"
+      case 7 => "argumentName"
+      case 8 => "argumentIndex"
       case _ => ""
     }
 
   override def productPrefix = "NewTypeRef"
-  override def productArity  = 8
+  override def productArity  = 9
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewTypeRef]
 }
@@ -4528,6 +4628,7 @@ class NewUnknown extends NewNode with UnknownBase with ExpressionNew {
   type StoredType = Unknown
 
   var typeFullName: String                        = "<empty>"
+  var possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
   var parserTypeName: String                      = "<empty>"
   var order: scala.Int                            = -1: Int
   var lineNumber: Option[Integer]                 = None
@@ -4551,6 +4652,7 @@ class NewUnknown extends NewNode with UnknownBase with ExpressionNew {
     newInstance.lineNumber = this.lineNumber
     newInstance.order = this.order
     newInstance.parserTypeName = this.parserTypeName
+    newInstance.possibleTypes = this.possibleTypes
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
@@ -4606,6 +4708,11 @@ class NewUnknown extends NewNode with UnknownBase with ExpressionNew {
     this
   }
 
+  def possibleTypes(value: IterableOnce[String]): this.type = {
+    this.possibleTypes = value.iterator.to(collection.immutable.ArraySeq)
+    this
+  }
+
   def typeFullName(value: String): this.type = {
     this.typeFullName = value
     this
@@ -4624,42 +4731,45 @@ class NewUnknown extends NewNode with UnknownBase with ExpressionNew {
     lineNumber.map { value => res += "LINE_NUMBER" -> value }
     if (!((-1: Int) == order)) { res += "ORDER" -> order }
     if (!(("<empty>") == parserTypeName)) { res += "PARSER_TYPE_NAME" -> parserTypeName }
+    if (possibleTypes != null && possibleTypes.nonEmpty) { res += "POSSIBLE_TYPES" -> possibleTypes }
     if (!(("<empty>") == typeFullName)) { res += "TYPE_FULL_NAME" -> typeFullName }
     res
   }
 
   override def productElement(n: Int): Any =
     n match {
-      case 0 => this.typeFullName
-      case 1 => this.parserTypeName
-      case 2 => this.order
-      case 3 => this.lineNumber
-      case 4 => this.dynamicTypeHintFullName
-      case 5 => this.containedRef
-      case 6 => this.columnNumber
-      case 7 => this.code
-      case 8 => this.argumentName
-      case 9 => this.argumentIndex
-      case _ => null
+      case 0  => this.typeFullName
+      case 1  => this.possibleTypes
+      case 2  => this.parserTypeName
+      case 3  => this.order
+      case 4  => this.lineNumber
+      case 5  => this.dynamicTypeHintFullName
+      case 6  => this.containedRef
+      case 7  => this.columnNumber
+      case 8  => this.code
+      case 9  => this.argumentName
+      case 10 => this.argumentIndex
+      case _  => null
     }
 
   override def productElementName(n: Int): String =
     n match {
-      case 0 => "typeFullName"
-      case 1 => "parserTypeName"
-      case 2 => "order"
-      case 3 => "lineNumber"
-      case 4 => "dynamicTypeHintFullName"
-      case 5 => "containedRef"
-      case 6 => "columnNumber"
-      case 7 => "code"
-      case 8 => "argumentName"
-      case 9 => "argumentIndex"
-      case _ => ""
+      case 0  => "typeFullName"
+      case 1  => "possibleTypes"
+      case 2  => "parserTypeName"
+      case 3  => "order"
+      case 4  => "lineNumber"
+      case 5  => "dynamicTypeHintFullName"
+      case 6  => "containedRef"
+      case 7  => "columnNumber"
+      case 8  => "code"
+      case 9  => "argumentName"
+      case 10 => "argumentIndex"
+      case _  => ""
     }
 
   override def productPrefix = "NewUnknown"
-  override def productArity  = 10
+  override def productArity  = 11
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewUnknown]
 }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/TypeRef.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/TypeRef.scala
@@ -16,9 +16,19 @@ object TypeRef {
     val DynamicTypeHintFullName = "DYNAMIC_TYPE_HINT_FULL_NAME"
     val LineNumber              = "LINE_NUMBER"
     val Order                   = "ORDER"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
-    val all: Set[String] =
-      Set(ArgumentIndex, ArgumentName, Code, ColumnNumber, DynamicTypeHintFullName, LineNumber, Order, TypeFullName)
+    val all: Set[String] = Set(
+      ArgumentIndex,
+      ArgumentName,
+      Code,
+      ColumnNumber,
+      DynamicTypeHintFullName,
+      LineNumber,
+      Order,
+      PossibleTypes,
+      TypeFullName
+    )
     val allAsJava: java.util.Set[String] = all.asJava
   }
 
@@ -30,6 +40,7 @@ object TypeRef {
     val DynamicTypeHintFullName = new overflowdb.PropertyKey[IndexedSeq[String]]("DYNAMIC_TYPE_HINT_FULL_NAME")
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -106,6 +117,7 @@ trait TypeRefBase extends AbstractNode with ExpressionBase {
   def dynamicTypeHintFullName: IndexedSeq[String]
   def lineNumber: Option[Integer]
   def order: scala.Int
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -122,6 +134,7 @@ class TypeRef(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
   override def dynamicTypeHintFullName: IndexedSeq[String] = get().dynamicTypeHintFullName
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def order: scala.Int                            = get().order
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -641,7 +654,8 @@ class TypeRef(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
       case 5 => "dynamicTypeHintFullName"
       case 6 => "lineNumber"
       case 7 => "order"
-      case 8 => "typeFullName"
+      case 8 => "possibleTypes"
+      case 9 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -654,11 +668,12 @@ class TypeRef(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
       case 5 => dynamicTypeHintFullName
       case 6 => lineNumber
       case 7 => order
-      case 8 => typeFullName
+      case 8 => possibleTypes
+      case 9 => typeFullName
     }
 
   override def productPrefix = "TypeRef"
-  override def productArity  = 9
+  override def productArity  = 10
 }
 
 class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Expression with TypeRefBase {
@@ -679,6 +694,8 @@ class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
   def lineNumber: Option[Integer]                          = Option(_lineNumber)
   private var _order: scala.Int                            = TypeRef.PropertyDefaults.Order
   def order: scala.Int                                     = _order
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = TypeRef.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -694,6 +711,7 @@ class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
     }
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("ORDER", order)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -711,6 +729,7 @@ class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
     }
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -906,7 +925,8 @@ class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case 5 => "dynamicTypeHintFullName"
       case 6 => "lineNumber"
       case 7 => "order"
-      case 8 => "typeFullName"
+      case 8 => "possibleTypes"
+      case 9 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -919,11 +939,12 @@ class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case 5 => dynamicTypeHintFullName
       case 6 => lineNumber
       case 7 => order
-      case 8 => typeFullName
+      case 8 => possibleTypes
+      case 9 => typeFullName
     }
 
   override def productPrefix = "TypeRef"
-  override def productArity  = 9
+  override def productArity  = 10
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[TypeRefDb]
 
@@ -936,6 +957,7 @@ class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case "DYNAMIC_TYPE_HINT_FULL_NAME" => this._dynamicTypeHintFullName
       case "LINE_NUMBER"                 => this._lineNumber
       case "ORDER"                       => this._order
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -966,8 +988,26 @@ class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
               collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
             } else collection.immutable.ArraySeq.empty
         }
-      case "LINE_NUMBER"    => this._lineNumber = value.asInstanceOf[Integer]
-      case "ORDER"          => this._order = value.asInstanceOf[scala.Int]
+      case "LINE_NUMBER" => this._lineNumber = value.asInstanceOf[Integer]
+      case "ORDER"       => this._order = value.asInstanceOf[scala.Int]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
       case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
@@ -994,6 +1034,9 @@ class TypeRefDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       else collection.immutable.ArraySeq.empty
     this._lineNumber = newNode.asInstanceOf[NewTypeRef].lineNumber.orNull
     this._order = newNode.asInstanceOf[NewTypeRef].order
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewTypeRef].possibleTypes != null) newNode.asInstanceOf[NewTypeRef].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewTypeRef].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Unknown.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/Unknown.scala
@@ -18,6 +18,7 @@ object Unknown {
     val LineNumber              = "LINE_NUMBER"
     val Order                   = "ORDER"
     val ParserTypeName          = "PARSER_TYPE_NAME"
+    val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
     val all: Set[String] = Set(
       ArgumentIndex,
@@ -29,6 +30,7 @@ object Unknown {
       LineNumber,
       Order,
       ParserTypeName,
+      PossibleTypes,
       TypeFullName
     )
     val allAsJava: java.util.Set[String] = all.asJava
@@ -44,6 +46,7 @@ object Unknown {
     val LineNumber              = new overflowdb.PropertyKey[Integer]("LINE_NUMBER")
     val Order                   = new overflowdb.PropertyKey[scala.Int]("ORDER")
     val ParserTypeName          = new overflowdb.PropertyKey[String]("PARSER_TYPE_NAME")
+    val PossibleTypes           = new overflowdb.PropertyKey[IndexedSeq[String]]("POSSIBLE_TYPES")
     val TypeFullName            = new overflowdb.PropertyKey[String]("TYPE_FULL_NAME")
 
   }
@@ -124,6 +127,7 @@ trait UnknownBase extends AbstractNode with ExpressionBase {
   def lineNumber: Option[Integer]
   def order: scala.Int
   def parserTypeName: String
+  def possibleTypes: IndexedSeq[String]
   def typeFullName: String
 
 }
@@ -142,6 +146,7 @@ class Unknown(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
   override def lineNumber: Option[Integer]                 = get().lineNumber
   override def order: scala.Int                            = get().order
   override def parserTypeName: String                      = get().parserTypeName
+  override def possibleTypes: IndexedSeq[String]           = get().possibleTypes
   override def typeFullName: String                        = get().typeFullName
   override def propertyDefaultValue(propertyKey: String) =
     propertyKey match {
@@ -658,7 +663,8 @@ class Unknown(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
       case 7  => "lineNumber"
       case 8  => "order"
       case 9  => "parserTypeName"
-      case 10 => "typeFullName"
+      case 10 => "possibleTypes"
+      case 11 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -673,11 +679,12 @@ class Unknown(graph_4762: Graph, id_4762: Long /*cf https://github.com/scala/bug
       case 7  => lineNumber
       case 8  => order
       case 9  => parserTypeName
-      case 10 => typeFullName
+      case 10 => possibleTypes
+      case 11 => typeFullName
     }
 
   override def productPrefix = "Unknown"
-  override def productArity  = 11
+  override def productArity  = 12
 }
 
 class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with Expression with UnknownBase {
@@ -702,6 +709,8 @@ class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
   def order: scala.Int                                     = _order
   private var _parserTypeName: String                      = Unknown.PropertyDefaults.ParserTypeName
   def parserTypeName: String                               = _parserTypeName
+  private var _possibleTypes: IndexedSeq[String]           = collection.immutable.ArraySeq.empty
+  def possibleTypes: IndexedSeq[String]                    = _possibleTypes
   private var _typeFullName: String                        = Unknown.PropertyDefaults.TypeFullName
   def typeFullName: String                                 = _typeFullName
 
@@ -719,6 +728,7 @@ class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     properties.put("ORDER", order)
     properties.put("PARSER_TYPE_NAME", parserTypeName)
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     properties.put("TYPE_FULL_NAME", typeFullName)
 
     properties
@@ -738,6 +748,7 @@ class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
     lineNumber.map { value => properties.put("LINE_NUMBER", value) }
     if (!((-1: Int) == order)) { properties.put("ORDER", order) }
     if (!(("<empty>") == parserTypeName)) { properties.put("PARSER_TYPE_NAME", parserTypeName) }
+    if (this._possibleTypes != null && this._possibleTypes.nonEmpty) { properties.put("POSSIBLE_TYPES", possibleTypes) }
     if (!(("<empty>") == typeFullName)) { properties.put("TYPE_FULL_NAME", typeFullName) }
 
     properties
@@ -931,7 +942,8 @@ class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case 7  => "lineNumber"
       case 8  => "order"
       case 9  => "parserTypeName"
-      case 10 => "typeFullName"
+      case 10 => "possibleTypes"
+      case 11 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
@@ -946,11 +958,12 @@ class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case 7  => lineNumber
       case 8  => order
       case 9  => parserTypeName
-      case 10 => typeFullName
+      case 10 => possibleTypes
+      case 11 => typeFullName
     }
 
   override def productPrefix = "Unknown"
-  override def productArity  = 11
+  override def productArity  = 12
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[UnknownDb]
 
@@ -965,6 +978,7 @@ class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case "LINE_NUMBER"                 => this._lineNumber
       case "ORDER"                       => this._order
       case "PARSER_TYPE_NAME"            => this._parserTypeName
+      case "POSSIBLE_TYPES"              => this._possibleTypes
       case "TYPE_FULL_NAME"              => this._typeFullName
 
       case _ => null
@@ -999,7 +1013,25 @@ class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
       case "LINE_NUMBER"      => this._lineNumber = value.asInstanceOf[Integer]
       case "ORDER"            => this._order = value.asInstanceOf[scala.Int]
       case "PARSER_TYPE_NAME" => this._parserTypeName = value.asInstanceOf[String]
-      case "TYPE_FULL_NAME"   => this._typeFullName = value.asInstanceOf[String]
+      case "POSSIBLE_TYPES" =>
+        this._possibleTypes = value match {
+          case null                                             => collection.immutable.ArraySeq.empty
+          case singleValue: String                              => collection.immutable.ArraySeq(singleValue)
+          case coll: IterableOnce[Any] if coll.iterator.isEmpty => collection.immutable.ArraySeq.empty
+          case arr: Array[_] if arr.isEmpty                     => collection.immutable.ArraySeq.empty
+          case arr: Array[_] => collection.immutable.ArraySeq.unsafeWrapArray(arr).asInstanceOf[IndexedSeq[String]]
+          case jCollection: java.lang.Iterable[_] =>
+            if (jCollection.iterator.hasNext) {
+              collection.immutable.ArraySeq.unsafeWrapArray(
+                jCollection.asInstanceOf[java.util.Collection[String]].iterator.asScala.toArray
+              )
+            } else collection.immutable.ArraySeq.empty
+          case iter: Iterable[_] =>
+            if (iter.nonEmpty) {
+              collection.immutable.ArraySeq.unsafeWrapArray(iter.asInstanceOf[Iterable[String]].toArray)
+            } else collection.immutable.ArraySeq.empty
+        }
+      case "TYPE_FULL_NAME" => this._typeFullName = value.asInstanceOf[String]
 
       case _ => PropertyErrorRegister.logPropertyErrorIfFirst(getClass, key)
     }
@@ -1027,6 +1059,9 @@ class UnknownDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode with E
     this._lineNumber = newNode.asInstanceOf[NewUnknown].lineNumber.orNull
     this._order = newNode.asInstanceOf[NewUnknown].order
     this._parserTypeName = newNode.asInstanceOf[NewUnknown].parserTypeName
+    this._possibleTypes =
+      if (newNode.asInstanceOf[NewUnknown].possibleTypes != null) newNode.asInstanceOf[NewUnknown].possibleTypes
+      else collection.immutable.ArraySeq.empty
     this._typeFullName = newNode.asInstanceOf[NewUnknown].typeFullName
 
   }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Block.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Block.scala
@@ -320,6 +320,10 @@ class BlockTraversalExtGen[NodeType <: Block](val traversal: Iterator[NodeType])
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Call.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Call.scala
@@ -490,6 +490,10 @@ class CallTraversalExtGen[NodeType <: Call](val traversal: Iterator[NodeType]) e
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to signature property */
   def signature: Iterator[String] =
     traversal.map(_.signature)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Identifier.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Identifier.scala
@@ -369,6 +369,10 @@ class IdentifierTraversalExtGen[NodeType <: Identifier](val traversal: Iterator[
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Literal.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Literal.scala
@@ -313,6 +313,10 @@ class LiteralTraversalExtGen[NodeType <: Literal](val traversal: Iterator[NodeTy
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Local.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Local.scala
@@ -342,6 +342,10 @@ class LocalTraversalExtGen[NodeType <: Local](val traversal: Iterator[NodeType])
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Member.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Member.scala
@@ -280,6 +280,10 @@ class MemberTraversalExtGen[NodeType <: Member](val traversal: Iterator[NodeType
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/MethodParameterIn.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/MethodParameterIn.scala
@@ -418,6 +418,10 @@ class MethodParameterInTraversalExtGen[NodeType <: MethodParameterIn](val traver
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/MethodRef.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/MethodRef.scala
@@ -377,6 +377,10 @@ class MethodRefTraversalExtGen[NodeType <: MethodRef](val traversal: Iterator[No
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/MethodReturn.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/MethodReturn.scala
@@ -276,6 +276,10 @@ class MethodReturnTraversalExtGen[NodeType <: MethodReturn](val traversal: Itera
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/TypeRef.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/TypeRef.scala
@@ -313,6 +313,10 @@ class TypeRefTraversalExtGen[NodeType <: TypeRef](val traversal: Iterator[NodeTy
     traversal.filter { node => !vset.contains(node.order) }
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Unknown.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/Unknown.scala
@@ -427,6 +427,10 @@ class UnknownTraversalExtGen[NodeType <: Unknown](val traversal: Iterator[NodeTy
     overflowdb.traversal.filter.StringPropertyFilter.regexpNotMultiple(traversal)(_.parserTypeName, patterns)
   }
 
+  /** Traverse to possibleTypes property */
+  def possibleTypes: Iterator[String] =
+    traversal.flatMap(_.possibleTypes)
+
   /** Traverse to typeFullName property */
   def typeFullName: Iterator[String] =
     traversal.map(_.typeFullName)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -155,22 +155,32 @@ object Hidden extends SchemaBase {
       .addProperty(
         name = "DYNAMIC_TYPE_HINT_FULL_NAME",
         valueType = ValueType.String,
-        comment = "Type hint for the dynamic type"
+        comment = "Type hint for the dynamic type. These are observed to be verifiable at runtime."
       )
       .asList()
       .protoId(1591)
 
-    callNode.addProperties(dynamicTypeHintFullName)
-    methodParameterIn.addProperties(dynamicTypeHintFullName)
-    methodReturn.addProperties(dynamicTypeHintFullName)
-    methodRef.addProperties(dynamicTypeHintFullName)
-    typeRef.addProperties(dynamicTypeHintFullName)
-    local.addProperties(dynamicTypeHintFullName)
-    block.addProperties(dynamicTypeHintFullName)
-    unknown.addProperties(dynamicTypeHintFullName)
-    literal.addProperties(dynamicTypeHintFullName)
-    identifier.addProperties(dynamicTypeHintFullName)
-    member.addProperties(dynamicTypeHintFullName)
+    val possibleTypes = builder
+      .addProperty(
+        name = "POSSIBLE_TYPES",
+        valueType = ValueType.String,
+        comment =
+          "Similar to `DYNAMIC_TYPE_HINT_FULL_NAME`, but that this makes no guarantee that types within this property are correct. This property is used to capture observations between node interactions during a 'may-analysis'."
+      )
+      .asList()
+      .protoId(1592)
+
+    callNode.addProperties(dynamicTypeHintFullName, possibleTypes)
+    methodParameterIn.addProperties(dynamicTypeHintFullName, possibleTypes)
+    methodReturn.addProperties(dynamicTypeHintFullName, possibleTypes)
+    methodRef.addProperties(dynamicTypeHintFullName, possibleTypes)
+    typeRef.addProperties(dynamicTypeHintFullName, possibleTypes)
+    local.addProperties(dynamicTypeHintFullName, possibleTypes)
+    block.addProperties(dynamicTypeHintFullName, possibleTypes)
+    unknown.addProperties(dynamicTypeHintFullName, possibleTypes)
+    literal.addProperties(dynamicTypeHintFullName, possibleTypes)
+    identifier.addProperties(dynamicTypeHintFullName, possibleTypes)
+    member.addProperties(dynamicTypeHintFullName, possibleTypes)
 
     /*
      * Declarative imports


### PR DESCRIPTION
This new property provides no guantee of correctness and is the property to use for `may`-style type recovery. Resolves #1721