### PR TITLE
temporarily use manual odb-codegen release...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
 val overflowdbVersion = "1.192"
-val overflowdbCodegenVersion = "2.108"
+val overflowdbCodegenVersion = "2.108a"
 
 inThisBuild(
   List(

--- a/schema/build.sbt
+++ b/schema/build.sbt
@@ -1,6 +1,7 @@
 name := "codepropertygraph-schema"
 
-libraryDependencies += "io.shiftleft" %% "overflowdb-codegen" % Versions.overflowdbCodegen
+// TODO change back to io.shiftleft after official releases are fixed, this is only temporary!
+libraryDependencies += "com.michaelpollmeier" %% "overflowdb-codegen" % Versions.overflowdbCodegen
 
 lazy val generatedSrcDir = settingKey[File]("root for generated sources - we want to check those in")
 enablePlugins(OdbCodegenSbtPlugin)


### PR DESCRIPTION
...while shiftleft github config hasn't been updated - this should
greenify the master build

odb codegen was released manually from https://github.com/ShiftLeftSecurity/overflowdb-codegen/tree/michael/temp-release-fix