### PR TITLE
[bazel] Adjust to moved bazel_tooling and neverlink domain classes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,13 +6,12 @@ bazel_dep(name = "rules_jvm_external", version = "7.0")
 bazel_dep(name = "aspect_rules_lint", version = "2.5.2")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
 
-JOERN_VERSION = "db325972fdf72e53f76beba77b72e84b2c469905"
+BAZEL_TOOLING_VERSION = "a07fda4f8bc736081ad9921831bc9973e77e6e19"
 
 git_override(
     module_name = "bazel_tooling",
-    commit = "{}".format(JOERN_VERSION),
-    remote = "git@github.com:joernio/joern.git",
-    strip_prefix = "bazel/tooling",
+    commit = "{}".format(BAZEL_TOOLING_VERSION),
+    remote = "git@github.com:joernio/bazel_tooling.git",
 )
 
 bazel_dep(name = "rules_scala", version = "7.2.4")

--- a/bazel/java.bzl
+++ b/bazel/java.bzl
@@ -9,6 +9,8 @@ _rules = make_java_rules(
         "-Xlint:-cast",
         "-XepDisableAllChecks",
     ],
+    common_java_binary_runtime_deps = [],
+    common_java_test_runtime_deps = [],
 )
 
 java_library = _rules.java_library

--- a/bazel/scala.bzl
+++ b/bazel/scala.bzl
@@ -11,7 +11,8 @@ _rules = make_scala_rules(
         "-deprecation",
         "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
     ],
-    common_scalatest_runtime_deps = [],
+    common_scala_binary_runtime_deps = [],
+    common_scala_test_runtime_deps = [],
 )
 
 scala_library = _rules.scala_library

--- a/codepropertygraph/BUILD
+++ b/codepropertygraph/BUILD
@@ -8,7 +8,7 @@ scala_library(
     ]),
     visibility = ["//visibility:public"],
     deps = [
-        "//schema:domainClasses",
+        "//schema:domainClassesNeverLinked",
         "//schema:java_proto",
         "@maven//:com_google_protobuf_protobuf_java",
         "@maven//:io_joern_flatgraph_core_3",

--- a/schema/BUILD
+++ b/schema/BUILD
@@ -83,7 +83,19 @@ genrule(
 )
 
 java_import(
-    name = "domainClasses",
+    name = "domainClassesNeverLinked",
+    jars = [":domainClasses_jar"],
+    srcjar = ":domainClasses_src_jar",
+    visibility = ["//visibility:public"],
+    exports = [
+        "@maven//:io_joern_flatgraph_core_3",
+        "@maven//:io_joern_flatgraph_help_3",
+    ],
+    neverlink = True,
+)
+
+java_import(
+    name = "domainClassesLinked",
     jars = [":domainClasses_jar"],
     srcjar = ":domainClasses_src_jar",
     visibility = ["//visibility:public"],

--- a/schema2json/BUILD
+++ b/schema2json/BUILD
@@ -12,4 +12,7 @@ scala_binary(
         "@maven//:org_json4s_json4s_ast_3",
         "@maven//:org_json4s_json4s_native_3",
     ],
+    runtime_deps = [
+        "//schema:domainClassesLinked",
+    ],
 )


### PR DESCRIPTION
- **[bazel] Adjust to bazel tooling in own repo.**
- **[bazel] Have a linked and not linked version of domain classes.**
    This is necessary to be able to swap in other domain classes since
Bazel does not have an override functionallity like maven resolvers
typically do. In order to achieve something similiar, the dependency
needs to be marked as `neverlink` from the begining and each executable
needs to bring in a linkable version on its own.
