### PR TITLE
upgrade sbt and protobuf plugin

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.10.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt"    % "sbt-protobuf"         % "0.7.1")
+addSbtPlugin("com.github.sbt"    % "sbt-protobuf"         % "0.8.2")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"         % "2.4.6")
 addSbtPlugin("com.github.sbt"    % "sbt-findbugs"         % "2.0.0")
 addSbtPlugin("io.shiftleft"      % "sbt-ci-release-early" % "2.0.48")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("com.github.sbt"    % "sbt-protobuf"         % "0.8.2")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"         % "2.4.6")
-addSbtPlugin("com.github.sbt"    % "sbt-findbugs"         % "2.0.0")
 addSbtPlugin("io.shiftleft"      % "sbt-ci-release-early" % "2.0.48")
 addSbtPlugin("com.github.sbt"    % "sbt-dynver"           % "5.1.0")
 addSbtPlugin("com.github.sbt"    % "sbt-native-packager"  % "1.10.4")


### PR DESCRIPTION
Some old versions disappeared from the repos, so upgrading to the latest
here as well. From an internal build:
```
[error] (update) sbt.librarymanagement.ResolveException: Error downloading com.github.gseitz:sbt-protobuf;sbtVersion=1.0;scalaVersion=2.12:0.6.5
[error]   Not found
[error]   Not found
[error]   not found: https://repo1.maven.org/maven2/com/github/gseitz/sbt-protobuf_2.12_1.0/0.6.5/sbt-protobuf-0.6.5.pom
[error]   not found: /home/mp/.ivy2/local/com.github.gseitz/sbt-protobuf/scala_2.12/sbt_1.0/0.6.5/ivys/ivy.xml
[error]   download error: Caught java.io.IOException (Server returned HTTP response code: 409 for URL: https://landing.jfrog.com/reactivate-server/scala) while downloading https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/com.github.gseitz/sbt-protobuf/scala_2.12/sbt_1.0/0.6.5/ivys/ivy.xml
[error]   download error: Caught java.io.IOException (Server returned HTTP response code: 409 for URL: https://landing.jfrog.com/reactivate-server/scala) while downloading https://repo.typesafe.com/typesafe/ivy-releases/com.github.gseitz/sbt-protobuf/scala_2.12/sbt_1.0/0.6.5/ivys/ivy.xml
```