### PR TITLE
github actions: use jdk21 for all builds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,8 +19,9 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
-        java-version: 19
+        distribution: temurin
+        java-version: 21
+        cache: sbt
     - uses: sbt/setup-sbt@v1
     - name: Compile and run tests
       run: sbt +test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'adopt'
-        java-version: 19
+        distribution: temurin
+        java-version: 21
+        cache: sbt
     - uses: sbt/setup-sbt@v1
     - name: Check formatting
       run: sbt scalafmtCheck Test/scalafmtCheck
@@ -53,11 +54,12 @@ jobs:
         run: echo $PGP_SECRET | base64 --decode | gpg --batch --import
         env:
             PGP_SECRET: ${{ secrets.PGP_SECRET }}
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
-          java-version: 11
+          distribution: temurin
+          java-version: 21
+          cache: sbt
       - uses: sbt/setup-sbt@v1
       - name: Release to Sonatype
         run: sbt ciReleaseTagNextVersion ciReleaseSonatype


### PR DESCRIPTION
`--release=8` for both javac and scalac ensure that we don't use jdk9+ apis...