### PR TITLE
change protoId for newly added genericSignature

### DIFF
--- a/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
+++ b/schema/src/main/scala/io/shiftleft/codepropertygraph/schema/Hidden.scala
@@ -299,7 +299,7 @@ object Hidden extends SchemaBase {
                     |""".stripMargin
       )
       .mandatory(PropertyDefaults.String)
-      .protoId(251)
+      .protoId(3000)
 
     method.addProperty(genericSignature)
     typeDecl.addProperty(genericSignature)


### PR DESCRIPTION
context: this clashed with a protoId from our internal schema extension :(