### PR TITLE
bump flatgraph, properly log transitive changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "codepropertygraph"
 
 // parsed by project/Versions.scala, updated by updateDependencies.sh
-val flatgraphVersion = "0.0.88"
+val flatgraphVersion = "0.0.89"
 
 inThisBuild(
   List(

--- a/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
+++ b/codepropertygraph/src/main/scala/io/shiftleft/passes/CpgPass.scala
@@ -75,12 +75,7 @@ abstract class ForkJoinParallelCpgPass[T <: AnyRef](cpg: Cpg, @nowarn outName: S
       nanosBuilt = System.nanoTime()
       nDiff = diffGraph.size
 
-      // TODO how about `nDiffT` which seems to count the number of modifications..
-      //      nDiffT = overflowdb.BatchedUpdate
-      //        .applyDiff(cpg.graph, diffGraph, null)
-      //        .transitiveModifications()
-
-      flatgraph.DiffGraphApplier.applyDiff(cpg.graph, diffGraph)
+      nDiffT = flatgraph.DiffGraphApplier.applyDiff(cpg.graph, diffGraph)
     } catch {
       case exc: Exception =>
         baseLogger.error(s"Pass ${name} failed", exc)


### PR DESCRIPTION
This bumps flatgraph and uses the (newly added) count of transitive modifications in the log message, restoring the overflowdb functionality. Thanks for pointing out that oversight @maltek 