### PR TITLE
Cleanup: Remove language constant for SOLIDITY.

### DIFF
--- a/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/Languages.java
+++ b/domainClasses/src/main/generated/io/shiftleft/codepropertygraph/generated/Languages.java
@@ -50,9 +50,6 @@ public static final String PYTHONSRC = "PYTHONSRC";
 /** Source-based JS frontend based on Babel */
 public static final String JSSRC = "JSSRC";
 
-/** Solidity language frontend */
-public static final String SOLIDITY = "SOLIDITY";
-
 /** Source-based frontend for Ruby */
 public static final String RUBYSRC = "RUBYSRC";
 
@@ -78,7 +75,6 @@ add(NEWC);
 add(JAVASRC);
 add(PYTHONSRC);
 add(JSSRC);
-add(SOLIDITY);
 add(RUBYSRC);
 add(SWIFTSRC);
 add(CSHARPSRC);

--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/MetaData.scala
@@ -118,12 +118,7 @@ object MetaData extends SchemaBase {
         valueType = ValueType.String,
         comment = "Source-based JS frontend based on Babel"
       ).protoId(15),
-      Constant(
-        name = "SOLIDITY",
-        value = "SOLIDITY",
-        valueType = ValueType.String,
-        comment = "Solidity language frontend"
-      ).protoId(16),
+      // Removed protoId 16. Used to be "Solidity".
       Constant(
         name = "RUBYSRC",
         value = "RUBYSRC",


### PR DESCRIPTION
This frontend was never introduced to joern and thus we do not need the
constant.
