### PR TITLE
Allow closure bindings on method parameters

### DIFF
--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/ClosureBinding.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/ClosureBinding.scala
@@ -96,12 +96,17 @@ class ClosureBinding(graph_4762: Graph, id_4762: Long /*cf https://github.com/sc
     */
   def _typeRefViaCaptureIn: overflowdb.traversal.Traversal[TypeRef] = get()._typeRefViaCaptureIn
 
-  def capturedByIn: Iterator[Local] = get().capturedByIn
-  override def _capturedByIn        = get()._capturedByIn
+  def capturedByIn: Iterator[AstNode] = get().capturedByIn
+  override def _capturedByIn          = get()._capturedByIn
 
   /** Traverse to LOCAL via CAPTURED_BY IN edge.
     */
   def _localViaCapturedByIn: overflowdb.traversal.Traversal[Local] = get()._localViaCapturedByIn
+
+  /** Traverse to METHOD_PARAMETER_IN via CAPTURED_BY IN edge.
+    */
+  def _methodParameterInViaCapturedByIn: overflowdb.traversal.Traversal[MethodParameterIn] =
+    get()._methodParameterInViaCapturedByIn
 
   // In view of https://github.com/scala/bug/issues/4762 it is advisable to use different variable names in
   // patterns like `class Base(x:Int)` and `class Derived(x:Int) extends Base(x)`.
@@ -189,9 +194,11 @@ class ClosureBindingDb(ref: NodeRef[NodeDb]) extends NodeDb(ref) with StoredNode
   def _methodRefViaCaptureIn: overflowdb.traversal.Traversal[MethodRef] = captureIn.collectAll[MethodRef]
   def _typeRefViaCaptureIn: overflowdb.traversal.Traversal[TypeRef]     = captureIn.collectAll[TypeRef]
 
-  def capturedByIn: Iterator[Local] = createAdjacentNodeScalaIteratorByOffSet[Local](2)
-  override def _capturedByIn        = createAdjacentNodeScalaIteratorByOffSet[StoredNode](2)
+  def capturedByIn: Iterator[AstNode] = createAdjacentNodeScalaIteratorByOffSet[AstNode](2)
+  override def _capturedByIn          = createAdjacentNodeScalaIteratorByOffSet[StoredNode](2)
   def _localViaCapturedByIn: overflowdb.traversal.Traversal[Local] = capturedByIn.collectAll[Local]
+  def _methodParameterInViaCapturedByIn: overflowdb.traversal.Traversal[MethodParameterIn] =
+    capturedByIn.collectAll[MethodParameterIn]
 
   override def label: String = {
     ClosureBinding.Label

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/MethodParameterIn.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/MethodParameterIn.scala
@@ -9,6 +9,7 @@ object MethodParameterIn {
   val Label = "METHOD_PARAMETER_IN"
 
   object PropertyNames {
+    val ClosureBindingId        = "CLOSURE_BINDING_ID"
     val Code                    = "CODE"
     val ColumnNumber            = "COLUMN_NUMBER"
     val DynamicTypeHintFullName = "DYNAMIC_TYPE_HINT_FULL_NAME"
@@ -21,6 +22,7 @@ object MethodParameterIn {
     val PossibleTypes           = "POSSIBLE_TYPES"
     val TypeFullName            = "TYPE_FULL_NAME"
     val all: Set[String] = Set(
+      ClosureBindingId,
       Code,
       ColumnNumber,
       DynamicTypeHintFullName,
@@ -37,6 +39,7 @@ object MethodParameterIn {
   }
 
   object Properties {
+    val ClosureBindingId        = new overflowdb.PropertyKey[String]("CLOSURE_BINDING_ID")
     val Code                    = new overflowdb.PropertyKey[String]("CODE")
     val ColumnNumber            = new overflowdb.PropertyKey[Integer]("COLUMN_NUMBER")
     val DynamicTypeHintFullName = new overflowdb.PropertyKey[IndexedSeq[String]]("DYNAMIC_TYPE_HINT_FULL_NAME")
@@ -66,6 +69,7 @@ object MethodParameterIn {
     PropertyNames.allAsJava,
     List(
       io.shiftleft.codepropertygraph.generated.edges.Ast.layoutInformation,
+      io.shiftleft.codepropertygraph.generated.edges.CapturedBy.layoutInformation,
       io.shiftleft.codepropertygraph.generated.edges.EvalType.layoutInformation,
       io.shiftleft.codepropertygraph.generated.edges.ParameterLink.layoutInformation,
       io.shiftleft.codepropertygraph.generated.edges.ReachingDef.layoutInformation,
@@ -80,7 +84,7 @@ object MethodParameterIn {
   )
 
   object Edges {
-    val Out: Array[String] = Array("AST", "EVAL_TYPE", "PARAMETER_LINK", "REACHING_DEF", "TAGGED_BY")
+    val Out: Array[String] = Array("AST", "CAPTURED_BY", "EVAL_TYPE", "PARAMETER_LINK", "REACHING_DEF", "TAGGED_BY")
     val In: Array[String]  = Array("AST", "CFG", "REACHING_DEF", "REF")
   }
 
@@ -97,6 +101,7 @@ object MethodParameterIn {
 trait MethodParameterInBase extends AbstractNode with AstNodeBase with CfgNodeBase with DeclarationBase {
   def asStored: StoredNode = this.asInstanceOf[StoredNode]
 
+  def closureBindingId: Option[String]
   def code: String
   def columnNumber: Option[Integer]
   def dynamicTypeHintFullName: IndexedSeq[String]
@@ -118,6 +123,7 @@ class MethodParameterIn(graph_4762: Graph, id_4762: Long /*cf https://github.com
     with AstNode
     with CfgNode
     with Declaration {
+  override def closureBindingId: Option[String]            = get().closureBindingId
   override def code: String                                = get().code
   override def columnNumber: Option[Integer]               = get().columnNumber
   override def dynamicTypeHintFullName: IndexedSeq[String] = get().dynamicTypeHintFullName
@@ -151,6 +157,14 @@ class MethodParameterIn(graph_4762: Graph, id_4762: Long /*cf https://github.com
   /** Traverse to UNKNOWN via AST OUT edge.
     */
   def _unknownViaAstOut: overflowdb.traversal.Traversal[Unknown] = get()._unknownViaAstOut
+
+  def capturedByOut: Iterator[ClosureBinding] = get().capturedByOut
+  override def _capturedByOut                 = get()._capturedByOut
+
+  /** Traverse to CLOSURE_BINDING via CAPTURED_BY OUT edge.
+    */
+  def _closureBindingViaCapturedByOut: overflowdb.traversal.Traversal[ClosureBinding] =
+    get()._closureBindingViaCapturedByOut
 
   def evalTypeOut: Iterator[Type] = get().evalTypeOut
   override def _evalTypeOut       = get()._evalTypeOut
@@ -260,37 +274,39 @@ class MethodParameterIn(graph_4762: Graph, id_4762: Long /*cf https://github.com
   override def productElementName(n: Int): String =
     n match {
       case 0  => "id"
-      case 1  => "code"
-      case 2  => "columnNumber"
-      case 3  => "dynamicTypeHintFullName"
-      case 4  => "evaluationStrategy"
-      case 5  => "index"
-      case 6  => "isVariadic"
-      case 7  => "lineNumber"
-      case 8  => "name"
-      case 9  => "order"
-      case 10 => "possibleTypes"
-      case 11 => "typeFullName"
+      case 1  => "closureBindingId"
+      case 2  => "code"
+      case 3  => "columnNumber"
+      case 4  => "dynamicTypeHintFullName"
+      case 5  => "evaluationStrategy"
+      case 6  => "index"
+      case 7  => "isVariadic"
+      case 8  => "lineNumber"
+      case 9  => "name"
+      case 10 => "order"
+      case 11 => "possibleTypes"
+      case 12 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
     n match {
       case 0  => id
-      case 1  => code
-      case 2  => columnNumber
-      case 3  => dynamicTypeHintFullName
-      case 4  => evaluationStrategy
-      case 5  => index
-      case 6  => isVariadic
-      case 7  => lineNumber
-      case 8  => name
-      case 9  => order
-      case 10 => possibleTypes
-      case 11 => typeFullName
+      case 1  => closureBindingId
+      case 2  => code
+      case 3  => columnNumber
+      case 4  => dynamicTypeHintFullName
+      case 5  => evaluationStrategy
+      case 6  => index
+      case 7  => isVariadic
+      case 8  => lineNumber
+      case 9  => name
+      case 10 => order
+      case 11 => possibleTypes
+      case 12 => typeFullName
     }
 
   override def productPrefix = "MethodParameterIn"
-  override def productArity  = 12
+  override def productArity  = 13
 }
 
 class MethodParameterInDb(ref: NodeRef[NodeDb])
@@ -303,6 +319,8 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
 
   override def layoutInformation: NodeLayoutInformation = MethodParameterIn.layoutInformation
 
+  private var _closureBindingId: String                    = null
+  def closureBindingId: Option[String]                     = Option(_closureBindingId)
   private var _code: String                                = MethodParameterIn.PropertyDefaults.Code
   def code: String                                         = _code
   private var _columnNumber: Integer                       = null
@@ -329,6 +347,7 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
   /** faster than the default implementation */
   override def propertiesMap: java.util.Map[String, Any] = {
     val properties = new java.util.HashMap[String, Any]
+    closureBindingId.map { value => properties.put("CLOSURE_BINDING_ID", value) }
     properties.put("CODE", code)
     columnNumber.map { value => properties.put("COLUMN_NUMBER", value) }
     if (this._dynamicTypeHintFullName != null && this._dynamicTypeHintFullName.nonEmpty) {
@@ -349,6 +368,7 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
   /** faster than the default implementation */
   override def propertiesMapForStorage: java.util.Map[String, Any] = {
     val properties = new java.util.HashMap[String, Any]
+    closureBindingId.map { value => properties.put("CLOSURE_BINDING_ID", value) }
     if (!(("<empty>") == code)) { properties.put("CODE", code) }
     columnNumber.map { value => properties.put("COLUMN_NUMBER", value) }
     if (this._dynamicTypeHintFullName != null && this._dynamicTypeHintFullName.nonEmpty) {
@@ -372,8 +392,13 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
   def _annotationViaAstOut: overflowdb.traversal.Traversal[Annotation] = astOut.collectAll[Annotation]
   def _unknownViaAstOut: overflowdb.traversal.Traversal[Unknown]       = astOut.collectAll[Unknown]
 
-  def evalTypeOut: Iterator[Type] = createAdjacentNodeScalaIteratorByOffSet[Type](1)
-  override def _evalTypeOut       = createAdjacentNodeScalaIteratorByOffSet[StoredNode](1)
+  def capturedByOut: Iterator[ClosureBinding] = createAdjacentNodeScalaIteratorByOffSet[ClosureBinding](1)
+  override def _capturedByOut                 = createAdjacentNodeScalaIteratorByOffSet[StoredNode](1)
+  def _closureBindingViaCapturedByOut: overflowdb.traversal.Traversal[ClosureBinding] =
+    capturedByOut.collectAll[ClosureBinding]
+
+  def evalTypeOut: Iterator[Type] = createAdjacentNodeScalaIteratorByOffSet[Type](2)
+  override def _evalTypeOut       = createAdjacentNodeScalaIteratorByOffSet[StoredNode](2)
   def typ: Type = try { evalTypeOut.collectAll[Type].next() }
   catch {
     case e: java.util.NoSuchElementException =>
@@ -383,12 +408,12 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
       )
   }
 
-  def parameterLinkOut: Iterator[MethodParameterOut] = createAdjacentNodeScalaIteratorByOffSet[MethodParameterOut](2)
-  override def _parameterLinkOut                     = createAdjacentNodeScalaIteratorByOffSet[StoredNode](2)
+  def parameterLinkOut: Iterator[MethodParameterOut] = createAdjacentNodeScalaIteratorByOffSet[MethodParameterOut](3)
+  override def _parameterLinkOut                     = createAdjacentNodeScalaIteratorByOffSet[StoredNode](3)
   def asOutput: overflowdb.traversal.Traversal[MethodParameterOut] = parameterLinkOut.collectAll[MethodParameterOut]
 
-  def reachingDefOut: Iterator[CfgNode] = createAdjacentNodeScalaIteratorByOffSet[CfgNode](3)
-  override def _reachingDefOut          = createAdjacentNodeScalaIteratorByOffSet[StoredNode](3)
+  def reachingDefOut: Iterator[CfgNode] = createAdjacentNodeScalaIteratorByOffSet[CfgNode](4)
+  override def _reachingDefOut          = createAdjacentNodeScalaIteratorByOffSet[StoredNode](4)
   def _callViaReachingDefOut: overflowdb.traversal.Traversal[Call]             = reachingDefOut.collectAll[Call]
   def _identifierViaReachingDefOut: overflowdb.traversal.Traversal[Identifier] = reachingDefOut.collectAll[Identifier]
   def _literalViaReachingDefOut: overflowdb.traversal.Traversal[Literal]       = reachingDefOut.collectAll[Literal]
@@ -398,12 +423,12 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
   def _returnViaReachingDefOut: overflowdb.traversal.Traversal[Return]       = reachingDefOut.collectAll[Return]
   def _typeRefViaReachingDefOut: overflowdb.traversal.Traversal[TypeRef]     = reachingDefOut.collectAll[TypeRef]
 
-  def taggedByOut: Iterator[Tag]                              = createAdjacentNodeScalaIteratorByOffSet[Tag](4)
-  override def _taggedByOut                                   = createAdjacentNodeScalaIteratorByOffSet[StoredNode](4)
+  def taggedByOut: Iterator[Tag]                              = createAdjacentNodeScalaIteratorByOffSet[Tag](5)
+  override def _taggedByOut                                   = createAdjacentNodeScalaIteratorByOffSet[StoredNode](5)
   def _tagViaTaggedByOut: overflowdb.traversal.Traversal[Tag] = taggedByOut.collectAll[Tag]
 
-  def astIn: Iterator[Method] = createAdjacentNodeScalaIteratorByOffSet[Method](5)
-  override def _astIn         = createAdjacentNodeScalaIteratorByOffSet[StoredNode](5)
+  def astIn: Iterator[Method] = createAdjacentNodeScalaIteratorByOffSet[Method](6)
+  override def _astIn         = createAdjacentNodeScalaIteratorByOffSet[StoredNode](6)
   def method: Method = try { astIn.collectAll[Method].next() }
   catch {
     case e: java.util.NoSuchElementException =>
@@ -413,15 +438,15 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
       )
   }
 
-  def cfgIn: Iterator[CfgNode] = createAdjacentNodeScalaIteratorByOffSet[CfgNode](6)
-  override def _cfgIn          = createAdjacentNodeScalaIteratorByOffSet[StoredNode](6)
+  def cfgIn: Iterator[CfgNode] = createAdjacentNodeScalaIteratorByOffSet[CfgNode](7)
+  override def _cfgIn          = createAdjacentNodeScalaIteratorByOffSet[StoredNode](7)
 
-  def reachingDefIn: Iterator[Method] = createAdjacentNodeScalaIteratorByOffSet[Method](7)
-  override def _reachingDefIn         = createAdjacentNodeScalaIteratorByOffSet[StoredNode](7)
+  def reachingDefIn: Iterator[Method] = createAdjacentNodeScalaIteratorByOffSet[Method](8)
+  override def _reachingDefIn         = createAdjacentNodeScalaIteratorByOffSet[StoredNode](8)
   def _methodViaReachingDefIn: overflowdb.traversal.Traversal[Method] = reachingDefIn.collectAll[Method]
 
-  def refIn: Iterator[StoredNode] = createAdjacentNodeScalaIteratorByOffSet[StoredNode](8)
-  override def _refIn             = createAdjacentNodeScalaIteratorByOffSet[StoredNode](8)
+  def refIn: Iterator[StoredNode] = createAdjacentNodeScalaIteratorByOffSet[StoredNode](9)
+  override def _refIn             = createAdjacentNodeScalaIteratorByOffSet[StoredNode](9)
   def _closureBindingViaRefIn: overflowdb.traversal.Traversal[ClosureBinding] = refIn.collectAll[ClosureBinding]
   def referencingIdentifiers: overflowdb.traversal.Traversal[Identifier]      = refIn.collectAll[Identifier]
 
@@ -432,42 +457,45 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
   override def productElementName(n: Int): String =
     n match {
       case 0  => "id"
-      case 1  => "code"
-      case 2  => "columnNumber"
-      case 3  => "dynamicTypeHintFullName"
-      case 4  => "evaluationStrategy"
-      case 5  => "index"
-      case 6  => "isVariadic"
-      case 7  => "lineNumber"
-      case 8  => "name"
-      case 9  => "order"
-      case 10 => "possibleTypes"
-      case 11 => "typeFullName"
+      case 1  => "closureBindingId"
+      case 2  => "code"
+      case 3  => "columnNumber"
+      case 4  => "dynamicTypeHintFullName"
+      case 5  => "evaluationStrategy"
+      case 6  => "index"
+      case 7  => "isVariadic"
+      case 8  => "lineNumber"
+      case 9  => "name"
+      case 10 => "order"
+      case 11 => "possibleTypes"
+      case 12 => "typeFullName"
     }
 
   override def productElement(n: Int): Any =
     n match {
       case 0  => id
-      case 1  => code
-      case 2  => columnNumber
-      case 3  => dynamicTypeHintFullName
-      case 4  => evaluationStrategy
-      case 5  => index
-      case 6  => isVariadic
-      case 7  => lineNumber
-      case 8  => name
-      case 9  => order
-      case 10 => possibleTypes
-      case 11 => typeFullName
+      case 1  => closureBindingId
+      case 2  => code
+      case 3  => columnNumber
+      case 4  => dynamicTypeHintFullName
+      case 5  => evaluationStrategy
+      case 6  => index
+      case 7  => isVariadic
+      case 8  => lineNumber
+      case 9  => name
+      case 10 => order
+      case 11 => possibleTypes
+      case 12 => typeFullName
     }
 
   override def productPrefix = "MethodParameterIn"
-  override def productArity  = 12
+  override def productArity  = 13
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[MethodParameterInDb]
 
   override def property(key: String): Any = {
     key match {
+      case "CLOSURE_BINDING_ID"          => this._closureBindingId
       case "CODE"                        => this._code
       case "COLUMN_NUMBER"               => this._columnNumber
       case "DYNAMIC_TYPE_HINT_FULL_NAME" => this._dynamicTypeHintFullName
@@ -486,8 +514,9 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
 
   override protected def updateSpecificProperty(key: String, value: Object): Unit = {
     key match {
-      case "CODE"          => this._code = value.asInstanceOf[String]
-      case "COLUMN_NUMBER" => this._columnNumber = value.asInstanceOf[Integer]
+      case "CLOSURE_BINDING_ID" => this._closureBindingId = value.asInstanceOf[String]
+      case "CODE"               => this._code = value.asInstanceOf[String]
+      case "COLUMN_NUMBER"      => this._columnNumber = value.asInstanceOf[Integer]
       case "DYNAMIC_TYPE_HINT_FULL_NAME" =>
         this._dynamicTypeHintFullName = value match {
           case null                                             => collection.immutable.ArraySeq.empty
@@ -546,6 +575,7 @@ class MethodParameterInDb(ref: NodeRef[NodeDb])
     fromNewNode(data.asInstanceOf[NewNode], nn => mapper.apply(nn).asInstanceOf[StoredNode])
 
   override def fromNewNode(newNode: NewNode, mapping: NewNode => StoredNode): Unit = {
+    this._closureBindingId = newNode.asInstanceOf[NewMethodParameterIn].closureBindingId.orNull
     this._code = newNode.asInstanceOf[NewMethodParameterIn].code
     this._columnNumber = newNode.asInstanceOf[NewMethodParameterIn].columnNumber.orNull
     this._dynamicTypeHintFullName =

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/NewNodes.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/nodes/NewNodes.scala
@@ -9602,7 +9602,7 @@ object NewClosureBinding {
 
   private val outNeighbors: Map[String, Set[String]] = Map("REF" -> Set("LOCAL", "METHOD_PARAMETER_IN"))
   private val inNeighbors: Map[String, Set[String]] =
-    Map("CAPTURE" -> Set("METHOD_REF", "TYPE_REF"), "CAPTURED_BY" -> Set("LOCAL"))
+    Map("CAPTURE" -> Set("METHOD_REF", "TYPE_REF"), "CAPTURED_BY" -> Set("LOCAL", "METHOD_PARAMETER_IN"))
 
 }
 
@@ -27940,11 +27940,13 @@ class NewMethodParameterIn
   var dynamicTypeHintFullName: IndexedSeq[String] = collection.immutable.ArraySeq.empty
   var columnNumber: Option[Integer]               = None
   var code: String                                = "<empty>"
+  var closureBindingId: Option[String]            = None
 
   override def label: String = "METHOD_PARAMETER_IN"
 
   override def copy: this.type = {
     val newInstance = new NewMethodParameterIn
+    newInstance.closureBindingId = this.closureBindingId
     newInstance.code = this.code
     newInstance.columnNumber = this.columnNumber
     newInstance.dynamicTypeHintFullName = this.dynamicTypeHintFullName
@@ -27958,6 +27960,13 @@ class NewMethodParameterIn
     newInstance.typeFullName = this.typeFullName
     newInstance.asInstanceOf[this.type]
   }
+
+  def closureBindingId(value: String): this.type = {
+    this.closureBindingId = Option(value)
+    this
+  }
+
+  def closureBindingId(value: Option[String]): this.type = closureBindingId(value.orNull)
 
   def code(value: String): this.type = {
     this.code = value
@@ -28020,6 +28029,7 @@ class NewMethodParameterIn
 
   override def properties: Map[String, Any] = {
     var res = Map[String, Any]()
+    closureBindingId.map { value => res += "CLOSURE_BINDING_ID" -> value }
     if (!(("<empty>") == code)) { res += "CODE" -> code }
     columnNumber.map { value => res += "COLUMN_NUMBER" -> value }
     if (dynamicTypeHintFullName != null && dynamicTypeHintFullName.nonEmpty) {
@@ -28057,6 +28067,7 @@ class NewMethodParameterIn
       case 8  => this.dynamicTypeHintFullName
       case 9  => this.columnNumber
       case 10 => this.code
+      case 11 => this.closureBindingId
       case _  => null
     }
 
@@ -28073,11 +28084,12 @@ class NewMethodParameterIn
       case 8  => "dynamicTypeHintFullName"
       case 9  => "columnNumber"
       case 10 => "code"
+      case 11 => "closureBindingId"
       case _  => ""
     }
 
   override def productPrefix = "NewMethodParameterIn"
-  override def productArity  = 11
+  override def productArity  = 12
 
   override def canEqual(that: Any): Boolean = that != null && that.isInstanceOf[NewMethodParameterIn]
 }

--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/MethodParameterIn.scala
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/traversal/MethodParameterIn.scala
@@ -35,6 +35,61 @@ class MethodParameterInTraversalExtGen[NodeType <: MethodParameterIn](val traver
   def typ: Iterator[Type] =
     traversal.map(_.typ)
 
+  /** Traverse to closureBindingId property */
+  def closureBindingId: Iterator[String] =
+    traversal.flatMap(_.closureBindingId)
+
+  /** Traverse to nodes where the closureBindingId matches the regular expression `value`
+    */
+  def closureBindingId(pattern: String): Iterator[NodeType] = {
+    if (!Misc.isRegex(pattern)) {
+      traversal.filter { node => node.closureBindingId.isDefined && node.closureBindingId.get == pattern }
+    } else {
+      overflowdb.traversal.filter.StringPropertyFilter
+        .regexp(traversal.filter(_.closureBindingId.isDefined))(_.closureBindingId.get, pattern)
+    }
+  }
+
+  /** Traverse to nodes where the closureBindingId matches at least one of the regular expressions in `values`
+    */
+  def closureBindingId(patterns: String*): Iterator[NodeType] = {
+    overflowdb.traversal.filter.StringPropertyFilter
+      .regexpMultiple(traversal.filter(_.closureBindingId.isDefined))(_.closureBindingId.get, patterns)
+  }
+
+  /** Traverse to nodes where closureBindingId matches `value` exactly.
+    */
+  def closureBindingIdExact(value: String): Iterator[NodeType] =
+    traversal.filter { node => node.closureBindingId.contains(value) }
+
+  /** Traverse to nodes where closureBindingId matches one of the elements in `values` exactly.
+    */
+  def closureBindingIdExact(values: String*): Iterator[NodeType] = {
+    if (values.size == 1)
+      closureBindingIdExact(values.head)
+    else
+      overflowdb.traversal.filter.StringPropertyFilter
+        .exactMultiple[NodeType, String](traversal, _.closureBindingId, values, "CLOSURE_BINDING_ID")
+  }
+
+  /** Traverse to nodes where closureBindingId does not match the regular expression `value`.
+    */
+  def closureBindingIdNot(pattern: String): Iterator[NodeType] = {
+    if (!Misc.isRegex(pattern)) {
+      traversal.filter { node => node.closureBindingId.isEmpty || node.closureBindingId.get != pattern }
+    } else {
+      overflowdb.traversal.filter.StringPropertyFilter
+        .regexpNot(traversal.filter(_.closureBindingId.isDefined))(_.closureBindingId.get, pattern)
+    }
+  }
+
+  /** Traverse to nodes where closureBindingId does not match any of the regular expressions in `values`.
+    */
+  def closureBindingIdNot(patterns: String*): Iterator[NodeType] = {
+    overflowdb.traversal.filter.StringPropertyFilter
+      .regexpNotMultiple(traversal.filter(_.closureBindingId.isDefined))(_.closureBindingId.get, patterns)
+  }
+
   /** Traverse to code property */
   def code: Iterator[String] =
     traversal.map(_.code)

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -81,6 +81,7 @@ object Hidden extends SchemaBase {
 
     // node types
     local.addProperties(closureBindingId)
+    methodParameterIn.addProperties(closureBindingId)
 
     val closureBinding: NodeType = builder
       .addNodeType(
@@ -99,6 +100,7 @@ object Hidden extends SchemaBase {
 
     // node relations
     local.addOutEdge(edge = capturedBy, inNode = closureBinding)
+    methodParameterIn.addOutEdge(edge = capturedBy, inNode = closureBinding)
 
     methodRef.addOutEdge(edge = capture, inNode = closureBinding)
 

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -107,8 +107,8 @@ object Hidden extends SchemaBase {
     typeRef.addOutEdge(edge = capture, inNode = closureBinding)
 
     closureBinding
-      .addOutEdge(edge = ref, inNode = local, cardinalityOut = EdgeType.Cardinality.One)
-      .addOutEdge(edge = ref, inNode = methodParameterIn)
+      .addOutEdge(edge = ref, inNode = local, cardinalityOut = EdgeType.Cardinality.ZeroOrOne)
+      .addOutEdge(edge = ref, inNode = methodParameterIn, cardinalityOut = EdgeType.Cardinality.ZeroOrOne)
 
     /* TemplateDOM
      */


### PR DESCRIPTION
The description for `CLOSURE_BINDING` is: "Represents the binding of a LOCAL or METHOD_PARAMETER_IN into the closure of a method", however there is no edge connecting parameters to the `CLOSURE_BINDING`. So this adds the `CLOSURE_BINDING_ID` and `CAPTURED_BY` edge to match the specification for `LOCAL` nodes.

Additionally, the cardinality needs to be changed, since if a method parameter is captured, then there won't be a REF to a local which may throw an error. Thus, cardinality was changed to `ZeroOrOne`.