### PR TITLE
Performance matrix logger

### DIFF
--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -67,7 +67,7 @@ abstract class ForkJoinParallelCpgPass[T <: AnyRef](
     prefix: String = ""
   ): Unit = {
     baseLogger.info(s"Start of pass: $name")
-    TimeMetric.initiateNewStage(getClass.getSimpleName, Some(name), "ForkJoinParallelCpgPass")
+    TimeMetric.initiateNewStage(getClass.getSimpleName, Some(name), getClass.getSuperclass.getSimpleName)
     val nanosStart = System.nanoTime()
     var nParts     = 0
     var nanosBuilt = -1L

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -3,6 +3,7 @@ package io.shiftleft.passes
 import com.google.protobuf.GeneratedMessageV3
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.utils.TimeMetric
 import org.slf4j.{Logger, LoggerFactory, MDC}
 import overflowdb.BatchedUpdate
 
@@ -66,6 +67,7 @@ abstract class ForkJoinParallelCpgPass[T <: AnyRef](
     prefix: String = ""
   ): Unit = {
     baseLogger.info(s"Start of pass: $name")
+    TimeMetric.initiateNewStage(name, "ForkJoinParallelCpgPass")
     val nanosStart = System.nanoTime()
     var nParts     = 0
     var nanosBuilt = -1L
@@ -99,6 +101,7 @@ abstract class ForkJoinParallelCpgPass[T <: AnyRef](
         baseLogger.info(
           f"Pass $name completed in ${(nanosStop - nanosStart) * 1e-6}%.0f ms (${fracRun}%.0f%% on mutations). ${nDiff}%d + ${nDiffT - nDiff}%d changes committed from ${nParts}%d parts.${serializationString}%s"
         )
+        TimeMetric.endLastStage()
       }
     }
   }

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -67,7 +67,7 @@ abstract class ForkJoinParallelCpgPass[T <: AnyRef](
     prefix: String = ""
   ): Unit = {
     baseLogger.info(s"Start of pass: $name")
-    TimeMetric.initiateNewStage(name, "ForkJoinParallelCpgPass")
+    TimeMetric.initiateNewStage(getClass.getSimpleName, Some(name), "ForkJoinParallelCpgPass")
     val nanosStart = System.nanoTime()
     var nParts     = 0
     var nanosBuilt = -1L

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -58,7 +58,7 @@ abstract class ConcurrentWriterCpgPass[T <: AnyRef](
   ): Unit = {
     import ConcurrentWriterCpgPass.producerQueueCapacity
     baseLogger.info(s"Start of enhancement: $name")
-    TimeMetric.initiateNewStage(getClass.getSimpleName, Some(name), "ConcurrentWriterCpgPass")
+    TimeMetric.initiateNewStage(getClass.getSimpleName, Some(name), getClass.getSuperclass.getSimpleName)
     val nanosStart = System.nanoTime()
     var nParts     = 0
     var nDiff      = 0

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -58,7 +58,7 @@ abstract class ConcurrentWriterCpgPass[T <: AnyRef](
   ): Unit = {
     import ConcurrentWriterCpgPass.producerQueueCapacity
     baseLogger.info(s"Start of enhancement: $name")
-    TimeMetric.initiateNewStage(name, "ConcurrentWriterCpgPass")
+    TimeMetric.initiateNewStage(getClass.getSimpleName, Some(name), "ConcurrentWriterCpgPass")
     val nanosStart = System.nanoTime()
     var nParts     = 0
     var nDiff      = 0

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/ParallelCpgPass.scala
@@ -1,7 +1,7 @@
 package io.shiftleft.passes
 import io.shiftleft.SerializedCpg
 import io.shiftleft.codepropertygraph.Cpg
-import io.shiftleft.utils.ExecutionContextProvider
+import io.shiftleft.utils.{ExecutionContextProvider, TimeMetric}
 import org.slf4j.MDC
 
 import java.util.concurrent.LinkedBlockingQueue
@@ -58,6 +58,7 @@ abstract class ConcurrentWriterCpgPass[T <: AnyRef](
   ): Unit = {
     import ConcurrentWriterCpgPass.producerQueueCapacity
     baseLogger.info(s"Start of enhancement: $name")
+    TimeMetric.initiateNewStage(name, "ConcurrentWriterCpgPass")
     val nanosStart = System.nanoTime()
     var nParts     = 0
     var nDiff      = 0
@@ -124,6 +125,7 @@ abstract class ConcurrentWriterCpgPass[T <: AnyRef](
       baseLogger.info(
         f"Enhancement $name completed in ${(nanosStop - nanosStart) * 1e-6}%.0f ms. ${nDiff}%d  + ${nDiffT - nDiff}%d changes committed from ${nParts}%d parts."
       )
+      TimeMetric.endLastStage()
     }
   }
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -463,7 +463,7 @@ object TimeMetric {
     * @return
     *   \- Formatted double value in string.
     */
-  private def doubleFormatter(value: Double): String = s"${String.format("%.2f", value)}"
+  private def doubleFormatter(value: Double): String = s"${"%.2f".formatLocal(java.util.Locale.US, value)}"
 
   /** Get current time by initialising internal latest data time tracker.
     * @return

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -9,34 +9,108 @@ import java.util
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.{Calendar, Date}
 import scala.collection.mutable
+
+/** Stage wise Time, cpu, and memory recording config to pass file path and the recording frequency
+  *
+  * @param resultFile
+  *   \- complete file path where the recording will be saved in csv format.
+  * @param recordFreq
+  *   \- Frequency to write the records in milliseconds.
+  */
 case class TimeMetricRecordConfig(resultFile: String = "cpuandmemoryusage.csv", recordFreq: Int = 60000)
+
+/** These buffers are used for console logs to set the output fix length of the column. This will help make the console
+  * output more readable. This has been kept configurable so that end consumer can adjust according to their use case.
+  * @param MAX_FULLNAME_BUFFER
+  *   \- If the class full names of passes is used to print the stage name on the console. Then this buffer is used
+  *   considering the length the full name of the class
+  * @param MAX_NAME_BUFFER
+  *   \- In case the only simple name of the class is used to print the stage name on the console. Then this buffer is
+  *   used considering the length of the only name of the class.
+  * @param MAX_DONE_TIME_BUFFER
+  *   \- When done status of the stage is updated, it also adds the total time taken by the time and then prints the cpu
+  *   and memory stats afte that. This buffer will make `stats` information to be printed in the same colum for
+  *   `invoked` status line to make it more readable.
+  */
 case class MaxPrintBuffers(MAX_FULLNAME_BUFFER: Int = 90, MAX_NAME_BUFFER: Int = 55, MAX_DONE_TIME_BUFFER: Int = 40)
+
+/** Cpu and Memory stats information to log
+  * @param usedOrAvgMemory
+  *   \- current or average used memory in MB
+  * @param maxHeap
+  *   \- current Max Heap size in MB
+  * @param usedOrAvgCpu
+  *   \- current or average cpu used in %
+  * @param maxStats
+  *   \- Option with tuple having max CPU and Memory consumption.
+  */
+case class CpuMemoryStats(
+  usedOrAvgMemory: Double,
+  maxHeap: Double,
+  usedOrAvgCpu: Double,
+  maxStats: Option[(Double, Double)]
+)
+
 object TimeMetric {
+
   val cal = Calendar.getInstance()
-  // Stage wise performance will be only recorded if parallel recording is started through initialize()
+
+  /** Stage wise performance will be only recorded if parallel recording is started through initialize(). This is
+    * accessible outside of this class, in case this information is required to be consumed outside of this class.
+    */
   val stagePerformance: mutable.Map[String, NumberProcessor] = mutable.Map()
-  private val start                                          = cal.getTime
-  private var subStageStartTime                              = start
-  private var newTime                                        = start
-  private var stageStartTime                                 = start
-  private val ACROSS_PROCESS_STAGE                           = "<ACROSS_ALL>"
-  private val STAGE_NOT_SET                                  = "<not set>"
-  private val STARTED                                        = "Started"
-  private val DONE                                           = "Done"
-  private var lastStageName                                  = STAGE_NOT_SET
-  private var lastSubStageName                               = STAGE_NOT_SET
-  private var additionalMetaData                             = STAGE_NOT_SET
-  private var alsoLogConsole                                 = false
+  // This will hold start time when the process is initialised.
+  private val start = cal.getTime
+  // parent stage start time.
+  private var stageStartTime = start
+  // sub stage start time.
+  private var subStageStartTime = start
+  // latest time when updates.
+  private var newTime = start
+  // This constant is used to hold the `cpu` and `memory` numbers across the stages.
+  private val ACROSS_PROCESS_STAGE = "<ACROSS_ALL>"
+  // Constant used when stage or subStage is not set.
+  private val STAGE_NOT_SET = "<not set>"
+  // Constant used to indicate `Started` status while recording the stats inside .csv file.
+  private val STARTED = "Started"
+  // Constant used to indicate `Done` status while recording the stats inside .csv file.
+  private val DONE = "Done"
+  // This will hold the ongoing stage name
+  private var lastStageName = STAGE_NOT_SET
+  // This will hold the ongoing sub stage name
+  private var lastSubStageName = STAGE_NOT_SET
+  // This will hold the metadata for ongoing stage and sub stage combination.
+  private var additionalMetaData = STAGE_NOT_SET
+  // Flag to indicate the `invoked` and `done` status logs for every stage on console as well.
+  private var printToConsole = false
+
+  /** Stage `invoked` and `done` status's can be logged to both console logger file. By default it will always log to
+    * logger file, printing the logs to console can be controlled using flag {@link TimeMetric#printToConsole}
+    */
   private val logger: (String, Boolean) => Unit = (msg, subStage) => {
-    if (alsoLogConsole && (!subStage || !supressSubstages))
+    if (printToConsole && (!subStage || !supressSubstages))
       println(msg)
     baseLogger.debug(msg)
   }
-  private val baseLogger: Logger             = LoggerFactory.getLogger(getClass)
+  private val baseLogger: Logger = LoggerFactory.getLogger(getClass)
+
+  /** This recorder is the writer thread to write the stats to .csv file. This is not initialised by default, to make it
+    * configurable and can be controlled from where it is getting used.
+    */
   private var recorder: Option[TimeRecorder] = None
-  private var fullName: Boolean              = false
-  private var maxBuffers: MaxPrintBuffers    = MaxPrintBuffers()
-  private var supressSubstages: Boolean      = true
+  // Flag which indicates whether to use full name or simple name of the pass while logging.
+  private var fullName: Boolean = false
+  // it holds buffer configuration.
+  private var maxBuffers: MaxPrintBuffers = MaxPrintBuffers()
+
+  /** This is to supress the sub stages stats being printed on console or not. This flag helps to print the stats only
+    * for the passes being used in application.
+    */
+  private var supressSubstages: Boolean = true
+
+  /** Calculate the buffer when it is being used. This is to avoid calculation again and again. Done lazy initialization
+    * as the buffer configuration can be done by calling {@link TimeMetric#initialize()}
+    */
   private lazy val maxStartingBuffer = {
     if (fullName) {
       maxBuffers.MAX_FULLNAME_BUFFER + maxBuffers.MAX_DONE_TIME_BUFFER
@@ -44,6 +118,10 @@ object TimeMetric {
       maxBuffers.MAX_NAME_BUFFER + maxBuffers.MAX_DONE_TIME_BUFFER
     }
   }
+
+  /** Calculate the buffer when it is being used. This is to avoid calculation again and again. Done lazy initialization
+    * as the buffer configuration can be done by calling {@link TimeMetric# initialize ( )}
+    */
   private lazy val maxEndingBuffer = {
     if (fullName) {
       maxBuffers.MAX_FULLNAME_BUFFER
@@ -53,6 +131,22 @@ object TimeMetric {
   }
   private val osBean = ManagementFactory.getOperatingSystemMXBean().asInstanceOf[OperatingSystemMXBean]
 
+  /** initialize method is expected to be invoked at the very start of the code. One can initialise the required flags
+    * and the other configurations to start the stats collections.
+    *
+    * @param useFullName
+    *   \- Flag to indicate whether to use fullName or simple name of the stage for logging
+    * @param consoleLog
+    *   \- Flag to indicate log the `invoked` and `done` status of every stage on console as well along with debug logs.
+    * @param timeMetricRecordConfig
+    *   \- If you set this to None, it will not start the thread to log the `cpu` and `memory` consumption stats for
+    *   each stage after regular interval of time to given file path. Configure the expected config values and it will
+    *   trigger the thread to write the stats after configured period of time. Refer {@link TimeMetricRecordConfig}
+    * @param maxPrintBuffers
+    *   \- Print buffer configuration refer {@link MaxPrintBuffers}
+    * @param supressSubStagesConsoleLog
+    *   \- Flag to suppress the sub stage logs to consoles and only log them to debug logs.
+    */
   def initialize(
     useFullName: Boolean = false,
     consoleLog: Boolean = false,
@@ -63,7 +157,7 @@ object TimeMetric {
     fullName = useFullName
     maxBuffers = maxPrintBuffers
     supressSubstages = supressSubStagesConsoleLog
-    alsoLogConsole = consoleLog
+    printToConsole = consoleLog
     timeMetricRecordConfig match {
       case Some(config) =>
         stagePerformance += (ACROSS_PROCESS_STAGE -> NumberProcessor())
@@ -73,14 +167,31 @@ object TimeMetric {
     }
   }
 
+  /** This will help change the flag once it has been set initially using {@link TimeMetric#initialize()} method.
+    * @param flag
+    *   \- flag to suppress console log for sub stages.
+    */
   def setSupressSubstagesFlag(flag: Boolean): Unit = supressSubstages = flag
 
+  /** Writer thread to write the on going stage stats (CPU and Memory) after configured period of time in milliseconds.
+    * @param timeMetricRecordConfig
+    *   \- required configuration to log the stats into CSV file refer - {@link TimeMetricRecordConfig}
+    */
   private class TimeRecorder(timeMetricRecordConfig: TimeMetricRecordConfig) extends Thread {
-
+    // Non blocking Queue to log the stage `Started` and `Done` status, pushed from the respective methods who facilitate start and end of the stage.
     val queue: util.Queue[String] = new ConcurrentLinkedQueue[String]()
 
+    /** Method to push the event to non blocking queue
+      * @param event
+      *   \- stage `Started` and `Done` status event
+      */
     def pushEvent(event: String): Unit = queue.offer(event)
 
+    /** Thread run method which goes into loop to log the ongoing stage stats (CPU and Memory) to CSV file after regular
+      * interval of time (configured in milliseconds). When it wakes up from the configured sleep time, it will first
+      * check if there are any events pushed to queue for logging them to csv file and log all of them in one go and
+      * then log the stats of ongoing stage.
+      */
     override def run(): Unit = {
       val writer = new PrintWriter(timeMetricRecordConfig.resultFile)
       try {
@@ -88,13 +199,15 @@ object TimeMetric {
         while (true) {
           // This while loop will take care of writing all the accumulated events in the queue first.
           while (!queue.isEmpty) writer.println(queue.poll)
-          val (usedMemory, maxHeap, cpuUsed, _) = getCurrentCpuMemoryStats()
-          stagePerformance(ACROSS_PROCESS_STAGE).process(cpuUsed, usedMemory)
-          if (lastStageName != STAGE_NOT_SET) then stagePerformance (s"+ $lastStageName").process(cpuUsed, usedMemory)
+          val stats = getCurrentCpuMemoryStats()
+          stagePerformance(ACROSS_PROCESS_STAGE).record(stats.usedOrAvgCpu, stats.usedOrAvgMemory)
+          if (lastStageName != STAGE_NOT_SET)
+            then stagePerformance (s"+ $lastStageName").record(stats.usedOrAvgCpu, stats.usedOrAvgMemory)
           if (lastSubStageName != STAGE_NOT_SET)
-            then stagePerformance (s"-- $lastSubStageName").process(cpuUsed, usedMemory)
-          writer.println(s"${getNewTime()}, $lastStageName, $lastSubStageName, $additionalMetaData, ${String
-              .format("%.2f", cpuUsed)}, ${String.format("%.2f", usedMemory)}, ${String.format("%.2f", maxHeap)}")
+            then stagePerformance (s"-- $lastSubStageName").record(stats.usedOrAvgCpu, stats.usedOrAvgMemory)
+          writer.println(
+            s"${getNewTime()}, $lastStageName, $lastSubStageName, $additionalMetaData, ${getCpuAndMemoryStatsForCSVInString(stats)}"
+          )
           Thread.sleep(timeMetricRecordConfig.recordFreq)
         }
       } catch {
@@ -106,6 +219,15 @@ object TimeMetric {
     }
   }
 
+  /** API to signal start of the stage. This same method is used to initiate parent stage as well as sub stage. If this
+    * method is called after parent stage is initiated, it will initiate child stage internally.
+    * @param stageName
+    *   \- stage name in case it is class name, this should be passed as class.simpleName
+    * @param stageFullName
+    *   \- class full name to use as stage when {@link TimeMetric#fullName} flag is set.
+    * @param additionalMetaDataToLog
+    *   \- Any additional meta data string in the context of ongoing stage and subStage.
+    */
   def initiateNewStage(
     stageName: String,
     stageFullName: Option[String] = None,
@@ -116,22 +238,19 @@ object TimeMetric {
       case _                             => stageName
     }
     if (lastStageName == STAGE_NOT_SET) {
-      val (usedMemory, maxHeap, cpuUsed, _) = getCurrentCpuMemoryStats()
-      pushToRecorder(
-        s"${getNewTime()}, $usedStageName, $STAGE_NOT_SET",
-        s"+ $usedStageName",
+      val newTime = getNewTime()
+      val logLine = pushToRecorderAndGetFormattedStringForLogger(
+        s"$newTime",
+        usedStageName,
+        STAGE_NOT_SET,
         STARTED,
-        usedMemory,
-        maxHeap,
-        cpuUsed
+        STARTED,
+        Some(s"+ $usedStageName"),
+        None,
+        s"- $usedStageName is invoked"
       )
-      val formattedString =
-        s"%-${maxStartingBuffer}s%s"
-          .format(
-            s"- $usedStageName is invoked",
-            s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap)}"
-          )
-      logger(s"${getNewTime()} $formattedString", false)
+      logger(logLine, false)
+      stageStartTime = newTime
       lastStageName = usedStageName
       additionalMetaData = additionalMetaDataToLog
     } else {
@@ -139,25 +258,22 @@ object TimeMetric {
     }
   }
 
+  /** API to end the last stage. The same API to be used to end the last subStage and then call the same method to end
+    * the last parent stage once all the child stages are done.
+    */
   def endLastStage(): Unit = {
     if (lastSubStageName == STAGE_NOT_SET) {
-      val (usedMemory, maxHeap, cpuUsed, maxStats) = getCurrentCpuMemoryStats(Some(s"+ $lastStageName"))
-      pushToRecorder(
-        s"${getNewTime()}, $lastStageName, $STAGE_NOT_SET",
+      val logMessage = pushToRecorderAndGetFormattedStringForLogger(
+        s"${getNewTime()}",
         lastStageName,
+        STAGE_NOT_SET,
         DONE,
-        usedMemory,
-        maxHeap,
-        cpuUsed
+        DONE,
+        Some(s"+ $lastStageName"),
+        Some(getLastStageTimeTaken()),
+        s"- $lastStageName is done ..."
       )
-      val formattedString = s"%-${maxEndingBuffer}s%s".format(
-        s"- $lastStageName is done ...",
-        s"%-${maxBuffers.MAX_DONE_TIME_BUFFER}s%s".format(
-          s"- ${setNewTimeToStageLastAndGetTimeDiff()}",
-          s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap, maxStats)}"
-        )
-      )
-      logger(s"${getNewTime()} $formattedString", false)
+      logger(logMessage, false)
       lastStageName = STAGE_NOT_SET
       additionalMetaData = STAGE_NOT_SET
     } else {
@@ -165,147 +281,232 @@ object TimeMetric {
     }
   }
 
+  /** This will end the time logging along with stats. It you have started the cpu and memory stats logging with {@link
+    * TimeMetric#initialize()}, you need to make sure to call this method once all the processing is done. This will
+    * also end the writer deamon thread which has been started to log the stats in CSV file.
+    * @param message
+    *   \- final log message to end the logging.
+    */
   def endTheTotalProcessing(message: String): Unit = {
-    val (usedMemory, maxHeap, cpuUsed, maxStats) = getCurrentCpuMemoryStats(Some(ACROSS_PROCESS_STAGE))
-    val formattedString = s"%-${maxEndingBuffer}s%s".format(
-      s"- $message",
-      s"%-${maxBuffers.MAX_DONE_TIME_BUFFER}s%s".format(
-        s"- ${getTheTotalTime()}",
-        s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap, maxStats)}"
-      )
+    val logMessage = pushToRecorderAndGetFormattedStringForLogger(
+      s"${getNewTime()}",
+      message,
+      "Total Time taken",
+      DONE,
+      s"${getTheTotalTime()}",
+      Some(ACROSS_PROCESS_STAGE),
+      Some(getTheTotalTime()),
+      s"- $message"
     )
-    logger(s"${getNewTime()} $formattedString", false)
+    logger(logMessage, false)
     recorder match {
       case Some(rec) =>
-        rec.pushEvent(
-          s"${getNewTime()}, $message, Total Time taken, ${getTheTotalTime()}, ${String
-              .format("%.2f", osBean.getProcessCpuLoad * 100)}, ${String.format("%.2f", usedMemory)}, ${String.format("%.2f", maxHeap)}"
-        )
-        Thread.sleep(100)
+        // this small delay to make sure writer thread logs the last record before it gets exited with rec.interrupt() invocation.
+        Thread.sleep(200)
         rec.interrupt()
       case _ =>
     }
   }
 
-  private def pushToRecorder(
-    event: String,
-    stage: String,
+  /** Common utility method to push the `Started` and `Done` events as well as create debug or console log message
+    * string with the required formatting.
+    * @param time
+    *   \- current time
+    * @param parentStage
+    *   \- main stage
+    * @param subStage
+    *   \- Sub stage
+    * @param status
+    *   \- Status `Started` or `Done`
+    * @param metaData
+    *   \- value to be inserted in meta data column
+    * @param avgAndMaxStatsLookUpKey
+    *   \- avg and max stats look up key
+    * @param timeTaken
+    *   \- Time taken to log with `Done` status
+    * @param loggerMessage
+    *   \- logger event message to log
+    * @return
+    */
+  private def pushToRecorderAndGetFormattedStringForLogger(
+    time: String,
+    parentStage: String,
+    subStage: String,
     status: String,
-    usedMemory: Double,
-    maxHeap: Double,
-    cpuUsed: Double
-  ): Unit = {
+    metaData: String,
+    avgAndMaxStatsLookUpKey: Option[String],
+    timeTaken: Option[String],
+    loggerMessage: String
+  ): String = {
+    val stats = getCurrentCpuMemoryStats(avgAndMaxStatsLookUpKey)
     recorder match {
       case Some(rec) =>
-        rec.pushEvent(s"$event, $status, ${String
-            .format("%.2f", cpuUsed)}, ${String.format("%.2f", usedMemory)}, ${String.format("%.2f", maxHeap)}")
+        rec.pushEvent(s"$time, $parentStage, $subStage, $metaData, ${getCpuAndMemoryStatsForCSVInString(stats)}")
         status match {
-          case STARTED => stagePerformance += (stage -> NumberProcessor())
+          case STARTED => stagePerformance += (avgAndMaxStatsLookUpKey.get -> NumberProcessor())
           case _       =>
         }
       case _ =>
     }
+    status match {
+      case STARTED =>
+        val formattedString =
+          s"%-${maxStartingBuffer}s%s".format(loggerMessage, s"- stats -> ${cpuAndMemoryStatsForLoggerInString(stats)}")
+        s"${getNewTime()} $formattedString"
+      case DONE =>
+        val formattedString = s"%-${maxEndingBuffer}s%s".format(
+          s"$loggerMessage",
+          s"%-${maxBuffers.MAX_DONE_TIME_BUFFER}s%s"
+            .format(s"- ${timeTaken.get}", s"- stats -> ${cpuAndMemoryStatsForLoggerInString(stats)}")
+        )
+        s"$time $formattedString"
+    }
   }
 
+  /** internal method initiate sub stgae
+    * @param subStageName
+    *   \- Sub stage name
+    * @param additionalMetaDataToLog
+    *   \- Additional meta data to log
+    */
   private def initiateNewSubStage(subStageName: String, additionalMetaDataToLog: String = STAGE_NOT_SET): Unit = {
-    val (usedMemory, maxHeap, cpuUsed, _) = getCurrentCpuMemoryStats()
-    pushToRecorder(
-      s"${getNewTime()}, $lastStageName, $subStageName",
-      s"-- $subStageName",
+    val newTime = getNewTime()
+    val logLine = pushToRecorderAndGetFormattedStringForLogger(
+      s"$newTime",
+      lastStageName,
+      subStageName,
       STARTED,
-      usedMemory,
-      maxHeap,
-      cpuUsed
+      STARTED,
+      Some(s"-- $subStageName"),
+      None,
+      s"- --$subStageName is invoked"
     )
-    val formattedString =
-      s"%-${maxStartingBuffer}s%s"
-        .format(
-          s"- --$subStageName is invoked",
-          s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap)}"
-        )
-    logger(s"${getNewTime()} $formattedString", true)
+    logger(logLine, false)
+    subStageStartTime = newTime
     lastSubStageName = subStageName
     additionalMetaData = additionalMetaDataToLog
   }
 
+  /** Internal method to end the last sub stage.
+    */
   private def endLastSubStage(): Unit = {
-    val (usedMemory, maxHeap, cpuUsed, maxStats) = getCurrentCpuMemoryStats(Some(s"-- $lastSubStageName"))
-    pushToRecorder(
-      s"${getNewTime()}, $lastStageName, $lastSubStageName",
+    val logMessage = pushToRecorderAndGetFormattedStringForLogger(
+      s"${getNewTime()}",
+      lastStageName,
       lastSubStageName,
       DONE,
-      usedMemory,
-      maxHeap,
-      cpuUsed
+      DONE,
+      Some(s"-- $lastSubStageName"),
+      Some(getLastSubStageTimeTaken()),
+      s"- --$lastSubStageName is done ..."
     )
-    val formattedString = s"%-${maxEndingBuffer}s%s".format(
-      s"- --$lastSubStageName is done ...",
-      s"%-${maxBuffers.MAX_DONE_TIME_BUFFER}s%s".format(
-        s"- ${setNewTimeToLastAndGetTimeDiff()}",
-        s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap, maxStats)}"
-      )
-    )
-    logger(s"${getNewTime()} $formattedString", true)
+    logger(logMessage, false)
     lastSubStageName = STAGE_NOT_SET
     additionalMetaData = STAGE_NOT_SET
   }
 
-  private def getCurrentCpuMemoryStats(
-    stage: Option[String] = None
-  ): (Double, Double, Double, Option[(Double, Double)]) = {
+  /** Utility method to generate formatted string to log the stats into CSV file.
+    *
+    * @param stats
+    *   \- machine stats data refer {@link CpuMemoryStats}
+    * @return
+    */
+  private def getCpuAndMemoryStatsForCSVInString(stats: CpuMemoryStats): String =
+    s"${doubleFormatter(stats.usedOrAvgCpu)}, ${doubleFormatter(stats.usedOrAvgMemory)}, ${doubleFormatter(stats.maxHeap)}"
+
+  /** Internal utility method to fetch CPU and Memory stats.
+    * @param stage
+    *   \- Lookup key for avg and max stats.
+    * @return
+    *   \- Formatted CSV string
+    */
+  private def getCurrentCpuMemoryStats(stage: Option[String] = None): CpuMemoryStats = {
     stage match {
       case Some(st) if stagePerformance.contains(st) =>
         val numberProcessor     = stagePerformance(st)
         val (avgCpu, avgMemory) = numberProcessor.getAverage
         val (maxCpu, maxMemory) = numberProcessor.getMax
-        (avgMemory, Runtime.getRuntime().maxMemory() * 0.000001, avgCpu, Some(maxCpu, maxMemory))
+        CpuMemoryStats(
+          usedOrAvgMemory = avgMemory,
+          maxHeap = Runtime.getRuntime().maxMemory() * 0.000001,
+          usedOrAvgCpu = avgCpu,
+          maxStats = Some(maxCpu, maxMemory)
+        )
       case _ =>
-        (
-          (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) * 0.000001,
-          Runtime.getRuntime().maxMemory() * 0.000001,
-          osBean.getProcessCpuLoad * 100,
+        CpuMemoryStats(
+          usedOrAvgMemory = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) * 0.000001,
+          maxHeap = Runtime.getRuntime().maxMemory() * 0.000001,
+          usedOrAvgCpu = osBean.getProcessCpuLoad * 100,
           None
         )
     }
   }
 
-  private def currentCpuMemoryStatsInString(
-    cpuUsed: Double,
-    usedMemory: Double,
-    maxHeap: Double,
-    maxCpuAndMemoryUsed: Option[(Double, Double)] = None
-  ): String = {
-    val maxStats = maxCpuAndMemoryUsed match {
+  /** Internal utility method to generate formatted string to log stats to console or debug logger.
+    * @param stats
+    *   \- machine stats data refer {@link CpuMemoryStats}
+    * @return
+    *   \- Formatted log string.
+    */
+  private def cpuAndMemoryStatsForLoggerInString(stats: CpuMemoryStats): String = {
+    val maxStats = stats.maxStats match {
       case Some((maxCpu, maxMemory)) =>
-        s"MAX => '${String.format("%.2f", maxCpu)}%', '${String.format("%.2f", maxMemory)}' MB"
+        s"MAX => '${doubleFormatter(maxCpu)}%', '${doubleFormatter(maxMemory)}' MB"
       case _ => ""
     }
-    s"'${String.format("%.2f", cpuUsed)}%', '${String.format("%.2f", usedMemory)}' MB, '${String.format("%.2f", maxHeap)}' MB $maxStats"
-
+    s"'${doubleFormatter(stats.usedOrAvgCpu)}%', '${doubleFormatter(stats.usedOrAvgMemory)}' MB, '${doubleFormatter(stats.maxHeap)}' MB $maxStats"
   }
 
+  /** Utility method to format double number to show 2 decimal points
+    * @param value
+    *   \- Double value to be formatted
+    * @return
+    *   \- Formatted double value in string.
+    */
+  private def doubleFormatter(value: Double): String = s"${String.format("%.2f", value)}"
+
+  /** Get current time by initialising internal latest data time tracker.
+    * @return
+    *   \- latest data time.
+    */
   private def getNewTime(): Date = {
     newTime = Calendar.getInstance().getTime
     newTime
   }
 
-  private def getNewTimeAndSetItToStageLast(): Date = {
-    stageStartTime = getNewTime()
-    stageStartTime
-  }
-
-  private def setNewTimeToStageLastAndGetTimeDiff(): String = {
+  /** Calculate the ongoing stags total time
+    * @return
+    *   \- total time taken by the last stage.
+    */
+  private def getLastStageTimeTaken(): String = {
     val diff = newTime.getTime - stageStartTime.getTime
-    stageStartTime = newTime
     getDiffFormatted(diff)
   }
 
-  private def setNewTimeToLastAndGetTimeDiff(): String = {
+  /** Calculate the total time taken by the last sub stage.
+    * @return
+    *   \- total time taken by the last sub stage.
+    */
+  private def getLastSubStageTimeTaken(): String = {
     val diff = newTime.getTime - subStageStartTime.getTime
-    subStageStartTime = newTime
     getDiffFormatted(diff)
   }
 
+  /** Calculate the total time taken till this point
+    * @return
+    *   \- total time
+    */
+  private def getTheTotalTime(): String = {
+    val diff = newTime.getTime - start.getTime
+    getDiffFormatted(diff)
+  }
+
+  /** Get the time formatted in readable string format.
+    * @param diff
+    *   \- time diff to be formatted
+    * @return
+    *   \- Formatted time diff
+    */
   def getDiffFormatted(diff: Long): String = {
     val seconds = diff / 1000
     val ms      = diff                  % 1000
@@ -314,13 +515,10 @@ object TimeMetric {
     val h       = (seconds / (60 * 60)) % 24
     String.format("%d ms - %02dh:%02dm:%02ds:%02dms", diff, h, m, s, ms)
   }
-
-  private def getTheTotalTime(): String = {
-    val diff = newTime.getTime - start.getTime
-    getDiffFormatted(diff)
-  }
 }
 
+/** Common utility to record the CPU and Memory stats for a stage to calculate average and max values.
+  */
 private class NumberProcessor {
   private var cpu: Double       = 0.0
   private var cpuMax: Double    = 0.0
@@ -328,7 +526,13 @@ private class NumberProcessor {
   private var memoryMax: Double = 0.0
   private var count: Int        = 0
 
-  def process(cpuUsed: Double, memoryUsed: Double): Unit = {
+  /** Take the stats values for a given stage at each interval and do the aggregation.
+    * @param cpuUsed
+    *   \- current cpu % used.
+    * @param memoryUsed
+    *   \- current memory used.
+    */
+  def record(cpuUsed: Double, memoryUsed: Double): Unit = {
     cpu += cpuUsed
     cpuMax = if (cpuMax < cpuUsed) then cpuUsed else cpuMax
     memory += memoryUsed
@@ -336,6 +540,10 @@ private class NumberProcessor {
     count += 1
   }
 
+  /** get the average of CPU and memory used.
+    * @return
+    *   \- average CPU and memory used.
+    */
   def getAverage: (Double, Double) = {
     val currentCount = count
     if (currentCount == 0) {
@@ -345,5 +553,9 @@ private class NumberProcessor {
     }
   }
 
+  /** Get max CPU and Memory used.
+    * @return
+    *   \- Max CPU and memory used.
+    */
   def getMax: (Double, Double) = (cpuMax, memoryMax)
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -1,0 +1,153 @@
+package io.shiftleft.utils
+
+import com.sun.management.OperatingSystemMXBean
+import org.slf4j.{Logger, LoggerFactory}
+
+import java.io.PrintWriter
+import java.lang.management.ManagementFactory
+import java.util.{Calendar, Date}
+
+case class TimeMetricRecordConfig(resultFile: String = "cpuandmemoryusage.csv", recordFreq: Int = 60000)
+
+object TimeMetric {
+  val cal                                    = Calendar.getInstance()
+  private val start                          = cal.getTime
+  private var subStageStartTime              = start
+  private var newTime                        = start
+  private var stageStartTime                 = start
+  private val STAGE_NOT_SET                  = "<not set>"
+  private var lastStageName                  = STAGE_NOT_SET
+  private var lastSubStageName               = STAGE_NOT_SET
+  private var additionalMetaData             = STAGE_NOT_SET
+  private var logger: String => Unit         = msg => baseLogger.debug(msg)
+  private val baseLogger: Logger             = LoggerFactory.getLogger(getClass)
+  private var recorder: Option[TimeRecorder] = None
+
+  def initialize(
+    newLogger: String => Unit = msg => println(msg),
+    timeMetricRecordConfig: Option[TimeMetricRecordConfig]
+  ): Unit = {
+    logger = newLogger
+    timeMetricRecordConfig match {
+      case Some(config) =>
+        recorder = Some(TimeRecorder(config))
+        recorder.get.start()
+      case _ =>
+    }
+  }
+
+  private class TimeRecorder(timeMetricRecordConfig: TimeMetricRecordConfig) extends Thread {
+    val osBean = ManagementFactory.getOperatingSystemMXBean().asInstanceOf[OperatingSystemMXBean]
+    override def run(): Unit = {
+      val writer = new PrintWriter(timeMetricRecordConfig.resultFile)
+      try {
+        writer.println(s"DateTime, MainStage, SubStage, MetaData, CPU (%), Used Memory (MB), Max Heap (MB)")
+        while (true) {
+          val (usedMemory, maxHeap) = getCurrentMemoryStats()
+          writer.println(s"${getNewTime()}, $lastStageName, $lastSubStageName, $additionalMetaData, ${String
+              .format("%.2f", osBean.getProcessCpuLoad * 100)}, $usedMemory, $maxHeap")
+          Thread.sleep(timeMetricRecordConfig.recordFreq)
+        }
+      } catch {
+        case exception: Exception =>
+          baseLogger.debug("Some error in Time Recorder: ", exception)
+      } finally {
+        writer.close()
+      }
+    }
+  }
+
+  def initiateNewStage(stageName: String, additionalMetaDataToLog: String = STAGE_NOT_SET) = {
+    if (lastStageName == STAGE_NOT_SET) {
+      logger(s"${getNewTime()} - $stageName is invoked  \t\t\t- memory -> ${currentMemoryStatsInString()}")
+      lastStageName = stageName
+      additionalMetaData = additionalMetaDataToLog
+    } else {
+      initiateNewSubStage(stageName, additionalMetaDataToLog)
+    }
+  }
+
+  def endLastStage() = {
+    if (lastSubStageName == STAGE_NOT_SET) {
+      logger(
+        s"${getNewTime()} - $lastStageName is done ... \t\t\t- ${setNewTimeToStageLastAndGetTimeDiff()} - memory -> ${currentMemoryStatsInString()}"
+      )
+      lastStageName = STAGE_NOT_SET
+      additionalMetaData = STAGE_NOT_SET
+    } else {
+      endLastSubStage()
+    }
+  }
+
+  def endTheTotalProcessing(message: String) = {
+    logger(s"${getNewTime()} - $message  \t\t\t- ${getTheTotalTime()} - memory -> ${currentMemoryStatsInString()}")
+    recorder match {
+      case Some(rec) => rec.interrupt()
+      case _         =>
+    }
+    println(s"${getNewTime()} ------ Some one called this last end")
+  }
+
+  private def initiateNewSubStage(subStageName: String, additionalMetaDataToLog: String = STAGE_NOT_SET) = {
+    logger(s"${getNewTime()} - --$subStageName is invoked  \t\t\t- memory -> ${currentMemoryStatsInString()}")
+    lastSubStageName = subStageName
+    additionalMetaData = additionalMetaDataToLog
+  }
+
+  private def endLastSubStage() = {
+    logger(
+      s"${getNewTime()} - --$lastSubStageName is done ... \t\t\t- ${setNewTimeToLastAndGetTimeDiff()} - memory -> ${currentMemoryStatsInString()}"
+    )
+    lastSubStageName = STAGE_NOT_SET
+    additionalMetaData = STAGE_NOT_SET
+  }
+
+  private def getCurrentMemoryStats(): (String, String) = (
+    s"${String.format("%.2f", (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) * 0.000001)}",
+    s"${String
+        .format("%.2f", Runtime.getRuntime().maxMemory() * 0.000001)}"
+  )
+
+  private def currentMemoryStatsInString(): String = {
+    val (usedMemory, maxHeap) = getCurrentMemoryStats()
+    s"used '$usedMemory' MB, max '$maxHeap' MB"
+
+  }
+
+  private def getNewTime(): Date = {
+    newTime = Calendar.getInstance().getTime
+    newTime
+  }
+
+  private def getNewTimeAndSetItToStageLast(): Date = {
+    stageStartTime = getNewTime()
+    stageStartTime
+  }
+
+  private def setNewTimeToStageLastAndGetTimeDiff(): String = {
+    val diff = newTime.getTime - stageStartTime.getTime
+    stageStartTime = newTime
+    getDiffFormatted(diff)
+  }
+
+  private def setNewTimeToLastAndGetTimeDiff(): String = {
+    val diff = newTime.getTime - subStageStartTime.getTime
+    subStageStartTime = newTime
+    getDiffFormatted(diff)
+  }
+
+  def getDiffFormatted(diff: Long): String = {
+    val seconds = diff / 1000
+    val ms      = diff                  % 1000
+    val s       = seconds               % 60
+    val m       = (seconds / 60)        % 60
+    val h       = (seconds / (60 * 60)) % 24
+    String.format("%d ms - %02dh:%02dm:%02ds:%02dms", diff, h, m, s, ms)
+  }
+
+  private def getTheTotalTime(): String = {
+    val diff = newTime.getTime - start.getTime
+    getDiffFormatted(diff)
+  }
+
+}

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -24,7 +24,7 @@ object TimeMetric {
   private var recorder: Option[TimeRecorder] = None
 
   def initialize(
-    newLogger: String => Unit = msg => println(msg),
+    newLogger: String => Unit = msg => baseLogger.debug(msg),
     timeMetricRecordConfig: Option[TimeMetricRecordConfig]
   ): Unit = {
     logger = newLogger

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -216,6 +216,9 @@ object TimeMetric {
         case exception: Exception =>
           baseLogger.debug("Some error in Time Recorder: ", exception)
       } finally {
+        // This while loop will take care of writing all the accumulated events in the queue first.
+        while (!queue.isEmpty) writer.println(queue.poll)
+        writer.flush()
         writer.close()
       }
     }

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -5,47 +5,96 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import java.io.PrintWriter
 import java.lang.management.ManagementFactory
+import java.util
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.{Calendar, Date}
-
+import scala.collection.mutable
 case class TimeMetricRecordConfig(resultFile: String = "cpuandmemoryusage.csv", recordFreq: Int = 60000)
-
+case class MaxPrintBuffers(MAX_FULLNAME_BUFFER: Int = 90, MAX_NAME_BUFFER: Int = 55, MAX_DONE_TIME_BUFFER: Int = 40)
 object TimeMetric {
-  val cal                                    = Calendar.getInstance()
-  private val start                          = cal.getTime
-  private var subStageStartTime              = start
-  private var newTime                        = start
-  private var stageStartTime                 = start
-  private val STAGE_NOT_SET                  = "<not set>"
-  private var lastStageName                  = STAGE_NOT_SET
-  private var lastSubStageName               = STAGE_NOT_SET
-  private var additionalMetaData             = STAGE_NOT_SET
-  private var logger: String => Unit         = msg => baseLogger.debug(msg)
+  val cal = Calendar.getInstance()
+  // Stage wise performance will be only recorded if parallel recording is started through initialize()
+  val stagePerformance: mutable.Map[String, NumberProcessor] = mutable.Map()
+  private val start                                          = cal.getTime
+  private var subStageStartTime                              = start
+  private var newTime                                        = start
+  private var stageStartTime                                 = start
+  private val ACROSS_PROCESS_STAGE                           = "<ACROSS_ALL>"
+  private val STAGE_NOT_SET                                  = "<not set>"
+  private val STARTED                                        = "Started"
+  private val DONE                                           = "Done"
+  private var lastStageName                                  = STAGE_NOT_SET
+  private var lastSubStageName                               = STAGE_NOT_SET
+  private var additionalMetaData                             = STAGE_NOT_SET
+  private var alsoLogConsole                                 = false
+  private val logger: (String, Boolean) => Unit = (msg, subStage) => {
+    if (alsoLogConsole && (!subStage || !supressSubstages))
+      println(msg)
+    baseLogger.debug(msg)
+  }
   private val baseLogger: Logger             = LoggerFactory.getLogger(getClass)
   private var recorder: Option[TimeRecorder] = None
+  private var fullName: Boolean              = false
+  private var maxBuffers: MaxPrintBuffers    = MaxPrintBuffers()
+  private var supressSubstages: Boolean      = true
+  private lazy val maxStartingBuffer = {
+    if (fullName) {
+      maxBuffers.MAX_FULLNAME_BUFFER + maxBuffers.MAX_DONE_TIME_BUFFER
+    } else {
+      maxBuffers.MAX_NAME_BUFFER + maxBuffers.MAX_DONE_TIME_BUFFER
+    }
+  }
+  private lazy val maxEndingBuffer = {
+    if (fullName) {
+      maxBuffers.MAX_FULLNAME_BUFFER
+    } else {
+      maxBuffers.MAX_NAME_BUFFER
+    }
+  }
+  private val osBean = ManagementFactory.getOperatingSystemMXBean().asInstanceOf[OperatingSystemMXBean]
 
   def initialize(
-    newLogger: String => Unit = msg => baseLogger.debug(msg),
-    timeMetricRecordConfig: Option[TimeMetricRecordConfig]
+    useFullName: Boolean = false,
+    consoleLog: Boolean = false,
+    timeMetricRecordConfig: Option[TimeMetricRecordConfig] = None,
+    maxPrintBuffers: MaxPrintBuffers = MaxPrintBuffers(),
+    supressSubStagesConsoleLog: Boolean = true
   ): Unit = {
-    logger = newLogger
+    fullName = useFullName
+    maxBuffers = maxPrintBuffers
+    supressSubstages = supressSubStagesConsoleLog
+    alsoLogConsole = consoleLog
     timeMetricRecordConfig match {
       case Some(config) =>
+        stagePerformance += (ACROSS_PROCESS_STAGE -> NumberProcessor())
         recorder = Some(TimeRecorder(config))
         recorder.get.start()
       case _ =>
     }
   }
 
+  def toggleSubStageLogFlag: Unit = supressSubstages = !supressSubstages
+
   private class TimeRecorder(timeMetricRecordConfig: TimeMetricRecordConfig) extends Thread {
-    val osBean = ManagementFactory.getOperatingSystemMXBean().asInstanceOf[OperatingSystemMXBean]
+
+    val queue: util.Queue[String] = new ConcurrentLinkedQueue[String]()
+
+    def pushEvent(event: String): Unit = queue.offer(event)
+
     override def run(): Unit = {
       val writer = new PrintWriter(timeMetricRecordConfig.resultFile)
       try {
         writer.println(s"DateTime, MainStage, SubStage, MetaData, CPU (%), Used Memory (MB), Max Heap (MB)")
         while (true) {
-          val (usedMemory, maxHeap) = getCurrentMemoryStats()
+          // This while loop will take care of writing all the accumulated events in the queue first.
+          while (!queue.isEmpty) writer.println(queue.poll)
+          val (usedMemory, maxHeap, cpuUsed, _) = getCurrentCpuMemoryStats()
+          stagePerformance(ACROSS_PROCESS_STAGE).process(cpuUsed, usedMemory)
+          if (lastStageName != STAGE_NOT_SET) then stagePerformance (s"+ $lastStageName").process(cpuUsed, usedMemory)
+          if (lastSubStageName != STAGE_NOT_SET)
+            then stagePerformance (s"-- $lastSubStageName").process(cpuUsed, usedMemory)
           writer.println(s"${getNewTime()}, $lastStageName, $lastSubStageName, $additionalMetaData, ${String
-              .format("%.2f", osBean.getProcessCpuLoad * 100)}, $usedMemory, $maxHeap")
+              .format("%.2f", cpuUsed)}, ${String.format("%.2f", usedMemory)}, ${String.format("%.2f", maxHeap)}")
           Thread.sleep(timeMetricRecordConfig.recordFreq)
         }
       } catch {
@@ -57,21 +106,58 @@ object TimeMetric {
     }
   }
 
-  def initiateNewStage(stageName: String, additionalMetaDataToLog: String = STAGE_NOT_SET) = {
+  def initiateNewStage(
+    stageName: String,
+    stageFullName: Option[String] = None,
+    additionalMetaDataToLog: String = STAGE_NOT_SET
+  ): Unit = {
+    val usedStageName = stageFullName match {
+      case Some(useFullName) if fullName => useFullName
+      case _                             => stageName
+    }
     if (lastStageName == STAGE_NOT_SET) {
-      logger(s"${getNewTime()} - $stageName is invoked  \t\t\t- memory -> ${currentMemoryStatsInString()}")
-      lastStageName = stageName
+      val (usedMemory, maxHeap, cpuUsed, _) = getCurrentCpuMemoryStats()
+      pushToRecorder(
+        s"${getNewTime()}, $usedStageName, $STAGE_NOT_SET",
+        s"+ $usedStageName",
+        STARTED,
+        usedMemory,
+        maxHeap,
+        cpuUsed
+      )
+      val formattedString =
+        s"%-${maxStartingBuffer}s%s"
+          .format(
+            s"- $usedStageName is invoked",
+            s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap)}"
+          )
+      logger(s"${getNewTime()} $formattedString", false)
+      lastStageName = usedStageName
       additionalMetaData = additionalMetaDataToLog
     } else {
-      initiateNewSubStage(stageName, additionalMetaDataToLog)
+      initiateNewSubStage(usedStageName, additionalMetaDataToLog)
     }
   }
 
-  def endLastStage() = {
+  def endLastStage(): Unit = {
     if (lastSubStageName == STAGE_NOT_SET) {
-      logger(
-        s"${getNewTime()} - $lastStageName is done ... \t\t\t- ${setNewTimeToStageLastAndGetTimeDiff()} - memory -> ${currentMemoryStatsInString()}"
+      val (usedMemory, maxHeap, cpuUsed, maxStats) = getCurrentCpuMemoryStats(Some(s"+ $lastStageName"))
+      pushToRecorder(
+        s"${getNewTime()}, $lastStageName, $STAGE_NOT_SET",
+        lastStageName,
+        DONE,
+        usedMemory,
+        maxHeap,
+        cpuUsed
       )
+      val formattedString = s"%-${maxEndingBuffer}s%s".format(
+        s"- $lastStageName is done ...",
+        s"%-${maxBuffers.MAX_DONE_TIME_BUFFER}s%s".format(
+          s"- ${setNewTimeToStageLastAndGetTimeDiff()}",
+          s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap, maxStats)}"
+        )
+      )
+      logger(s"${getNewTime()} $formattedString", false)
       lastStageName = STAGE_NOT_SET
       additionalMetaData = STAGE_NOT_SET
     } else {
@@ -79,37 +165,122 @@ object TimeMetric {
     }
   }
 
-  def endTheTotalProcessing(message: String) = {
-    logger(s"${getNewTime()} - $message  \t\t\t- ${getTheTotalTime()} - memory -> ${currentMemoryStatsInString()}")
+  def endTheTotalProcessing(message: String): Unit = {
+    val (usedMemory, maxHeap, cpuUsed, maxStats) = getCurrentCpuMemoryStats(Some(ACROSS_PROCESS_STAGE))
+    val formattedString = s"%-${maxEndingBuffer}s%s".format(
+      s"- $message",
+      s"%-${maxBuffers.MAX_DONE_TIME_BUFFER}s%s".format(
+        s"- ${getTheTotalTime()}",
+        s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap, maxStats)}"
+      )
+    )
+    logger(s"${getNewTime()} $formattedString", false)
     recorder match {
-      case Some(rec) => rec.interrupt()
-      case _         =>
+      case Some(rec) =>
+        rec.pushEvent(
+          s"${getNewTime()}, $message, Total Time taken, ${getTheTotalTime()}, ${String
+              .format("%.2f", osBean.getProcessCpuLoad * 100)}, ${String.format("%.2f", usedMemory)}, ${String.format("%.2f", maxHeap)}"
+        )
+        Thread.sleep(100)
+        rec.interrupt()
+      case _ =>
     }
   }
 
-  private def initiateNewSubStage(subStageName: String, additionalMetaDataToLog: String = STAGE_NOT_SET) = {
-    logger(s"${getNewTime()} - --$subStageName is invoked  \t\t\t- memory -> ${currentMemoryStatsInString()}")
+  private def pushToRecorder(
+    event: String,
+    stage: String,
+    status: String,
+    usedMemory: Double,
+    maxHeap: Double,
+    cpuUsed: Double
+  ): Unit = {
+    recorder match {
+      case Some(rec) =>
+        rec.pushEvent(s"$event, $status, ${String
+            .format("%.2f", cpuUsed)}, ${String.format("%.2f", usedMemory)}, ${String.format("%.2f", maxHeap)}")
+        status match {
+          case STARTED => stagePerformance += (stage -> NumberProcessor())
+          case _       =>
+        }
+      case _ =>
+    }
+  }
+
+  private def initiateNewSubStage(subStageName: String, additionalMetaDataToLog: String = STAGE_NOT_SET): Unit = {
+    val (usedMemory, maxHeap, cpuUsed, _) = getCurrentCpuMemoryStats()
+    pushToRecorder(
+      s"${getNewTime()}, $lastStageName, $subStageName",
+      s"-- $subStageName",
+      STARTED,
+      usedMemory,
+      maxHeap,
+      cpuUsed
+    )
+    val formattedString =
+      s"%-${maxStartingBuffer}s%s"
+        .format(
+          s"- --$subStageName is invoked",
+          s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap)}"
+        )
+    logger(s"${getNewTime()} $formattedString", true)
     lastSubStageName = subStageName
     additionalMetaData = additionalMetaDataToLog
   }
 
-  private def endLastSubStage() = {
-    logger(
-      s"${getNewTime()} - --$lastSubStageName is done ... \t\t\t- ${setNewTimeToLastAndGetTimeDiff()} - memory -> ${currentMemoryStatsInString()}"
+  private def endLastSubStage(): Unit = {
+    val (usedMemory, maxHeap, cpuUsed, maxStats) = getCurrentCpuMemoryStats(Some(s"-- $lastSubStageName"))
+    pushToRecorder(
+      s"${getNewTime()}, $lastStageName, $lastSubStageName",
+      lastSubStageName,
+      DONE,
+      usedMemory,
+      maxHeap,
+      cpuUsed
     )
+    val formattedString = s"%-${maxEndingBuffer}s%s".format(
+      s"- --$lastSubStageName is done ...",
+      s"%-${maxBuffers.MAX_DONE_TIME_BUFFER}s%s".format(
+        s"- ${setNewTimeToLastAndGetTimeDiff()}",
+        s"- stats -> ${currentCpuMemoryStatsInString(cpuUsed, usedMemory, maxHeap, maxStats)}"
+      )
+    )
+    logger(s"${getNewTime()} $formattedString", true)
     lastSubStageName = STAGE_NOT_SET
     additionalMetaData = STAGE_NOT_SET
   }
 
-  private def getCurrentMemoryStats(): (String, String) = (
-    s"${String.format("%.2f", (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) * 0.000001)}",
-    s"${String
-        .format("%.2f", Runtime.getRuntime().maxMemory() * 0.000001)}"
-  )
+  private def getCurrentCpuMemoryStats(
+    stage: Option[String] = None
+  ): (Double, Double, Double, Option[(Double, Double)]) = {
+    stage match {
+      case Some(st) =>
+        val numberProcessor     = stagePerformance(st)
+        val (avgCpu, avgMemory) = numberProcessor.getAverage
+        val (maxCpu, maxMemory) = numberProcessor.getMax
+        (avgMemory, Runtime.getRuntime().maxMemory() * 0.000001, avgCpu, Some(maxCpu, maxMemory))
+      case _ =>
+        (
+          (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) * 0.000001,
+          Runtime.getRuntime().maxMemory() * 0.000001,
+          osBean.getProcessCpuLoad * 100,
+          None
+        )
+    }
+  }
 
-  private def currentMemoryStatsInString(): String = {
-    val (usedMemory, maxHeap) = getCurrentMemoryStats()
-    s"used '$usedMemory' MB, max '$maxHeap' MB"
+  private def currentCpuMemoryStatsInString(
+    cpuUsed: Double,
+    usedMemory: Double,
+    maxHeap: Double,
+    maxCpuAndMemoryUsed: Option[(Double, Double)] = None
+  ): String = {
+    val maxStats = maxCpuAndMemoryUsed match {
+      case Some((maxCpu, maxMemory)) =>
+        s"MAX => '${String.format("%.2f", maxCpu)}%', '${String.format("%.2f", maxMemory)}' MB"
+      case _ => ""
+    }
+    s"'${String.format("%.2f", cpuUsed)}%', '${String.format("%.2f", usedMemory)}' MB, '${String.format("%.2f", maxHeap)}' MB $maxStats"
 
   }
 
@@ -148,5 +319,31 @@ object TimeMetric {
     val diff = newTime.getTime - start.getTime
     getDiffFormatted(diff)
   }
+}
 
+private class NumberProcessor {
+  private var cpu: Double       = 0.0
+  private var cpuMax: Double    = 0.0
+  private var memory: Double    = 0.0
+  private var memoryMax: Double = 0.0
+  private var count: Int        = 0
+
+  def process(cpuUsed: Double, memoryUsed: Double): Unit = {
+    cpu += cpuUsed
+    cpuMax = if (cpuMax < cpuUsed) then cpuUsed else cpuMax
+    memory += memoryUsed
+    memoryMax = if (memoryMax < memoryUsed) then memoryUsed else memoryMax
+    count += 1
+  }
+
+  def getAverage: (Double, Double) = {
+    val currentCount = count
+    if (currentCount == 0) {
+      (0.0, 0.0) // Avoid division by zero
+    } else {
+      (cpu / currentCount.toDouble, memory / currentCount.toDouble)
+    }
+  }
+
+  def getMax: (Double, Double) = (cpuMax, memoryMax)
 }

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -3,7 +3,7 @@ package io.shiftleft.utils
 import com.sun.management.OperatingSystemMXBean
 import org.slf4j.{Logger, LoggerFactory}
 
-import java.io.PrintWriter
+import java.io.{File, PrintWriter}
 import java.lang.management.ManagementFactory
 import java.util
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -193,7 +193,9 @@ object TimeMetric {
       * then log the stats of ongoing stage.
       */
     override def run(): Unit = {
-      val writer = new PrintWriter(timeMetricRecordConfig.resultFile)
+      val file = new File(timeMetricRecordConfig.resultFile)
+      file.getParentFile.mkdirs() // Create parent directories if they don't exist
+      val writer = new PrintWriter(file)
       try {
         writer.println(s"DateTime, MainStage, SubStage, MetaData, CPU (%), Used Memory (MB), Max Heap (MB)")
         while (true) {

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -73,7 +73,7 @@ object TimeMetric {
     }
   }
 
-  def toggleSubStageLogFlag: Unit = supressSubstages = !supressSubstages
+  def setSupressSubstagesFlag(flag: Boolean): Unit = supressSubstages = flag
 
   private class TimeRecorder(timeMetricRecordConfig: TimeMetricRecordConfig) extends Thread {
 

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -254,7 +254,7 @@ object TimeMetric {
     stage: Option[String] = None
   ): (Double, Double, Double, Option[(Double, Double)]) = {
     stage match {
-      case Some(st) =>
+      case Some(st) if stagePerformance.contains(st) =>
         val numberProcessor     = stagePerformance(st)
         val (avgCpu, avgMemory) = numberProcessor.getAverage
         val (maxCpu, maxMemory) = numberProcessor.getMax

--- a/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/utils/TimeMetric.scala
@@ -85,7 +85,6 @@ object TimeMetric {
       case Some(rec) => rec.interrupt()
       case _         =>
     }
-    println(s"${getNewTime()} ------ Some one called this last end")
   }
 
   private def initiateNewSubStage(subStageName: String, additionalMetaDataToLog: String = STAGE_NOT_SET) = {

--- a/codepropertygraph/src/test/scala/io/shiftleft/utils/TimeMetricTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/utils/TimeMetricTest.scala
@@ -1,0 +1,31 @@
+package io.shiftleft.utils
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.Calendar
+
+class TimeMetricTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  "Millisecond String format " should {
+    "Millisecond" in {
+      val firstTime = TimeMetric.cal.getTime
+      TimeMetric.cal.add(Calendar.MILLISECOND, 10)
+      val newTime = TimeMetric.cal.getTime
+      val str     = TimeMetric.getDiffFormatted(newTime.getTime - firstTime.getTime)
+      str shouldBe "10 ms - 00h:00m:00s:10ms"
+
+    }
+    "Hours, Min, Second and Milliseconds" in {
+      val firstTime = TimeMetric.cal.getTime
+      TimeMetric.cal.add(Calendar.MILLISECOND, 10)
+      TimeMetric.cal.add(Calendar.SECOND, 11)
+      TimeMetric.cal.add(Calendar.MINUTE, 12)
+      TimeMetric.cal.add(Calendar.HOUR, 13)
+      val newTime = TimeMetric.cal.getTime
+      val str     = TimeMetric.getDiffFormatted(newTime.getTime - firstTime.getTime)
+      str shouldBe "47531010 ms - 13h:12m:11s:10ms"
+    }
+  }
+}

--- a/codepropertygraph/src/test/scala/io/shiftleft/utils/TimeMetricTest.scala
+++ b/codepropertygraph/src/test/scala/io/shiftleft/utils/TimeMetricTest.scala
@@ -1,12 +1,64 @@
 package io.shiftleft.utils
 
+import better.files.File
+import io.shiftleft.codepropertygraph.Cpg
+import io.shiftleft.codepropertygraph.generated.nodes.NewFile
+import io.shiftleft.passes.{ConcurrentWriterCpgPass, KeyPool, NewStyleCpgPassBase}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.util.Calendar
-
 class TimeMetricTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  private object Fixture {
+    def apply(keyPools: Option[Iterator[KeyPool]] = None)(f: (Cpg, List[NewStyleCpgPassBase[String]]) => Unit): Unit = {
+      val cpg  = Cpg.emptyCpg
+      val pool = keyPools.flatMap(_.nextOption())
+      class MyPassOne(cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg, "MyPassOne", pool) {
+        override def generateParts(): Array[String] = Array("foo", "bar")
+
+        override def runOnPart(diffGraph: DiffGraphBuilder, part: String): Unit = {
+          diffGraph.addNode(NewFile().name(part))
+        }
+      }
+      class MyPassTwo(cpg: Cpg) extends ConcurrentWriterCpgPass[String](cpg, "MyPassTwo", pool) {
+        override def generateParts(): Array[String] = Array("footwo", "bartwo")
+
+        override def runOnPart(diffGraph: DiffGraphBuilder, part: String): Unit = {
+          diffGraph.addNode(NewFile().name(part))
+        }
+      }
+      val passes = List(new MyPassOne(cpg), new MyPassTwo(cpg))
+      f(cpg, passes)
+    }
+  }
+
+  "Time Metric Stats collection test" should {
+    "Simple test" in Fixture() { (_, passes) =>
+      File.usingTemporaryFile("performance", ".csv") { file =>
+        file.delete()
+        val filename = file.path.toString
+        TimeMetric.initialize(timeMetricRecordConfig =
+          Some(TimeMetricRecordConfig(resultFile = filename, recordFreq = 100))
+        )
+        TimeMetric.initiateNewStage("Group Stage")
+        passes.foreach(_.createAndApply())
+        TimeMetric.endLastStage()
+        TimeMetric.endTheTotalProcessing("Done all")
+        file.exists shouldBe true
+        file.lineIterator.foreach(println)
+        file.lineIterator.exists(_.contains("Group Stage, <not set>, Started")) shouldBe true
+        file.lineIterator.exists(_.contains("Group Stage, MyPassOne, Started")) shouldBe true
+        file.lineIterator.exists(_.contains("Group Stage, MyPassOne, Done")) shouldBe true
+        file.lineIterator.exists(_.contains("Group Stage, MyPassTwo, Started")) shouldBe true
+        file.lineIterator.exists(_.contains("Group Stage, MyPassTwo, Done")) shouldBe true
+        file.lineIterator.exists(_.contains("Group Stage, <not set>, Done")) shouldBe true
+        file.lineIterator.exists(_.contains("Done all, Total Time taken")) shouldBe true
+      }
+      TimeMetric.stagePerformance.size shouldBe 4
+    }
+  }
 
   "Millisecond String format " should {
     "Millisecond" in {


### PR DESCRIPTION
Added one utility to record the performance matrix in the following format. 

1. One if you `initialize` method and set the file where to write the matrix in csv format then it will start writing to that specific file with the configured interval of time.

DateTime | MainStage (group of passes like overlay pass) | SubStage (Pass to be executed) | MetaData (some additional data like which CPG pass is being used) | CPU (%) | Used Memory (MB) | Max Heap (MB)
-- | -- | -- | -- | -- | -- | --

2. It will also log debug logs when a pass is invoked and when the pass is ended with the time it took to finish the pass.

Sample report 
[performancematrix.csv](https://github.com/ShiftLeftSecurity/codepropertygraph/files/14521184/performancematrix.csv)
